### PR TITLE
security: fix stale watchdog comment + surface the WASM no-watchdog gap

### DIFF
--- a/packages/core/src/lua-math.ts
+++ b/packages/core/src/lua-math.ts
@@ -395,13 +395,19 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
     end
   `);
 
-  // Define the guarded invoker BEFORE the sandbox nils `debug`. It arms a
-  // Lua count hook on the current thread, runs the math fn, disarms  - the
-  // hook fires every N instructions and aborts once we pass the per-call
-  // deadline. It must be CALLED FROM a doString chunk (see invoke()), not
-  // via the JS function bridge, for the hook to apply. `sethook`, the hook,
-  // and the deadline check are captured as upvalues then hidden, so the
-  // (sandboxed) math cannot reach or disable the watchdog.
+  // Define the guarded invokers BEFORE the sandbox nils `debug`. Each arms a
+  // Lua count hook (fires every N instructions; aborts once we pass the
+  // per-call deadline) as its FIRST act, runs the math under pcall, then
+  // disarms. The hook applies to the thread it is armed ON:
+  //   - `__open_rgs_invoke` guards load-time module construction (run from a
+  //     doString, below);
+  //   - `__open_rgs_invoke_named` guards each per-call entry point, which
+  //     invoke() reaches through the JS function bridge - arming the hook
+  //     INSIDE the bridged call is what makes it carry to wasmoon's per-call
+  //     thread (verified empirically; this is why no per-call doString is
+  //     needed).
+  // `sethook`, the hook, and the deadline check are captured as upvalues then
+  // hidden, so the (sandboxed) math cannot reach or disable the watchdog.
   if (watchdog) {
     lua.global.set("__open_rgs_deadline_check", () => performance.now() > deadline);
     await lua.doString(`

--- a/packages/core/src/wasm-math.ts
+++ b/packages/core/src/wasm-math.ts
@@ -13,6 +13,13 @@
 // an output buffer, and msgpack-decodes the returned bytes. RNG resolution is
 // shared with loadLuaMath (secure system CSPRNG by default; fail-closed in
 // production).
+//
+// LIMITATION - NO EXECUTION WATCHDOG (security/availability). Unlike the Lua
+// loader, a running WASM call cannot be interrupted from JS, so a kernel that
+// loops forever blocks the event loop (a DoS). There is no per-call timeout
+// here yet: treat WASM kernels as TRUSTED and bounded. A timeout requires
+// running the kernel in a worker and `terminate()`-ing it (planned: the shared
+// math worker pool). loadWasmMath logs a warning at load to keep this visible.
 
 import { readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
@@ -57,6 +64,16 @@ export async function loadWasmMath(path: string, opts?: LoadWasmMathOptions): Pr
   const bytes = await readFile(path);
   // Hash the artifact  - proves which kernel produced an outcome (audit log).
   const contentHash = createHash("sha256").update(bytes).digest("hex");
+
+  // Visibility for the no-watchdog limitation (see file header): a runaway WASM
+  // call cannot be interrupted from JS, so the kernel must be trusted/bounded.
+  log.warn("loadWasmMath: WASM math runs without an execution watchdog  - a " +
+    "runaway kernel blocks the event loop. Use only trusted, bounded kernels " +
+    "until the math worker pool (with terminate-on-timeout) lands.", {
+    "event.category": "process",
+    "event.action": "wasm_math_no_watchdog",
+    "math.path": path,
+  });
 
   let ex!: WasmExports;
   const readStr = (ptr: number, len: number): string =>

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -25,6 +25,13 @@ kernel runs ~15x faster than the equivalent Lua math (measured, 1-draw
 distribution) with no per-draw boundary tax, stays sandboxed by
 construction, and ships as a hashable artifact for certification.
 
+**WASM watchdog caveat:** unlike the Lua loader, a running WASM call cannot be
+interrupted from JS, so `loadWasmMath` currently has **no per-call timeout** - a
+runaway kernel blocks the event loop (a DoS). Treat WASM kernels as trusted and
+bounded; `loadWasmMath` logs a warning at load to keep this visible. A timeout
+needs the kernel to run in a worker that can be `terminate()`-ed (planned: the
+shared math worker pool, which also moves math off the I/O thread).
+
 ## RNG seam
 
 Math NEVER ships its own PRNG. The host provides one:


### PR DESCRIPTION
Follow-ups from a **security review of this session's trust-sensitive changes** (RNG default, host/sandbox wiring, watchdog dispatch, WASM loader), done before publishing `core 1.5.0`. **No release** — merges to `main`.

## Review verdict: no trust regressions
Verified intact: RNG fail-closed (prod throws; no `Math.random` in the outcome path; `cryptoRng` default), the Lua sandbox lockdown, the Lua watchdog, the seed-expand generator being hidden, the WASM loader's output bounds-check + fail-closed behaviour, and `native-batch`'s shell-injection-safe `spawn`.

## Two fixes (doc/visibility only, no logic change)
1. **Stale, contradictory comment** above the Lua watchdog claimed the hook *"must be CALLED FROM a doString chunk … not via the JS function bridge"* — the opposite of what #4 proved and ships. In security-critical code that could mislead a maintainer into reintroducing the per-call recompile or doubting the watchdog. Corrected.
2. **WASM no-watchdog gap made loud.** A running WASM call can't be interrupted from JS, so a runaway kernel blocks the event loop (a fail-closed/no-DoS gap, Guarantee 5). It was silent; now there's a header note, a load-time `log.warn` (`wasm_math_no_watchdog`), and a spec 03 caveat. The real fix is the planned math worker pool (terminate-on-timeout) — this just makes the interim state visible and documents "treat WASM kernels as trusted/bounded."

## Tests
`bun run typecheck` ✅ · affected lua/wasm tests 18/0 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)