### PR TITLE
feat(core): default math RNG to the system CSPRNG (cryptoRng), never Math.random

### DIFF
--- a/.changeset/secure-default-rng.md
+++ b/.changeset/secure-default-rng.md
@@ -1,0 +1,9 @@
+---
+"@open-rgs/core": minor
+---
+
+feat(core): default the math RNG to the system CSPRNG (`cryptoRng`), never `Math.random`
+
+`loadLuaMath` now defaults to `cryptoRng` — a new exported helper backed by the system CSPRNG via WebCrypto (`getRandomValues` → BoringSSL/OpenSSL, the same source Bun's `crypto` uses), returning a uniform 53-bit float in `[0,1)`. Outcome randomness is therefore cryptographically secure by default, and `Math.random` (V8 xorshift128+, non-crypto, unseedable) is never used to determine outcomes — previously it was the dev/no-rng fallback.
+
+Production still **fails closed** when no `rng` is injected (Guarantee 5 intact), so operators choose their source consciously: pass `{ rng: cryptoRng }` for the system CSPRNG, or inject a jurisdiction-certified (auditable, seed-commit) source. `cryptoRng` is exported from `@open-rgs/core`.

--- a/examples/hello-spin/src/index.ts
+++ b/examples/hello-spin/src/index.ts
@@ -6,23 +6,16 @@
 
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { webcrypto } from "node:crypto";
-import { createServer, binaryTransport, loadLuaMath } from "@open-rgs/core";
+import { createServer, binaryTransport, loadLuaMath, cryptoRng } from "@open-rgs/core";
 import { defineGame } from "@open-rgs/contract";
 import { MockPlatform } from "@open-rgs/platform-mock";
 
 const here = fileURLToPath(new URL(".", import.meta.url));
 
-// Inject the RNG that determines outcomes. open-rgs deliberately does NOT
-// default to Math.random for real-money play  - loadLuaMath fails closed in
-// production without an rng. Here we use a crypto-backed 53-bit float in
-// [0,1); a production deployment wires its certified/approved RNG instead.
-function cryptoRng(): number {
-  const u = new Uint32Array(2);
-  webcrypto.getRandomValues(u);
-  return (u[0]! * 2 ** 21 + (u[1]! >>> 11)) / 2 ** 53;
-}
-
+// Inject the RNG that determines outcomes. open-rgs defaults to the secure
+// system CSPRNG (`cryptoRng`, WebCrypto -> BoringSSL)  - never Math.random  -
+// and fails closed in production unless you choose a source explicitly. We
+// pass it here; a production deployment wires its certified/approved RNG.
 const math = await loadLuaMath(resolve(here, "../maths/spin.lua"), { rng: cryptoRng });
 
 const manifest = defineGame({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,7 +9,7 @@ export {
   type AuditLog, type AuditSink, type AuditEvent, type AuditInput, type RoundOutcomeStatus,
 } from "./audit-log.js";
 export { binaryTransport } from "./transport-binary.js";
-export { loadLuaMath, type LoadLuaMathOptions } from "./lua-math.js";
+export { loadLuaMath, cryptoRng, type LoadLuaMathOptions } from "./lua-math.js";
 export { startAdmin } from "./admin.js";
 export { log } from "./log.js";
 export { Registry, DEFAULT_BUCKETS, type Counter, type Gauge, type Histogram } from "./metrics.js";

--- a/packages/core/src/lua-math.ts
+++ b/packages/core/src/lua-math.ts
@@ -13,7 +13,7 @@
 
 import { LuaFactory, type LuaEngine } from "wasmoon";
 import { readFile } from "node:fs/promises";
-import { createHash } from "node:crypto";
+import { createHash, webcrypto } from "node:crypto";
 import { RGSError } from "@open-rgs/contract";
 import type {
   SimpleMath, ComplexMath, MathModule,
@@ -45,17 +45,21 @@ interface LuaApi {
 export interface LoadLuaMathOptions {
   /** Random source for the math VM  - `() => number` in `[0, 1)`.
    *
-   *  REQUIRED for real-money use. A certified RGS must determine outcomes
-   *  from an auditable CSPRNG; `Math.random` (V8 xorshift128+) is
-   *  non-cryptographic, unseedable, and explicitly disallowed by GLI-19 /
-   *  GLI-11. When omitted, `loadLuaMath` FAILS CLOSED under
-   *  `NODE_ENV=production` (throws) rather than silently using `Math.random`.
-   *  Outside production it falls back to `Math.random` with a loud warning,
-   *  which is fine for simulation, local dev, and examples only. */
+   *  Determines outcomes, so it must be cryptographically secure. When
+   *  omitted, open-rgs defaults to {@link cryptoRng}  - the system CSPRNG via
+   *  WebCrypto (BoringSSL/OpenSSL, the same source Bun's `crypto` uses)  -
+   *  NEVER `Math.random` (V8 xorshift128+, non-cryptographic and unseedable).
+   *  Under `NODE_ENV=production` with no `rng`, `loadLuaMath` FAILS CLOSED
+   *  (throws) so the operator picks its certified/approved source consciously;
+   *  pass `{ rng: cryptoRng }` to use the system CSPRNG in production. A
+   *  jurisdiction-certified RGS injects its approved (auditable, seed-commit)
+   *  RNG here. */
   rng?: () => number;
-  /** Escape hatch: permit the `Math.random` fallback even under
-   *  `NODE_ENV=production` (e.g. an offline, non-real-money tooling job).
-   *  Defaults to `false`  - production fails closed without an injected rng. */
+  /** Escape hatch: permit booting WITHOUT an injected rng under
+   *  `NODE_ENV=production` (the secure {@link cryptoRng} default is then used),
+   *  and permit a tagged simulator-only PRNG in production. Defaults to
+   *  `false`  - production fails closed without an explicit rng choice. For
+   *  offline, non-real-money tooling only. */
   allowInsecureRng?: boolean;
   /** Per-call wall-clock budget (ms) for every math entry point
    *  (play/open/step/close/autoclose) and for load-time evaluation. wasmoon
@@ -76,9 +80,26 @@ export interface LoadLuaMathOptions {
   marks?: boolean;
 }
 
-/** Resolve the math RNG, failing closed in production when none is injected.
- *  A real-money RGS must not determine outcomes from `Math.random`; in
- *  production we refuse to boot without an explicit (certified) source. */
+/** Cryptographically-secure default RNG, backed by the system CSPRNG (Bun /
+ *  Node WebCrypto -> BoringSSL/OpenSSL `RAND_bytes`, the same source Bun's
+ *  `crypto` uses). Returns a uniform 53-bit float in `[0, 1)`. This is
+ *  open-rgs's secure default for outcome determination  - unpredictable and
+ *  unseedable, unlike `Math.random` (V8 xorshift128+).
+ *
+ *  It is a CSPRNG, NOT necessarily a *certified/auditable* RNG (no seed-commit
+ *  or consumed-value log). Jurisdictions that mandate a certified source should
+ *  inject their approved RNG via `loadLuaMath({ rng })`. */
+export function cryptoRng(): number {
+  const u = new Uint32Array(2);
+  webcrypto.getRandomValues(u);
+  // 53 random bits: all 32 of u[0] shifted up by 21, plus the top 21 of u[1].
+  return (u[0]! * 0x20_0000 + (u[1]! >>> 11)) / 0x20_0000_0000_0000;
+}
+
+/** Resolve the math RNG. Defaults to the secure system CSPRNG ({@link
+ *  cryptoRng})  - never `Math.random`. In production with no injected rng we
+ *  fail closed (throw) so the operator chooses its certified/approved source
+ *  consciously rather than us picking silently. */
 function resolveRng(path: string, opts: LoadLuaMathOptions | undefined): () => number {
   const isProduction = process.env["NODE_ENV"] === "production";
   if (opts?.rng) {
@@ -97,19 +118,23 @@ function resolveRng(path: string, opts: LoadLuaMathOptions | undefined): () => n
   }
   if (isProduction && !opts?.allowInsecureRng) {
     throw new Error(
-      `loadLuaMath(${path}): no rng provided. A production RGS must inject a ` +
-      `certified CSPRNG for outcome determination  - refusing to fall back to ` +
-      `Math.random (non-auditable, GLI-19/GLI-11 disallowed). Pass { rng } or, ` +
-      `for non-real-money tooling only, { allowInsecureRng: true }.`,
+      `loadLuaMath(${path}): no rng provided. A production RGS must choose its ` +
+      `outcome RNG consciously  - pass { rng: cryptoRng } to use the secure system ` +
+      `CSPRNG (WebCrypto -> BoringSSL), or inject a certified/approved source. ` +
+      `(We refuse to default silently in production, even to a secure CSPRNG; ` +
+      `outside production cryptoRng is the default. { allowInsecureRng: true } ` +
+      `permits the default for non-real-money tooling.)`,
     );
   }
-  log.warn("loadLuaMath: no rng injected  - falling back to Math.random. " +
-    "NOT auditable; do not use for real-money play.", {
+  log.warn("loadLuaMath: no rng injected  - defaulting to the system CSPRNG " +
+    "(cryptoRng / WebCrypto -> BoringSSL). Secure and unpredictable, but not a " +
+    "certified/auditable source  - inject your approved RNG for real-money " +
+    "certification.", {
     "event.category": "process",
-    "event.action": "rng_insecure_fallback",
+    "event.action": "rng_crypto_default",
     "math.path": path,
   });
-  return Math.random;
+  return cryptoRng;
 }
 
 /** Load a Lua math file and adapt it to MathModule. */

--- a/packages/core/test/lua-rng.test.ts
+++ b/packages/core/test/lua-rng.test.ts
@@ -5,7 +5,7 @@
 import { describe, expect, test, afterEach } from "bun:test";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { loadLuaMath } from "../src/lua-math.js";
+import { loadLuaMath, cryptoRng } from "../src/lua-math.js";
 import type { SimpleMath } from "@open-rgs/contract";
 
 const here = fileURLToPath(new URL(".", import.meta.url));
@@ -19,9 +19,11 @@ afterEach(() => {
 });
 
 describe("loadLuaMath RNG fail-closed (C5)", () => {
-  test("production + no rng -> throws (refuses Math.random)", async () => {
+  test("production + no rng -> throws (must choose a source explicitly)", async () => {
     process.env["NODE_ENV"] = "production";
-    await expect(loadLuaMath(SIMPLE)).rejects.toThrow(/certified CSPRNG/);
+    // Fails closed even though a secure default (cryptoRng) exists: prod must
+    // choose its outcome RNG consciously.
+    await expect(loadLuaMath(SIMPLE)).rejects.toThrow(/choose its outcome RNG|cryptoRng/);
   });
 
   test("production + allowInsecureRng -> loads (explicit opt-out)", async () => {
@@ -71,6 +73,29 @@ describe("loadLuaMath rejects a simulator-only PRNG in production (H8)", () => {
     process.env["NODE_ENV"] = "development";
     const m = await loadLuaMath(SIMPLE, { rng: simRng });
     expect(m.kind).toBe("simple");
+  });
+});
+
+describe("secure default RNG (system CSPRNG, never Math.random)", () => {
+  test("cryptoRng returns uniform [0,1) and varies", () => {
+    const xs = Array.from({ length: 2000 }, () => cryptoRng());
+    expect(Math.min(...xs)).toBeGreaterThanOrEqual(0);
+    expect(Math.max(...xs)).toBeLessThan(1);
+    expect(new Set(xs).size).toBeGreaterThan(1990); // essentially all distinct
+  });
+
+  test("default path (no rng) does NOT call Math.random", async () => {
+    process.env["NODE_ENV"] = "development";
+    const orig = Math.random;
+    let called = false;
+    Math.random = () => { called = true; return orig(); };
+    try {
+      const m = await loadLuaMath(SIMPLE) as SimpleMath;          // no rng injected
+      await m.play(undefined, { mode: "default" });               // draws host.rng_next
+    } finally {
+      Math.random = orig;
+    }
+    expect(called).toBe(false); // outcomes came from the system CSPRNG, not Math.random
   });
 });
 

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -29,20 +29,26 @@ Math NEVER ships its own PRNG. The host provides one:
 - **WASM**: import `host.rng_next` declared as `(): f64`.
 - **TS**: a `random: () => number` argument injected at construction.
 
-The host implementation is **injected at boot** via
-`loadLuaMath(path, { rng })`. There is no real-money default:
+The host implementation can be **injected at boot** via
+`loadLuaMath(path, { rng })`. The default is a secure CSPRNG  - **never
+`Math.random`**:
 
-- Production: a certified RNG (e.g. a CSPRNG or a jurisdiction-approved
-  RNG sidecar) wrapped behind a synchronous `rng.next()`. **Required**  -
-  `loadLuaMath` fails closed (throws) under `NODE_ENV=production` when no
-  `rng` is injected; it will not silently use `Math.random` (non-crypto,
-  unseedable, GLI-19/GLI-11 disallowed).
+- Default: `cryptoRng`, the system CSPRNG via WebCrypto (`getRandomValues`
+  -> BoringSSL/OpenSSL, the same source Bun's `crypto` uses). Exported from
+  `@open-rgs/core`. Secure and unpredictable, but a CSPRNG  - not necessarily
+  a *certified/auditable* RNG (no seed-commit or consumed-value log).
+- Production: must choose the source **consciously**. `loadLuaMath` fails
+  closed (throws) under `NODE_ENV=production` when no `rng` is injected  -
+  even though a secure default exists  - so the operator picks deliberately.
+  Pass `{ rng: cryptoRng }` to use the system CSPRNG, or inject a
+  jurisdiction-certified (auditable) source. `Math.random` (non-crypto,
+  unseedable, GLI-19/GLI-11 disallowed) is never used.
 - Dev / examples: when no `rng` is injected outside production,
-  `loadLuaMath` falls back to `Math.random` with a loud warning. Acceptable
-  for local play only; an offline tooling job can opt in explicitly with
-  `{ allowInsecureRng: true }`.
+  `loadLuaMath` uses `cryptoRng` with a one-line warning. An offline tooling
+  job can also opt out of the prod fail-closed with `{ allowInsecureRng: true }`.
 - Testing / simulation: a seeded PRNG (e.g. `mulberry32` from
-  `@open-rgs/simulator`) for reproducible RTP runs.
+  `@open-rgs/simulator`) for reproducible RTP runs (refused in production
+  unless `allowInsecureRng`).
 
 Math produces byte-identical outputs for byte-identical RNG sequences,
 because no other source of nondeterminism is exposed.


### PR DESCRIPTION
## Why
Outcome randomness must be cryptographically secure. The dev/no-rng path fell back to **`Math.random`** (V8 xorshift128+ — non-crypto, unseedable). This makes the **system CSPRNG the default** and removes `Math.random` from the outcome path entirely.

## What
- **New export `cryptoRng`** — the system CSPRNG via WebCrypto (`getRandomValues` → **BoringSSL/OpenSSL**, the same source Bun's `crypto` uses), a uniform 53-bit float in `[0,1)`.
- `loadLuaMath` **defaults to `cryptoRng`** when no `rng` is injected — never `Math.random`.
- Example DRY'd to import `cryptoRng` from core (no more copy-pasted helper).

## Production stays fail-closed (Guarantee 5 intact)
Production with no `rng` still **throws** — operators must choose their source *consciously*. The message now points at the secure one-liner:
> pass `{ rng: cryptoRng }` to use the system CSPRNG, or inject a certified/approved source.

Rationale: `crypto.getRandomValues` is **secure** but not a *certified/auditable* RNG (no seed-commit / consumed-value log). Forcing an explicit choice is a safety feature for real money. Tagged simulator PRNGs (mulberry32) are still refused in prod.

## Tests
- `cryptoRng` returns uniform `[0,1)` and varies (≈all distinct).
- The default path **provably does not call `Math.random`** (spy asserts zero calls).
- Existing fail-closed / injected-rng / sim-PRNG-rejection tests still pass.
- `bun run typecheck` ✅ · `bun test` → **289 pass / 0 fail** ✅ · example typechecks ✅

## Docs
- spec 03 RNG seam rewritten (secure default + prod conscious-choice)
- `LoadLuaMathOptions.rng` / `allowInsecureRng` docs updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)