### PR TITLE
perf(core): evict idle sessions without sorting the whole map

### DIFF
--- a/.changeset/perf-session-eviction.md
+++ b/.changeset/perf-session-eviction.md
@@ -1,0 +1,7 @@
+---
+"@open-rgs/core": patch
+---
+
+perf(core): session-cache eviction no longer snapshots and sorts the whole map on the INIT hot path
+
+At `MAX_CACHED_SESSIONS` capacity, `put()` previously copied every session into an array, filtered, and full-sorted by `createdAt` (O(n log n) plus a large transient allocation) on every INIT. It now walks the `Map` in insertion (creation) order and drops the oldest idle sessions in O(evicted) with no allocation. Behaviour is unchanged: sessions with an open round are never evicted, and the cache is trimmed to the same low-water mark.

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -102,15 +102,21 @@ export function all(): readonly LocalSession[] { return [...sessions.values()]; 
 export function size(): number { return sessions.size; }
 
 /** Evict the oldest IDLE (no open round) sessions down to a low-water mark.
- *  Returns the number evicted. */
+ *  Returns the number evicted.
+ *
+ *  This runs on the INIT hot path whenever the cache sits at capacity, so it
+ *  must not snapshot or sort the whole map. A Map iterates in insertion
+ *  order, and `put` inserts a session once when it's created, so walking from
+ *  the front visits the oldest sessions first  - the same victims the previous
+ *  copy-filter-sort produced, but in O(evicted) with no transient array.
+ *  Deleting the current entry mid-iteration is well-defined for Map and does
+ *  not disturb the walk. */
 function evictIdleOverflow(): number {
   const lowWater = Math.floor(MAX_CACHED_SESSIONS * 0.9);
-  const idle = [...sessions.values()]
-    .filter((s) => !s.openRound)
-    .sort((a, b) => a.createdAt - b.createdAt);
   let removed = 0;
-  for (const s of idle) {
+  for (const s of sessions.values()) {
     if (sessions.size <= lowWater) break;
+    if (s.openRound) continue; // never evict a debited, in-flight round
     sessions.delete(s.sessionId);
     removed++;
   }


### PR DESCRIPTION
Closes #10.

## What
At `MAX_CACHED_SESSIONS` (50k) capacity, `evictIdleOverflow()` ran on every INIT and did `[...sessions.values()].filter(...).sort((a,b) => a.createdAt - b.createdAt)` — an O(n·log n) sort plus a full-map transient array, exactly when the server is busiest.

A `Map` iterates in insertion order, and `put()` inserts a session once at creation, so walking from the front visits the oldest sessions first. We now evict by walking the map and deleting the oldest idle entries in **O(evicted)** with **no allocation**. Deleting the current entry mid-iteration is well-defined for `Map`.

## Behaviour: unchanged
- Sessions with an open round are **never** evicted (debited, in-flight stake).
- The cache is trimmed to the same low-water mark (90%).
- Same victims (oldest idle first); only the algorithm changed.

## Trust / guarantees
No security-relevant behaviour changes — this is a pure data-structure-traversal optimization. No new deps.

## Tests
- `bun run typecheck` ✅
- `bun test packages/core` → 129 pass / 0 fail ✅
- No spec describes the eviction algorithm (grep confirmed), so no spec edit needed per the "spec + code together" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)