### PR TITLE
perf(core): invoke Lua math via the JS bridge, not a per-call doString

### DIFF
--- a/.changeset/perf-lua-invoke-bridge.md
+++ b/.changeset/perf-lua-invoke-bridge.md
@@ -1,0 +1,7 @@
+---
+"@open-rgs/core": patch
+---
+
+perf(core): run Lua math through the JS bridge instead of recompiling a chunk per call
+
+With the execution watchdog on (the default), every math entry-point call previously built a Lua source string and ran it through `lua.doString`, which lexes + compiles a fresh chunk each call — and accumulates one per call, so a sustained loop (simulation, a busy server) degrades badly. The watchdog now arms its instruction-count abort hook *inside* a guarded dispatcher that is invoked through wasmoon's JS function bridge, so the math runs with no per-call recompilation and returns synchronously (no forced Promise/microtask). The watchdog still aborts a runaway math with `MATH_TIMEOUT`, the sandbox lockdown is unchanged, and outcomes are byte-identical. With the example math, watchdog-on now runs within ~6% of watchdog-off (200k spins in ~4.2s); the previous path could not complete the same run.

--- a/packages/core/src/lua-math.ts
+++ b/packages/core/src/lua-math.ts
@@ -125,16 +125,22 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
   // --- Execution watchdog (see timeoutMs) --------------------------------
   // wasmoon runs Lua synchronously on the event loop, so a runaway math
   // (`while true do end`) would block the whole server and no JS timer could
-  // interrupt it. The only lever is a Lua instruction hook that aborts once
-  // we pass a wall-clock deadline. Crucially the hook only applies when the
-  // math is CALLED FROM a doString chunk (the JS function bridge runs on a
-  // context where the hook does not carry), so when the watchdog is on we
-  // invoke math through `__open_rgs_invoke` inside a doString and read the
-  // result back as that chunk's return value  - race-free because wasmoon
-  // executes the chunk synchronously (no await between arg-set and the call).
+  // interrupt it. The only lever is a Lua instruction (count) hook that aborts
+  // once we pass a wall-clock deadline. The hook applies to the thread it is
+  // armed ON, and wasmoon runs each JS->Lua bridge call on its own thread - so
+  // we arm the hook INSIDE the call: the guarded dispatcher does `sethook(...)`
+  // as its first act, then pcall's the math. That makes the watchdog apply on a
+  // plain bridge call, so the math can be invoked through the JS function bridge
+  // (synchronous, no per-call work) instead of recompiling a fresh `doString`
+  // chunk every call. (Arming the hook beforehand, on a different thread, does
+  // NOT carry to the call's thread - verified - which is why it's armed inside.)
   const timeoutMs = opts?.timeoutMs ?? 1000;
   const watchdog = timeoutMs > 0;
   let deadline = Infinity;
+  // Bridge handle to the guarded dispatcher, captured once after it's defined
+  // (watchdog on). Calling it runs the math under the abort hook without
+  // recompiling a chunk per call. Stays undefined when the watchdog is off.
+  let invokeNamed: ((name: string, ...args: unknown[]) => unknown) | undefined;
   const asTimeout = (e: unknown): RGSError | null =>
     e instanceof Error && e.message.includes("MATH_TIMEOUT")
       ? new RGSError("MATH_TIMEOUT", `math exceeded its ${timeoutMs}ms execution budget`)
@@ -142,19 +148,23 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
 
   /** Invoke a math entry point. With the watchdog off, call it directly
    *  (synchronous, zero overhead  - for trusted bulk simulation). With it on,
-   *  route through the guarded doString so the abort hook applies. */
+   *  call the guarded dispatcher through the JS bridge: it arms the count hook
+   *  on the call's own thread before pcall-ing the math, so the abort hook
+   *  applies WITHOUT recompiling a fresh chunk per call (the old per-call
+   *  `doString` did, which dominated the cost of a small math). The bridge call
+   *  is synchronous for synchronous Lua, so no Promise / microtask is created. */
   function invoke(fnName: string, args: unknown[]): unknown | Promise<unknown> {
     if (!watchdog) {
       return (api as Record<string, (...a: unknown[]) => unknown>)[fnName]!(...args);
     }
     deadline = performance.now() + timeoutMs;
-    for (let i = 0; i < args.length; i++) lua.global.set(`__open_rgs_arg${i + 1}`, args[i]);
-    const refs = args.map((_, i) => `__open_rgs_arg${i + 1}`).join(", ");
-    const code = `return __open_rgs_invoke(__open_rgs_math.${fnName}${refs ? ", " + refs : ""})`;
-    return lua.doString(code).then(
-      (raw) => { deadline = Infinity; return raw; },
-      (e) => { deadline = Infinity; throw asTimeout(e) ?? e; },
-    );
+    try {
+      return invokeNamed!(fnName, ...args);
+    } catch (e) {
+      throw asTimeout(e) ?? e;
+    } finally {
+      deadline = Infinity;
+    }
   }
 
   /** Apply a Lua->TS adapter to an invoke() result, awaiting if guarded. */
@@ -274,6 +284,8 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
         local function hook()
           if check() then error("MATH_TIMEOUT: math exceeded its time budget", 0) end
         end
+        -- Used at LOAD time only: module construction runs inside a doString
+        -- (below), and this guards that one evaluation.
         function __open_rgs_invoke(fn, a, b)
           sethook(hook, "", 100000)
           local ok, res = pcall(fn, a, b)
@@ -281,9 +293,21 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
           if not ok then error(res, 0) end
           return res
         end
+        -- Used PER CALL: looked up by name and invoked through the JS bridge
+        -- (see invoke()), so no chunk is recompiled per call. sethook is armed
+        -- HERE, inside the bridged call, which is what makes the hook apply on
+        -- wasmoon's call thread - arming it beforehand does not carry.
+        function __open_rgs_invoke_named(name, ...)
+          sethook(hook, "", 100000)
+          local ok, res = pcall(__open_rgs_math[name], ...)
+          sethook()
+          if not ok then error(res, 0) end
+          return res
+        end
       end
       __open_rgs_deadline_check = nil
     `);
+    invokeNamed = lua.global.get("__open_rgs_invoke_named") as (name: string, ...args: unknown[]) => unknown;
   }
 
   // Lock down the global environment before the (untrusted) math file runs.

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -102,12 +102,17 @@ The loader:
   default 1000ms; `0` disables for trusted bulk simulation). wasmoon runs
   Lua synchronously on the event loop, so a runaway math (`while true do
   end`) would block the whole server for every player with no JS timer able
-  to interrupt it. A Lua instruction hook  - armed on the executing thread by
-  invoking each entry point (and module construction) from inside a
-  `doString` chunk, so it actually applies  - aborts the call with
-  `MATH_TIMEOUT` once it passes the deadline. The hook, its `sethook`
-  handle, and the deadline check are captured as upvalues then hidden, and
-  the hook survives `debug = nil`, so sandboxed math cannot disable it.
+  to interrupt it. A Lua instruction (count) hook aborts the call with
+  `MATH_TIMEOUT` once it passes the deadline. The hook applies to the thread
+  it is armed ON, and wasmoon runs each JS->Lua bridge call on its own
+  thread, so a guarded dispatcher arms the hook INSIDE the call (its first
+  act) before `pcall`-ing the math. That lets each entry point be invoked
+  through the JS function bridge - synchronous, no per-call work - rather than
+  recompiling a fresh `doString` chunk every call; module construction still
+  runs once inside a `doString`, guarded the same way. The hook, its
+  `sethook` handle, and the deadline check are captured as upvalues then
+  hidden, and the hook survives `debug = nil`, so sandboxed math cannot
+  disable it.
 
 ## WASM runtime details (planned)
 


### PR DESCRIPTION
Closes #4.

## Problem
With the execution watchdog **on (the default, `timeoutMs ?? 1000`)**, every math entry-point call built a Lua source string and ran it through `lua.doString(...)` — which lexes + compiles a **fresh chunk every call**. Worse, those chunks **accumulate**, so a sustained loop (the simulator, or a busy server) degrades pathologically.

## Empirical findings
Verified directly against `wasmoon@1.16.0`:

1. **The "hook only carries from a `doString` chunk" assumption was wrong.** A `debug` count hook armed **inside** a call *does* fire when that call is reached through the JS function bridge — because wasmoon runs each bridge call on its own thread, and `sethook` applies to the thread it's armed on. (Arming it beforehand on another thread does *not* carry — which is what the original code observed and misattributed.)
2. **Old path is unusable under load.** With the example math, the new path runs **200k spins in ~4.2s (≈48k spins/s)** and watchdog-on is within **~6%** of watchdog-off. The old per-call-`doString` path **could not finish even 500 spins in 60s** in a sustained loop.

## Change
- Per call, the math is now invoked through a **guarded dispatcher called via the JS bridge** (`__open_rgs_invoke_named`). The dispatcher arms the count hook as its first act, then `pcall`s the math — so the watchdog still applies, with **no per-call recompilation** and **no forced Promise/microtask** (synchronous for synchronous Lua).
- Module construction still runs once inside a `doString`, guarded the same way (unchanged).
- Spec 03 updated to describe the bridge-dispatch mechanism (spec + code together). Spec 06's "sync calls, no unnecessary awaits" claim is now actually true.

## Trust / guarantees — unchanged
- Watchdog still aborts a runaway with `MATH_TIMEOUT` (`lua-timeout.test.ts` passes).
- Sandbox lockdown, RNG seam (fail-closed), and outcomes are byte-identical.
- No new deps.

## Tests
- `bun run typecheck` ✅
- `bun test` → **282 pass / 0 fail** ✅ (watchdog, sandbox, RNG, faulty-rounds included)

🤖 Generated with [Claude Code](https://claude.com/claude-code)