### PR TITLE
feat(simulator): shard big runs across cores with --shards N

### DIFF
--- a/.changeset/simulator-shards.md
+++ b/.changeset/simulator-shards.md
@@ -1,0 +1,7 @@
+---
+"@open-rgs/simulator": minor
+---
+
+feat(simulator): shard big runs across cores with `--shards N`
+
+`open-rgs-sim --shards N` splits a run across N independently-seeded worker processes (one per core) and merges the per-shard reports — near-linear speedup for large certification runs. The merge (new exported `mergeReports`) is **exact** for the cert-critical numbers: measured RTP, standard error, 95% CI, verdict, hit rate, outcome-type/next-mode counts, RTP contributions, deviations, and the multiplier mean / stdDev (pooled population variance) / min / max. Only the distribution percentiles (multiplier + observation p50..p99) are count-weighted across shards and flagged via a new optional `SimulationReport.sharded` field. Sharding requires the manifest module to export a factory `({ seed }) => GameManifest` so each shard draws an independent RNG substream; a static manifest is refused (it would replay the identical stream — a fail-closed safeguard against an over-confident result).

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -29,6 +29,31 @@ function export is called with `{ seed }` so it can seed the math RNG.
 Reports are written to `--out` (default `./reports`) in the chosen
 `--format` (default `all`).
 
+### Sharding across cores (`--shards N`)
+
+For big certification runs, `--shards N` splits the spins across **N
+independently-seeded worker processes** (one per core) and merges the
+results  - near-linear speedup with core count:
+
+```bash
+bunx open-rgs-sim ./src/manifest.ts --spins 8000000 --shards 8
+```
+
+Each shard runs `spins / N` spins with its own derived seed, so the
+shards draw **independent RNG substreams**. This requires the module to
+export a **factory** `({ seed }) => GameManifest` so each shard can be
+re-seeded; a static manifest export is **refused** with a clear error,
+because every shard would otherwise replay the identical stream and the
+result would be a bogus, over-confident number.
+
+The merged report is **exact** for the cert-critical numbers  - measured
+RTP, standard error, 95% CI, verdict, hit rate, outcome-type counts, RTP
+contributions, deviations, and the multiplier mean / stdDev / min / max.
+The only approximated values are the distribution **percentiles**
+(multiplier and observation p50..p99), which are count-weighted across
+shards; merged reports carry `sharded.percentilesApproximate` and the
+markdown notes it. Use `--shards 1` (the default) for exact percentiles.
+
 ## Use
 
 Write a `simulate.ts` next to your game's `index.ts`:
@@ -135,5 +160,7 @@ class yet  - write your own loop using the orchestrator's
 - Free-round campaigns aren't simulated either  - those are platform-
   side, and the simulator skips the platform adapter entirely.
 - The whole reel-distribution is held in memory (`number[]` of length
-  `spinsPerMode`) so percentile and stddev can be computed. 100k spins
-  ~= 800kB. For 10M-spin runs, refactor to streaming quantile sketches.
+  `spinsPerMode`) **per process** so percentile and stddev can be
+  computed. 100k spins ~= 800kB; `--shards N` cuts per-process memory to
+  `spinsPerMode / N`. For very large single-process runs, refactor to
+  streaming quantile sketches.

--- a/packages/simulator/src/cli.ts
+++ b/packages/simulator/src/cli.ts
@@ -3,7 +3,7 @@
 //
 // Usage:
 //   bunx open-rgs-sim <manifest-module> [--spins N] [--seed N] [--out DIR]
-//                                       [--format md|html|json|all]
+//                                       [--format md|html|json|all] [--shards N]
 //
 // <manifest-module> is a TS / JS file that default-exports either:
 //   - a GameManifest, OR
@@ -12,12 +12,19 @@
 // Examples:
 //   bunx open-rgs-sim ./src/manifest.ts
 //   bunx open-rgs-sim ./src/manifest.ts --spins 250000 --seed 7
-//   bunx open-rgs-sim ./src/manifest.ts --out reports --format html
+//   bunx open-rgs-sim ./src/manifest.ts --spins 4000000 --shards 8
+//
+// --shards N (N>1) splits the spins across N independently-seeded worker
+// processes (one per core) and merges the results - near-linear speedup for
+// big runs. It REQUIRES the module to export a factory `({ seed }) => manifest`
+// so each shard gets its own RNG substream; a static manifest is refused
+// (all shards would draw the identical stream). See specs/06-performance.md.
 
-import { resolve, dirname, join, basename } from "node:path";
+import { resolve, join } from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import { simulate } from "./simulate.js";
-import { mdReportSet } from "./report.js";
+import { mergeReports } from "./merge.js";
+import { mdReportSet, type SimulationReport } from "./report.js";
 import { htmlReportSet } from "./html.js";
 import type { GameManifest } from "@open-rgs/contract";
 
@@ -30,6 +37,9 @@ interface CliOpts {
   betUnits: number;
   includeInternal: boolean;
   quiet: boolean;
+  shards: number;
+  /** Internal: this process is one shard worker; run a slice, print JSON. */
+  shardWorker: boolean;
 }
 
 function parseArgs(argv: readonly string[]): CliOpts {
@@ -55,6 +65,8 @@ function parseArgs(argv: readonly string[]): CliOpts {
     betUnits: Number(flags["bet"] ?? "1"),
     includeInternal: flags["skip-internal"] === "true" ? false : true,
     quiet: flags["quiet"] === "true",
+    shards: Math.max(1, Math.floor(Number(flags["shards"] ?? "1")) || 1),
+    shardWorker: flags["__shard-worker"] === "true",
   };
 }
 
@@ -65,6 +77,7 @@ function usageAndExit(msg: string): never {
   process.stderr.write(`  --spins N            spins per mode (default 100000)\n`);
   process.stderr.write(`  --seed N             simulator PRNG seed (default 0)\n`);
   process.stderr.write(`  --bet N              units per spin pre-stakeMultiplier (default 1)\n`);
+  process.stderr.write(`  --shards N           split spins across N seeded worker processes (default 1)\n`);
   process.stderr.write(`  --out DIR            output directory (default ./reports)\n`);
   process.stderr.write(`  --format md|html|json|all   (default all)\n`);
   process.stderr.write(`  --skip-internal      skip modes flagged { internal: true }\n`);
@@ -72,41 +85,43 @@ function usageAndExit(msg: string): never {
   process.exit(2);
 }
 
-async function loadManifest(modulePath: string, seed: number): Promise<GameManifest> {
+/** Load the manifest module. Returns the manifest and whether its export is
+ *  a seedable factory (required for sharding - each shard is called with a
+ *  distinct seed so it draws an independent RNG substream). */
+async function loadManifest(modulePath: string, seed: number): Promise<{ manifest: GameManifest; seedable: boolean }> {
   const abs = resolve(process.cwd(), modulePath);
   const mod = await import(abs);
-  // Accept default export, named `manifest`, or named `buildManifest`.
-  // Functions are called with `{ seed }` so they can seed the math's RNG.
   const candidate = mod.default ?? mod.manifest ?? mod.buildManifest;
   if (candidate == null) {
     usageAndExit(`module ${modulePath} does not export default / manifest / buildManifest`);
   }
-  const resolved = typeof candidate === "function" ? await candidate({ seed }) : candidate;
+  const seedable = typeof candidate === "function";
+  const resolved = seedable ? await candidate({ seed }) : candidate;
   if (!resolved || typeof resolved !== "object" || typeof resolved.id !== "string") {
     usageAndExit(`module ${modulePath} did not produce a GameManifest`);
   }
-  return resolved as GameManifest;
+  return { manifest: resolved as GameManifest, seedable };
 }
 
-async function main(): Promise<void> {
-  const opts = parseArgs(process.argv.slice(2));
-  const manifest = await loadManifest(opts.manifestPath, opts.seed);
+/** Spread `total` spins across `shards` slices (remainder to the front). */
+function shardSlices(total: number, shards: number): number[] {
+  const per = Math.floor(total / shards);
+  const rem = total - per * shards;
+  return Array.from({ length: shards }, (_, i) => per + (i < rem ? 1 : 0)).filter(n => n > 0);
+}
 
-  if (!opts.quiet) {
-    process.stderr.write(`open-rgs-sim . ${manifest.id} . ${opts.spins.toLocaleString()} spins/mode . seed ${opts.seed}\n`);
-  }
+/** Derive a well-separated seed per shard so adjacent shards don't draw
+ *  correlated mulberry32 streams. */
+function shardSeed(base: number, i: number): number {
+  let x = (base ^ Math.imul(i + 1, 0x9e3779b1)) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x85ebca77) >>> 0;
+  x = Math.imul(x ^ (x >>> 13), 0xc2b2ae3d) >>> 0;
+  return (x ^ (x >>> 16)) >>> 0;
+}
 
-  const reports = await simulate(manifest, {
-    spinsPerMode: opts.spins,
-    seed: opts.seed,
-    betUnits: opts.betUnits,
-    includeInternal: opts.includeInternal,
-  });
-
+async function writeReports(reports: readonly SimulationReport[], opts: CliOpts, stem: string): Promise<string[]> {
   await mkdir(opts.outDir, { recursive: true });
-  const stem = `${manifest.id}-seed${opts.seed}-spins${opts.spins}`;
   const wrote: string[] = [];
-
   if (opts.format === "all" || opts.format === "md") {
     const p = join(opts.outDir, `${stem}.md`);
     await writeFile(p, mdReportSet(reports), "utf-8");
@@ -126,12 +141,123 @@ async function main(): Promise<void> {
     }, null, 2), "utf-8");
     wrote.push(p);
   }
+  return wrote;
+}
+
+/** One shard worker: simulate this slice with this seed, print the reports as
+ *  JSON to stdout (and nothing else), then exit. Invoked by runSharded. */
+async function runShardWorker(opts: CliOpts): Promise<void> {
+  const { manifest } = await loadManifest(opts.manifestPath, opts.seed);
+  const reports = await simulate(manifest, {
+    spinsPerMode: opts.spins,
+    seed: opts.seed,
+    betUnits: opts.betUnits,
+    includeInternal: opts.includeInternal,
+  });
+  process.stdout.write(JSON.stringify(reports));
+}
+
+/** Parent: fan spins out to N seeded worker processes, merge per mode. */
+async function runSharded(opts: CliOpts): Promise<void> {
+  const manifestAbs = resolve(process.cwd(), opts.manifestPath);
+  const { manifest, seedable } = await loadManifest(manifestAbs, opts.seed);
+
+  // Fail closed: a static manifest can't be re-seeded per shard, so every
+  // shard would draw the identical RNG stream - duplicated spins, a bogus
+  // (over-confident, possibly biased) result. Refuse rather than mislead.
+  if (!seedable) {
+    process.stderr.write(
+      `open-rgs-sim: cannot shard a static manifest - each shard needs an independent RNG ` +
+      `substream. Export a factory \`({ seed }) => GameManifest\` (called with a distinct seed ` +
+      `per shard), or run with --shards 1.\n`,
+    );
+    process.exit(2);
+  }
+
+  const slices = shardSlices(opts.spins, opts.shards);
+  if (!opts.quiet) {
+    process.stderr.write(`open-rgs-sim . ${manifest.id} . ${opts.spins.toLocaleString()} spins/mode across ${slices.length} shards . seed ${opts.seed}\n`);
+  }
+
+  const t0 = performance.now();
+  const results = await Promise.all(slices.map(async (slice, i) => {
+    const seed = shardSeed(opts.seed, i);
+    const proc = Bun.spawn({
+      cmd: [
+        "bun", import.meta.path, manifestAbs,
+        "--__shard-worker", "true",
+        "--spins", String(slice),
+        "--seed", String(seed),
+        "--bet", String(opts.betUnits),
+        "--skip-internal", opts.includeInternal ? "false" : "true",
+      ],
+      cwd: process.cwd(),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [out, err, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    if (code !== 0) throw new Error(`shard ${i} (seed ${seed}, ${slice} spins) failed [exit ${code}]: ${err.trim()}`);
+    try {
+      return JSON.parse(out) as SimulationReport[];
+    } catch {
+      throw new Error(`shard ${i} produced unparseable output: ${out.slice(0, 200)}`);
+    }
+  }));
+
+  // Group each shard's reports by mode id, then merge per mode in the order
+  // the first shard emitted them (manifest mode order).
+  const order = results[0]?.map(r => r.mode.id) ?? [];
+  const byMode = new Map<string, SimulationReport[]>();
+  for (const shardReports of results) {
+    for (const r of shardReports) {
+      const list = byMode.get(r.mode.id) ?? [];
+      list.push(r);
+      byMode.set(r.mode.id, list);
+    }
+  }
+  const merged = order.map(id =>
+    mergeReports(byMode.get(id)!, manifest.modes[id]?.math.expected),
+  );
+
+  const stem = `${manifest.id}-seed${opts.seed}-spins${opts.spins}-shards${slices.length}`;
+  const wrote = await writeReports(merged, opts, stem);
 
   if (!opts.quiet) {
+    process.stderr.write(`done in ${Math.round(performance.now() - t0)}ms wall-clock (${slices.length} shards)\n`);
     for (const p of wrote) process.stderr.write(`-> ${p}\n`);
-    // Always print the one-line narrative(s) to stdout for grep/jq.
+    for (const r of merged) process.stdout.write(`${r.narrative}\n`);
+  }
+}
+
+/** Single-process run (the default, --shards 1). */
+async function runSingle(opts: CliOpts): Promise<void> {
+  const { manifest } = await loadManifest(opts.manifestPath, opts.seed);
+  if (!opts.quiet) {
+    process.stderr.write(`open-rgs-sim . ${manifest.id} . ${opts.spins.toLocaleString()} spins/mode . seed ${opts.seed}\n`);
+  }
+  const reports = await simulate(manifest, {
+    spinsPerMode: opts.spins,
+    seed: opts.seed,
+    betUnits: opts.betUnits,
+    includeInternal: opts.includeInternal,
+  });
+  const stem = `${manifest.id}-seed${opts.seed}-spins${opts.spins}`;
+  const wrote = await writeReports(reports, opts, stem);
+  if (!opts.quiet) {
+    for (const p of wrote) process.stderr.write(`-> ${p}\n`);
     for (const r of reports) process.stdout.write(`${r.narrative}\n`);
   }
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.shardWorker) return runShardWorker(opts);
+  if (opts.shards > 1) return runSharded(opts);
+  return runSingle(opts);
 }
 
 main().catch(e => {
@@ -139,6 +265,3 @@ main().catch(e => {
   if (e instanceof Error && e.stack) process.stderr.write(e.stack + "\n");
   process.exit(1);
 });
-
-// Silence "unused" warnings for path helpers  - they're imported for runtime use only.
-void dirname; void basename;

--- a/packages/simulator/src/index.ts
+++ b/packages/simulator/src/index.ts
@@ -1,6 +1,7 @@
 // @open-rgs/simulator public surface.
 
 export { simulate, type SimulateOptions } from "./simulate.js";
+export { mergeReports } from "./merge.js";
 export { mdReport, mdReportSet, type SimulationReport, type DistributionStats } from "./report.js";
 export { htmlReportSet, type HtmlReportOptions } from "./html.js";
 export { computeDeviations, narrate, type TargetDeviation, type DeviationStatus } from "./deviation.js";

--- a/packages/simulator/src/merge.ts
+++ b/packages/simulator/src/merge.ts
@@ -1,0 +1,168 @@
+// Merge per-shard SimulationReports (same mode) into one, for sharded runs.
+//
+// A sharded run splits the spins across N independently-seeded processes
+// (see cli.ts `--shards`). Each shard reports on its own slice; this merges
+// the slices into a report statistically equivalent to one big run.
+//
+// EXACT (from per-shard sufficient statistics):
+//   - measured RTP, standard error, 95% CI, verdict
+//   - hit rate, outcome-type / next-mode counts
+//   - multiplier mean, stdDev (pooled population variance), min, max
+//   - counters, tag shares, RTP contributions, mark observation mean/stdDev
+//   - deviations (recomputed from the merged series vs the math's `expected`)
+//   - narrative
+//
+// APPROXIMATE (cannot be recovered exactly from per-shard percentiles
+// without the raw samples): the distribution PERCENTILES (multiplier and
+// observation p50..p99). We count-weight them and flag the merged report
+// with `sharded.percentilesApproximate`. Min/mean/stdDev/max stay exact, so
+// the cert-critical numbers are never approximate.
+
+import type { MathExpectations } from "@open-rgs/contract";
+import type { SimulationReport, DistributionStats } from "./report.js";
+import { computeDeviations, narrate } from "./deviation.js";
+
+const sum = (xs: readonly number[]): number => xs.reduce((a, b) => a + b, 0);
+
+/** Union of keys across a list of records, first-seen order. */
+function unionKeys(maps: ReadonlyArray<Record<string, unknown>>): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of maps) for (const k of Object.keys(m)) if (!seen.has(k)) { seen.add(k); out.push(k); }
+  return out;
+}
+
+/** Sum a set of `Record<string, number>` over the union of their keys. */
+function sumNumMaps(maps: ReadonlyArray<Record<string, number>>): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const m of maps) for (const [k, v] of Object.entries(m)) out[k] = (out[k] ?? 0) + v;
+  return out;
+}
+
+/** Exact pooled population mean + stdDev from per-part (n, mean, stdDev).
+ *  Uses total Sx2 = sum n_i (sd_i^2 + mean_i^2); var = Sx2/N - mean^2. */
+function pooled(parts: ReadonlyArray<{ n: number; mean: number; std: number }>): { mean: number; std: number } {
+  const N = sum(parts.map(p => p.n));
+  if (N === 0) return { mean: 0, std: 0 };
+  const mean = sum(parts.map(p => p.n * p.mean)) / N;
+  const sx2 = sum(parts.map(p => p.n * (p.std * p.std + p.mean * p.mean)));
+  return { mean, std: Math.sqrt(Math.max(0, sx2 / N - mean * mean)) };
+}
+
+/** Count-weighted percentile blend (approximate; see file header). */
+function blend(parts: ReadonlyArray<{ n: number; v: number }>): number {
+  const N = sum(parts.map(p => p.n));
+  return N === 0 ? 0 : sum(parts.map(p => p.n * p.v)) / N;
+}
+
+/** Merge N per-shard reports for the SAME mode into one. `expected` is the
+ *  mode's `math.expected` (the parent has the manifest), used to recompute
+ *  deviations exactly from the merged series. Single-element input is
+ *  returned unchanged. */
+export function mergeReports(reports: readonly SimulationReport[], expected?: MathExpectations): SimulationReport {
+  if (reports.length === 0) throw new Error("mergeReports: no reports to merge");
+  const base = reports[0]!;
+  if (reports.length === 1) return base;
+
+  const spins = sum(reports.map(r => r.spins));
+  const totalBet = sum(reports.map(r => r.bet.totalUnits));
+  const totalWin = sum(reports.map(r => r.win.totalUnits));
+  const measured = totalBet === 0 ? 0 : totalWin / totalBet;
+  const declared = base.rtp.declared;
+  const betPerSpin = base.bet.unitsPerSpin;
+
+  const mult = pooled(reports.map(r => ({ n: r.spins, mean: r.multiplier.mean, std: r.multiplier.stdDev })));
+  const multiplier: DistributionStats = {
+    min: Math.min(...reports.map(r => r.multiplier.min)),
+    max: Math.max(...reports.map(r => r.multiplier.max)),
+    mean: mult.mean,
+    stdDev: mult.std,
+    p50: blend(reports.map(r => ({ n: r.spins, v: r.multiplier.p50 }))),
+    p90: blend(reports.map(r => ({ n: r.spins, v: r.multiplier.p90 }))),
+    p95: blend(reports.map(r => ({ n: r.spins, v: r.multiplier.p95 }))),
+    p99: blend(reports.map(r => ({ n: r.spins, v: r.multiplier.p99 }))),
+  };
+
+  const standardError = spins > 0 ? mult.std / Math.sqrt(spins) : 0;
+  const rtpDelta = Math.abs(declared - measured);
+  const verdict: "pass" | "warn" | "fail" =
+    standardError === 0 ? (rtpDelta < 1e-9 ? "pass" : "fail") :
+    rtpDelta <= 1.96 * standardError ? "pass" :
+    rtpDelta <= 2.576 * standardError ? "warn" : "fail";
+
+  const hitRate = spins === 0 ? 0 : sum(reports.map(r => r.hitRate * r.spins)) / spins;
+  const outcomeTypes = sumNumMaps(reports.map(r => r.outcomeTypes));
+  const nextModeRoutes = sumNumMaps(reports.map(r => r.nextModeRoutes));
+
+  const counterTotals = sumNumMaps(reports.map(r => Object.fromEntries(Object.entries(r.counters).map(([k, c]) => [k, c.total]))));
+  const counters: SimulationReport["counters"] = {};
+  for (const [k, total] of Object.entries(counterTotals)) counters[k] = { total, perSpin: spins === 0 ? 0 : total / spins };
+
+  const observations: SimulationReport["observations"] = {};
+  for (const name of unionKeys(reports.map(r => r.observations))) {
+    const parts = reports.map(r => r.observations[name]).filter(Boolean) as (DistributionStats & { count: number })[];
+    const ms = pooled(parts.map(o => ({ n: o.count, mean: o.mean, std: o.stdDev })));
+    observations[name] = {
+      count: sum(parts.map(o => o.count)),
+      min: Math.min(...parts.map(o => o.min)),
+      max: Math.max(...parts.map(o => o.max)),
+      mean: ms.mean,
+      stdDev: ms.std,
+      p50: blend(parts.map(o => ({ n: o.count, v: o.p50 }))),
+      p90: blend(parts.map(o => ({ n: o.count, v: o.p90 }))),
+      p95: blend(parts.map(o => ({ n: o.count, v: o.p95 }))),
+      p99: blend(parts.map(o => ({ n: o.count, v: o.p99 }))),
+    };
+  }
+
+  const tagSpinTotals = sumNumMaps(reports.map(r => Object.fromEntries(Object.entries(r.tagShares).map(([k, t]) => [k, t.spins]))));
+  const tagShares: SimulationReport["tagShares"] = {};
+  for (const [k, sp] of Object.entries(tagSpinTotals)) tagShares[k] = { spins: sp, share: spins === 0 ? 0 : sp / spins };
+
+  const ctbSums = sumNumMaps(reports.map(r => Object.fromEntries(Object.entries(r.rtpContributions).map(([k, c]) => [k, c.sumMultiplier]))));
+  const rtpContributions: SimulationReport["rtpContributions"] = {};
+  for (const [k, sm] of Object.entries(ctbSums)) rtpContributions[k] = { sumMultiplier: sm, rtpShare: totalBet === 0 ? 0 : (sm * betPerSpin) / totalBet };
+
+  const rates: Record<string, number> = {};
+  for (const [k, c] of Object.entries(counters)) rates[k] = c.perSpin;
+  const deviations = computeDeviations(expected, {
+    hitRate,
+    rates,
+    rtpContributions: Object.fromEntries(Object.entries(rtpContributions).map(([k, v]) => [k, v.rtpShare])),
+    tagShares: Object.fromEntries(Object.entries(tagShares).map(([k, v]) => [k, v.share])),
+  });
+
+  const topContributions = Object.entries(rtpContributions)
+    .map(([name, c]) => ({ name, rtpShare: c.rtpShare }))
+    .sort((a, b) => b.rtpShare - a.rtpShare);
+  const narrative = narrate(
+    base.game.id, base.mode.id,
+    { measured, declared, delta: measured - declared },
+    hitRate, deviations, topContributions,
+  );
+
+  return {
+    game: base.game,
+    mode: base.mode,
+    math: base.math,
+    spins,
+    bet: { unitsPerSpin: betPerSpin, totalUnits: totalBet },
+    win: { totalUnits: totalWin, maxMultiplier: Math.max(...reports.map(r => r.win.maxMultiplier)) },
+    rtp: { measured, declared, delta: measured - declared, standardError, ci95: [measured - 1.96 * standardError, measured + 1.96 * standardError], verdict },
+    hitRate,
+    multiplier,
+    outcomeTypes,
+    nextModeRoutes,
+    counters,
+    observations,
+    tagShares,
+    rtpContributions,
+    deviations,
+    narrative,
+    ...(base.complex
+      ? { complex: { averageStepsPerRound: spins === 0 ? 0 : sum(reports.map(r => (r.complex?.averageStepsPerRound ?? 0) * r.spins)) / spins } }
+      : {}),
+    elapsedMs: Math.max(...reports.map(r => r.elapsedMs)),
+    sharded: { shards: reports.length, percentilesApproximate: true },
+  };
+}

--- a/packages/simulator/src/report.ts
+++ b/packages/simulator/src/report.ts
@@ -101,6 +101,12 @@ export interface SimulationReport {
   };
   /** Wall-clock time spent simulating this mode. */
   elapsedMs: number;
+  /** Present only on a merged report from a sharded run (`--shards N>1`).
+   *  Everything is an exact merge EXCEPT the distribution percentiles
+   *  (multiplier + observation p50..p99), which are count-weighted
+   *  approximations across shards. RTP / CI / verdict, hit rate, mean,
+   *  stdDev, min, max, contributions, and deviations are all exact. */
+  sharded?: { shards: number; percentilesApproximate: true };
 }
 
 /** Render one SimulationReport as a tidy markdown block. */
@@ -138,6 +144,10 @@ export function mdReport(r: SimulationReport): string {
 
   lines.push("## Multiplier distribution");
   lines.push("");
+  if (r.sharded) {
+    lines.push(`> ⚠ percentiles are approximate (merged from ${r.sharded.shards} shards); min / mean / stddev / max are exact.`);
+    lines.push("");
+  }
   lines.push("| stat   | value   |");
   lines.push("|--------|---------|");
   lines.push(`| min    | ${num(r.multiplier.min)} |`);

--- a/packages/simulator/test/fixtures/shard-factory.ts
+++ b/packages/simulator/test/fixtures/shard-factory.ts
@@ -1,0 +1,17 @@
+// A seedable factory manifest (TS math, no wasmoon) for shard CLI tests.
+// Each call to the factory gets a distinct seed, so each shard draws an
+// independent mulberry32 substream.
+import { mulberry32 } from "../../src/rng.js";
+import type { GameManifest, SimpleMath } from "@open-rgs/contract";
+
+export default function build({ seed }: { seed: number }): GameManifest {
+  const rng = mulberry32(seed);
+  const math: SimpleMath = {
+    kind: "simple", name: "shardfix", version: "1.0.0", rtp: 0.5,
+    play() {
+      const m = rng() < 0.5 ? 1 : 0;
+      return { multiplier: m, ops: [], type: m > 0 ? "win" : "loss" };
+    },
+  };
+  return { id: "shardfix", declaredRtp: 0.5, defaultMode: "default", modes: { default: { math, stakeMultiplier: 1 } } };
+}

--- a/packages/simulator/test/fixtures/shard-static.ts
+++ b/packages/simulator/test/fixtures/shard-static.ts
@@ -1,0 +1,16 @@
+// A STATIC manifest (not a factory): all shards would draw the identical
+// stream, so the CLI must refuse to shard it. Used by the fail-closed test.
+import { mulberry32 } from "../../src/rng.js";
+import type { GameManifest, SimpleMath } from "@open-rgs/contract";
+
+const rng = mulberry32(123);
+const math: SimpleMath = {
+  kind: "simple", name: "staticfix", version: "1.0.0", rtp: 0.5,
+  play() {
+    const m = rng() < 0.5 ? 1 : 0;
+    return { multiplier: m, ops: [], type: m > 0 ? "win" : "loss" };
+  },
+};
+
+const manifest: GameManifest = { id: "staticfix", declaredRtp: 0.5, defaultMode: "default", modes: { default: { math, stakeMultiplier: 1 } } };
+export default manifest;

--- a/packages/simulator/test/shard.test.ts
+++ b/packages/simulator/test/shard.test.ts
@@ -1,0 +1,113 @@
+// Sharded simulation: the merge math must be EXACT for the cert-critical
+// numbers, and the CLI must FAIL CLOSED when a manifest can't be re-seeded
+// per shard (which would duplicate the RNG stream).
+
+import { describe, expect, test, afterAll } from "bun:test";
+import { resolve } from "node:path";
+import { mkdtemp, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mergeReports } from "../src/merge.js";
+import { mean, stdDev, percentileSorted } from "../src/stats.js";
+import type { SimulationReport } from "../src/report.js";
+
+const CLI = resolve(import.meta.dir, "../src/cli.ts");
+const FACTORY = resolve(import.meta.dir, "fixtures/shard-factory.ts");
+const STATIC = resolve(import.meta.dir, "fixtures/shard-static.ts");
+
+const tmps: string[] = [];
+afterAll(async () => { for (const d of tmps) await rm(d, { recursive: true, force: true }); });
+
+/** Build a SimulationReport from raw multiplier samples, mirroring how
+ *  simulate() computes each field, so the merge can be checked against
+ *  ground truth over the concatenation. */
+function makeReport(samples: number[], betPerSpin = 1): SimulationReport {
+  const spins = samples.length;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const mu = mean(samples);
+  const totalWin = samples.reduce((a, m) => a + m * betPerSpin, 0);
+  const totalBet = spins * betPerSpin;
+  const outcomeTypes: Record<string, number> = {};
+  for (const m of samples) { const t = m > 0 ? "win" : "loss"; outcomeTypes[t] = (outcomeTypes[t] ?? 0) + 1; }
+  return {
+    game: { id: "g", declaredRtp: 0.5, defaultMode: "default" },
+    mode: { id: "default", stakeMultiplier: 1, internal: false },
+    math: { name: "m", version: "1", declaredRtp: 0.5, kind: "simple" },
+    spins,
+    bet: { unitsPerSpin: betPerSpin, totalUnits: totalBet },
+    win: { totalUnits: totalWin, maxMultiplier: sorted[sorted.length - 1] ?? 0 },
+    rtp: { measured: totalBet ? totalWin / totalBet : 0, declared: 0.5, delta: 0, standardError: 0, ci95: [0, 0], verdict: "pass" },
+    hitRate: spins ? samples.filter(m => m > 0).length / spins : 0,
+    multiplier: {
+      min: sorted[0] ?? 0, max: sorted[sorted.length - 1] ?? 0, mean: mu, stdDev: stdDev(samples, mu),
+      p50: percentileSorted(sorted, 50), p90: percentileSorted(sorted, 90), p95: percentileSorted(sorted, 95), p99: percentileSorted(sorted, 99),
+    },
+    outcomeTypes, nextModeRoutes: {},
+    counters: {}, observations: {}, tagShares: {}, rtpContributions: {},
+    deviations: [], narrative: "", elapsedMs: 1,
+  };
+}
+
+const close = (a: number, b: number, eps = 1e-9) => expect(Math.abs(a - b)).toBeLessThan(eps);
+
+describe("mergeReports (exact merge math)", () => {
+  test("mean / stdDev / min / max / rtp / hitRate equal the concatenation", () => {
+    const A = [0, 1, 2, 0, 3, 0, 5, 1];
+    const B = [1, 1, 0, 4, 0, 0, 2];
+    const all = [...A, ...B];
+    const m = mergeReports([makeReport(A), makeReport(B)]);
+
+    expect(m.spins).toBe(all.length);
+    close(m.multiplier.mean, mean(all));
+    close(m.multiplier.stdDev, stdDev(all));          // pooled variance, exact
+    expect(m.multiplier.min).toBe(Math.min(...all));
+    expect(m.multiplier.max).toBe(Math.max(...all));
+    close(m.rtp.measured, mean(all));                 // betPerSpin = 1
+    close(m.hitRate, all.filter(x => x > 0).length / all.length);
+    expect(m.win.maxMultiplier).toBe(Math.max(...all));
+    expect(m.sharded?.shards).toBe(2);
+    expect(m.sharded?.percentilesApproximate).toBe(true);
+  });
+
+  test("outcome-type counts are additive across shards", () => {
+    const A = [0, 1, 0];      // 2 loss, 1 win
+    const B = [1, 1, 0, 2];   // 1 loss, 3 win
+    const m = mergeReports([makeReport(A), makeReport(B)]);
+    expect(m.outcomeTypes["win"]).toBe(4);
+    expect(m.outcomeTypes["loss"]).toBe(3);
+  });
+
+  test("single report passes through unchanged", () => {
+    const A = makeReport([1, 0, 2]);
+    expect(mergeReports([A])).toBe(A);
+  });
+});
+
+describe("shard CLI", () => {
+  test("happy path: factory manifest shards and merges", async () => {
+    const out = await mkdtemp(join(tmpdir(), "rgs-shard-")); tmps.push(out);
+    const proc = Bun.spawn({
+      cmd: ["bun", CLI, FACTORY, "--spins", "400", "--shards", "2", "--seed", "5", "--format", "json", "--out", out, "--quiet", "true"],
+      stdout: "pipe", stderr: "pipe",
+    });
+    const [err, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+    expect(code).toBe(0);
+    const json = JSON.parse(await readFile(join(out, "shardfix-seed5-spins400-shards2.json"), "utf-8"));
+    const r = json.reports[0] as SimulationReport;
+    expect(r.spins).toBe(400);                    // 2 shards x 200
+    expect(r.sharded?.shards).toBe(2);
+    expect(r.rtp.measured).toBeGreaterThan(0.2);  // ~0.5 EV, loose band
+    expect(r.rtp.measured).toBeLessThan(0.8);
+    if (code !== 0) console.error(err);
+  }, 30_000);
+
+  test("fail closed: refuses to shard a static (non-factory) manifest", async () => {
+    const proc = Bun.spawn({
+      cmd: ["bun", CLI, STATIC, "--spins", "100", "--shards", "2", "--quiet", "true"],
+      stdout: "pipe", stderr: "pipe",
+    });
+    const [err, code] = await Promise.all([new Response(proc.stderr).text(), proc.exited]);
+    expect(code).toBe(2);
+    expect(err).toContain("cannot shard a static manifest");
+  }, 30_000);
+});

--- a/specs/06-performance.md
+++ b/specs/06-performance.md
@@ -43,6 +43,17 @@ These are well above realistic player loads (10K concurrent players x
 30 spins/sec/player = 300K spins/sec spread across cores). The point
 is having headroom for tuning runs and simulator workloads.
 
+The `@open-rgs/simulator` CLI parallelises big certification runs with
+`--shards N`: N independently-seeded worker processes (one per core),
+each running `spins / N`, with the per-shard reports merged. The merge
+is exact for RTP / CI / verdict / hit-rate / contributions / deviations
+and the multiplier mean / stdDev / min / max; only the distribution
+percentiles are count-weighted across shards (flagged in the report).
+Sharding requires a seedable factory manifest so each shard draws an
+independent substream  - a static manifest is refused. This is the
+in-stack way to use all cores today; a standalone Zig simulator binary
+(below) is the future path for billion-spin runs.
+
 ## Bun usage  - what makes the orchestrator fast
 
 ### Runtime choice rationale


### PR DESCRIPTION
Closes #18. The chosen "simulate faster" win — low trust risk, near-linear with core count.

## What
`open-rgs-sim --shards N` splits a run across **N independently-seeded worker processes** (one per core) and merges the per-shard reports.

```bash
bunx open-rgs-sim ./manifest.ts --spins 8000000 --shards 8
```

## Correctness (the trust bar for an offline tool)
- **Independent RNG substreams:** each shard is re-seeded with a derived, well-separated seed. Requires the module to export a **factory** `({ seed }) => GameManifest`.
- **Fail closed:** a *static* manifest export + `--shards >1` is **refused** with a clear error (exit 2) — every shard would otherwise replay the identical stream → an over-confident, possibly biased result.
- **Exact merge** (new exported `mergeReports`) for the cert-critical numbers: measured RTP, standard error, 95% CI, verdict, hit rate, outcome-type/next-mode counts, RTP contributions, deviations, and the multiplier **mean / stdDev (pooled population variance) / min / max**.
- **Percentiles** (multiplier + observation p50..p99) can't be merged exactly from per-shard percentiles without the raw samples, so they're count-weighted and **flagged** via a new optional `SimulationReport.sharded = { shards, percentilesApproximate: true }` (the markdown renders a note). `--shards 1` (default) stays exact.

## Verification
- Unit: merged `mean / stdDev / min / max / rtp / hitRate` equal ground truth over the concatenation; outcome counts additive; single-report pass-through.
- Integration (spawns the CLI): factory manifest `--shards 2` → 400 spins merged, `sharded` flag set; static manifest `--shards 2` → exit 2 with "cannot shard a static manifest".
- Manual at scale: 200k spins, single RTP 0.50018 vs 4-shard RTP 0.49808 (independent substreams), spins summed exactly, **407% CPU = 4 cores engaged**.

## Tests / typecheck
- `bun run typecheck` ✅
- `bun test` → **287 pass / 0 fail** (+5 new) ✅

## Docs (spec + code together)
- simulator README: `--shards` section + memory caveat
- spec 06-performance: sharding paragraph

🤖 Generated with [Claude Code](https://claude.com/claude-code)