### PR TITLE
ci: local/CI test parity + require a changeset for source changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,32 @@ jobs:
 
       - name: Build site
         run: bun run --filter @open-rgs/site build
+
+  # A PR that changes published package SOURCE must carry a changeset, so no
+  # user-visible change ever ships without a changelog + version bump. Escape
+  # hatch for genuinely no-release src edits (pure refactor, comment): add an
+  # empty changeset with `bunx changeset add --empty`. Scoped to packages/*/src
+  # so docs / tests / examples / apps changes don't trip it.
+  changeset-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Require a changeset for source changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          src="$(git diff --name-only "$BASE_SHA"...HEAD | grep -E '^packages/[^/]+/src/' || true)"
+          cs="$(git diff --name-only --diff-filter=A "$BASE_SHA"...HEAD | grep -E '^\.changeset/.+\.md$' | grep -viE 'README\.md$' || true)"
+          if [ -n "$src" ] && [ -z "$cs" ]; then
+            echo "::error::Published source changed but no changeset was added."
+            echo "Run 'bun run changeset' to describe the release, or 'bunx changeset add --empty' if this ships nothing user-visible."
+            echo "--- changed source files ---"
+            printf '%s\n' "$src"
+            exit 1
+          fi
+          echo "changeset check OK"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,10 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit -p packages/contract && tsc --noEmit -p packages/log && tsc --noEmit -p packages/core && tsc --noEmit -p packages/platform-mock && tsc --noEmit -p packages/simulator && tsc --noEmit -p packages/adapter-kit && tsc --noEmit -p packages/adapter-test-kit && tsc --noEmit -p packages/client",
-    "test": "bun --filter '@open-rgs/simulator' test",
+    "test": "bun test",
+    "test:core": "bun test packages/core",
+    "test:sim": "bun test packages/simulator",
+    "test:examples": "bun test examples",
     "site:dev": "npm --workspace apps/site run dev",
     "site:build": "npm --workspace apps/site run build",
     "site:preview": "npm --workspace apps/site run preview",


### PR DESCRIPTION
Two of the pre-release test gates from the testing plan. Both are tooling/CI only — no published-package source changes, so the new changeset gate doesn't (and shouldn't) require a changeset for this PR.

## 1. Local ↔ CI test parity (the footgun)

`bun run test` was `bun --filter '@open-rgs/simulator' test` — **only the simulator**. A dev running `bun run test` locally got a green from one package while CI runs the whole tree via bare `bun test`. Now:

- `test` → `bun test` (full suite, == CI)
- `test:core` / `test:sim` / `test:examples` → focused local runs

## 2. `changeset-check` CI job (PR-only)

Fails a PR that changes `packages/*/src/**` **without** adding a changeset, so no user-visible change ships without a changelog + version bump.

- **Escape hatch** for genuine no-release src edits (pure refactor, comment-only): `bunx changeset add --empty`.
- **Scoped to `src/`** — docs, tests, examples, and `apps/site` changes don't trip it.
- Logic unit-tested against synthetic diffs. Notably, `.changeset/README.md` (the boilerplate) is correctly **not** counted as a real changeset.

> Note: this adds a new check but doesn't make it *blocking* — to enforce it, add `changeset-check` to the branch's required status checks in repo settings.

No changeset here on purpose (root `package.json` is private; workflows aren't published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)