### PR TITLE
docs: sync with shipped WASM/Zig/pool/RNG; fix stale claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # open-rgs
 
 A small, MIT-licensed Remote Game Server. Bun-native orchestrator,
-snap-in Lua maths, pluggable wallet adapters, binary-msgpack on the
-wire. One Bun file boots a working server.
+snap-in maths (Lua, or compiled WASM kernels in Zig/Rust), pluggable
+wallet adapters, binary-msgpack on the wire. One Bun file boots a
+working server.
 
 Built for slots, instant games, Mines, Chicken-Road, crash, and any
 other casino round shape.
@@ -66,7 +67,7 @@ return {
             +-------------------------------+
             |         ORCHESTRATOR          | ◀---- admin http
             |   +-----------------------+   |       /livez /healthz
-            |   |   Lua math (wasmoon)  |   |       /admin/*
+            |   |  Lua / WASM kernel    |   |       /admin/*
             |   +-----------------------+   |
             +----------------+--------------+
                              |  PlatformAdapter (one interface)
@@ -110,13 +111,13 @@ not break it  - in **[specs/00-guarantees.md](specs/00-guarantees.md)**.
 | Package | Purpose |
 |---|---|
 | `@open-rgs/contract` | types only, zero deps |
-| `@open-rgs/core` | orchestrator, Lua runtime, binary-msgpack transport, admin, metrics |
+| `@open-rgs/core` | orchestrator, Lua + WASM math runtimes, math worker pool, secure RNG, binary-msgpack transport, admin, metrics |
 | `@open-rgs/log` | structured logger (JSON / Server-core / Console formats) |
 | `@open-rgs/platform-mock` | in-memory dev wallet with promo + autoclose helpers |
 | `@open-rgs/adapter-kit` | WS / HTTP RPC helpers + currency conversion for adapter authors |
 | `@open-rgs/adapter-test-kit` | conformance suite for any PlatformAdapter implementation |
 | `@open-rgs/client` | tiny TS WebSocket client (Bun / Node / browser) |
-| `@open-rgs/simulator` | per-mode RTP / hit-rate / mark simulator + reports |
+| `@open-rgs/simulator` | per-mode RTP / hit-rate / mark simulator + reports; fast WASM & native-Zig batch tiers |
 
 ## Build a game
 
@@ -137,6 +138,7 @@ Plug points (each is one interface):
 - **Wallet adapter** -> implement `PlatformAdapter` (talks to your operator's wallet)
 - **Transport** -> implement `ClientTransport` (the default `binaryTransport` is binary-msgpack + WS)
 - **Lua VM extensions** -> `LuaExtension` for helpers (reels, paylines, distributions)
+- **Compiled math** -> ship a WASM kernel (`loadWasmMath`) authored in Zig/Rust; run it fail-closed under a worker pool (`createMathPool`)
 - **Metrics / logs** -> bring your own registry / formatter
 - **Idempotency** -> configurable per RPC
 
@@ -157,8 +159,7 @@ is a round calculator + wallet driver.
 
 ## Status
 
-`v1.0.0`  - the first stable release, following a full
-production-readiness audit. The public contract (`@open-rgs/contract`
+`v1.x`  - stable, following a full production-readiness audit. The public contract (`@open-rgs/contract`
 + `@open-rgs/core`) follows semver from 1.0: a breaking change means a
 major bump, not a surprise. Releases and per-package changelogs are
 managed with [Changesets](https://github.com/changesets/changesets)  -

--- a/apps/site/src/pages/boot.astro
+++ b/apps/site/src/pages/boot.astro
@@ -36,7 +36,7 @@ const manifest = defineGame({
 
 await createServer({
   manifest,
-  platform:  new MockPlatform({ startingBalance: 100_00 }),
+  platform:  new MockPlatform({ startingBalance: 100_000 }),
   transport: binaryTransport({ port: Number(process.env.PORT ?? 80) }),
   version:   pkg.version,
   shutdownDrainMs: 30_000,

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -26,7 +26,7 @@ await createServer({
     id: "hello", declaredRtp: 0.95, defaultMode: "default",
     modes: { default: { math: await loadLuaMath("./maths/spin.lua"), stakeMultiplier: 1 } },
   }),
-  platform:  new MockPlatform({ startingBalance: 100_00 }),
+  platform:  new MockPlatform({ startingBalance: 100_000 }),
   transport: binaryTransport({ port: 80 }),
 });`}</code></pre>
 

--- a/apps/site/src/pages/math.astro
+++ b/apps/site/src/pages/math.astro
@@ -68,7 +68,7 @@ return {
     <table>
       <thead><tr><th>Helper</th><th>Behaviour</th></tr></thead>
       <tbody>
-        <tr><td><code>host.rng_next()</code></td><td>returns a float in <code>[0, 1)</code> from the orchestrator's RNG</td></tr>
+        <tr><td><code>host.rng_next()</code></td><td>returns a float in <code>[0, 1)</code> from the orchestrator's RNG (a secure CSPRNG by default; <code>Math.random</code> is never used)</td></tr>
         <tr><td><code>host.log_debug(msg)</code></td><td>writes a debug line tagged with the math file path</td></tr>
         <tr><td><code>host.mark.count(name)</code></td><td>increments a named counter  - inert in production, recorded by the simulator</td></tr>
         <tr><td><code>host.mark.observe(name, v)</code></td><td>appends a value to a named histogram</td></tr>
@@ -101,6 +101,47 @@ const math = await loadLuaMath("./maths/spin.lua", {
       round (visible in <code>/healthz</code>). Math version mismatch
       against stored session carry triggers the
       <code>manifest.recovery</code> policy.
+    </p>
+
+    <h2 data-section="§ 7">Compiled math (WASM / Zig)</h2>
+
+    <p>
+      For production-grade or certification-bound math, compile a kernel to
+      WebAssembly - typically in <strong>Zig</strong> (Rust, TinyGo, C also
+      work) - and load it instead of Lua. Same <code>MathModule</code>
+      contract; the orchestrator can't tell the difference. A WASM kernel runs
+      ~15x faster than the equivalent Lua and ships as one hashable artifact.
+    </p>
+
+    <pre><code>{`import { loadWasmMath, createMathPool, cryptoRng } from "@open-rgs/core";
+
+// Direct, synchronous calls - the fast path (trusted, bounded kernels).
+const math = await loadWasmMath("./maths/play.wasm", { rng: cryptoRng });
+
+// Fail-closed: run the kernel in a Worker pool with a per-call timeout.
+// A runaway kernel is killed via terminate() and the worker replaced.
+const pooled = await createMathPool({
+  wasmPath: "./maths/play.wasm", size: 4, timeoutMs: 1000,
+});`}</code></pre>
+
+    <p class="mute">
+      A running WASM call can't be interrupted from JS, so bare
+      <code>loadWasmMath</code> has <strong>no execution watchdog</strong> (it
+      warns at load). <code>createMathPool</code> is the fail-closed path - it
+      enforces the per-call budget by terminating the worker
+      (<code>MATH_TIMEOUT</code>). See <code>examples/hold-and-win</code> for a
+      worked Zig kernel and <a href="/build">build</a> for the toolchain.
+    </p>
+
+    <h2 data-section="§ 8">RNG (secure by default)</h2>
+
+    <p>
+      The host injects randomness; the math never owns its PRNG. The default is
+      a secure CSPRNG (<code>cryptoRng</code>, WebCrypto -> BoringSSL) -
+      <code>Math.random</code> is never used for outcomes. In production the
+      loader <strong>fails closed</strong>: you choose the source explicitly
+      (<code>&#123; rng: cryptoRng &#125;</code> or a certified source), even
+      though a secure default exists.
     </p>
 
     <nav class="related" aria-label="Related">

--- a/apps/site/src/pages/overview.astro
+++ b/apps/site/src/pages/overview.astro
@@ -5,7 +5,7 @@ import Mermaid from "../components/Mermaid.astro";
 
 <BaseLayout
   title="How it works (mile-high)  - open-rgs"
-  description="Mile-high overview of open-rgs: client transport, orchestrator, Lua math, platform adapter. One Bun process, one port, four interchangeable parts."
+  description="Mile-high overview of open-rgs: client transport, orchestrator, Lua/WASM math, platform adapter. One Bun process, one port, four interchangeable parts."
 >
   <main>
     <h1>How it works</h1>
@@ -24,7 +24,7 @@ flowchart TD
   subgraph RGS["one Bun process . one port"]
     direction TB
     Transport["TRANSPORT"]
-    Orch["ORCHESTRATOR<br/>. Lua math via wasmoon"]
+    Orch["ORCHESTRATOR<br/>. math: Lua or WASM (Zig)"]
     Transport --> Orch
   end
   Admin["admin http<br/>/livez . /healthz<br/>/admin/manifest<br/>/admin/autoclose"]
@@ -55,7 +55,7 @@ flowchart TD
         <tr>
           <td><strong>Math</strong></td>
           <td>RTP, ops, awaiting hints. Currency-blind. RNG injected via <code>host</code></td>
-          <td>write one Lua file per game shape</td>
+          <td>write a Lua file - or compile a WASM kernel (Zig) for certification</td>
         </tr>
         <tr>
           <td><strong>Adapter</strong></td>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,122 @@
+# @open-rgs/core
+
+The orchestrator and runtime for [open-rgs](https://open-rgs.dev) - the
+round lifecycle, money-movement choreography, math runtimes, secure RNG,
+binary-msgpack transport, admin endpoints, and metrics. With
+`@open-rgs/contract` it is the only required package.
+
+**Bun is required.** This package publishes raw TypeScript (no `dist/`) and
+leans on Bun-specific APIs; run it under Bun, not Node.
+
+## Install
+
+```bash
+bun add @open-rgs/core @open-rgs/contract @open-rgs/platform-mock
+```
+
+## Boot
+
+```ts
+import { createServer, binaryTransport, loadLuaMath } from "@open-rgs/core";
+import { defineGame } from "@open-rgs/contract";
+import { MockPlatform } from "@open-rgs/platform-mock";
+
+await createServer({
+  manifest: defineGame({
+    id: "hello", declaredRtp: 0.95, defaultMode: "default",
+    modes: { default: { math: await loadLuaMath("./maths/spin.lua"), stakeMultiplier: 1 } },
+  }),
+  platform:  new MockPlatform({ startingBalance: 100_000 }),
+  transport: binaryTransport({ port: 80 }),
+});
+```
+
+## Math runtimes
+
+A game's math is a `MathModule` (`@open-rgs/contract`). Core loads it from
+one of three source forms - same contract, swappable by a manifest entry:
+
+| Loader | Source | Use case |
+|--------|--------|----------|
+| `loadLuaMath(path, opts?)` | `.lua` via wasmoon (Lua 5.4 -> WASM) | Default. Cheap to write, hot-reloadable. Per-call watchdog (`debug.sethook`). |
+| `loadWasmMath(path, opts?)` | `.wasm` kernel (typically **Zig** or Rust) | Production-grade, certification-friendly, ~15x faster than Lua. Simple math only. |
+| `createMathPool(opts)` | the same `.wasm` kernel, in a Worker pool | The **fail-closed** way to run WASM math: per-call timeout enforced by `terminate()`. |
+
+### Compiled (WASM / Zig) math
+
+```ts
+import { loadWasmMath, cryptoRng } from "@open-rgs/core";
+
+// Direct, synchronous calls - the fast path.
+const math = await loadWasmMath("./maths/play.wasm", { rng: cryptoRng });
+```
+
+A WASM call cannot be interrupted from JS, so `loadWasmMath` has **no
+execution watchdog** - a runaway kernel would block the event loop. It logs
+a warning at load to keep that visible. Use it only for trusted, bounded
+kernels.
+
+For unbounded or untrusted WASM math, run it through the worker pool:
+
+```ts
+import { createMathPool } from "@open-rgs/core";
+
+const math = await createMathPool({
+  wasmPath:  "./maths/play.wasm",
+  size:      4,      // worker threads (default 4)
+  timeoutMs: 1000,   // per-call budget; an overrun is killed via terminate()
+});
+// ...later: math.shutdown();
+```
+
+The pool runs the kernel on Worker threads (off the I/O thread) and **kills**
+any worker that overruns the budget, failing the round with `MATH_TIMEOUT` and
+replacing the worker. This is the WASM tier's enforcement of Guarantee 5
+(Fail Closed / no-DoS). v1 is simple (single `play`) math.
+
+Why Zig for kernels: comptime RTP invariants, no GC pauses, no JIT warmup,
+tiny hashable output, and one source that compiles to **both** WASM (server)
+and a native binary (simulator) - byte-for-byte identical. See
+[`specs/06-performance.md`](../../specs/06-performance.md) and the worked
+`examples/hold-and-win` (a 3x3 hold-&-win on a Zig kernel).
+
+## Secure RNG
+
+Outcome randomness is injected by the host; the math never ships its own PRNG.
+
+- **Default is a secure CSPRNG.** `cryptoRng` (exported) draws from WebCrypto
+  `getRandomValues` (-> BoringSSL/OpenSSL, the same source Bun's `crypto`
+  uses). `Math.random` is **never** used for outcomes.
+- **Production fails closed.** Under `NODE_ENV=production`, a loader with no
+  `rng` injected **throws** - even though a secure default exists - so the
+  operator chooses the source deliberately. Pass `{ rng: cryptoRng }` for the
+  system CSPRNG, or inject a jurisdiction-certified source.
+- A seeded PRNG (e.g. `mulberry32` from `@open-rgs/simulator`) is for
+  simulation only; it is tagged and **refused** in production.
+
+```ts
+import { loadLuaMath, cryptoRng } from "@open-rgs/core";
+
+// Production: choose the RNG explicitly.
+const math = await loadLuaMath("./maths/spin.lua", { rng: cryptoRng });
+```
+
+## Also exported
+
+`createOrchestrator` (drive rounds without a transport), `binaryTransport`,
+`startAdmin` + admin/probe handlers, `createAuditLog` / `verifyChain` (hash-
+chained audit log), `createRgsMetrics` + a Prometheus-style `Registry`,
+`settleAmount` / `roundHalfEven` (integer minor-unit money), `uuidV4` /
+`deriveIdempotencyKey`, `cryptoRng`, and the `session` / `promo` namespaces.
+
+## Specs
+
+The contracts and guarantees this package enforces:
+[00-guarantees](../../specs/00-guarantees.md),
+[02-orchestrator](../../specs/02-orchestrator.md),
+[03-math-runtime](../../specs/03-math-runtime.md),
+[06-performance](../../specs/06-performance.md).
+
+## License
+
+MIT.

--- a/packages/simulator/README.md
+++ b/packages/simulator/README.md
@@ -81,6 +81,62 @@ console.log(mdReportSet(reports));
 
 Run it: `bun src/simulate.ts > report.md`.
 
+## Fast batch simulation (WASM + native Zig)
+
+`simulate()` above runs the math one spin at a time (the Lua path). When the
+math is a **WASM kernel** that exports `sim_batch`, the whole spin loop runs
+*inside* the kernel - 100M+ spins incur no per-spin `JS<->WASM` boundary, just
+one crossing per chunk. It uses a seeded in-VM PRNG and the same `decide`
+logic as the kernel's production `play`, so the measured RTP is exactly the
+shipped math's, on the same sandboxed artifact you serve (nothing to
+re-certify).
+
+```ts
+import { simulateWasmBatch } from "@open-rgs/simulator";
+
+const report = await simulateWasmBatch("./maths/play.wasm", {
+  spins:       100_000_000,
+  seed:        42,          // each chunk derives an independent substream
+  declaredRtp: 0.95,        // optional; else taken from the kernel's rtp_x10000
+});
+console.log(report.rtp.measured, report.rtp.verdict, report.hitRate);
+```
+
+Measured **~216M spins/sec single-threaded** (~250x the per-spin WASM path).
+The returned `WasmBatchReport` carries exact RTP + standard error + 95% CI +
+verdict, hit rate, and multiplier min/max/mean/stdDev (from the kernel's
+`count/sum/sumsq/min/max/hits` aggregate). Distribution percentiles and
+outcome-type / mark breakdowns are *not* produced by the fast path - use the
+per-spin `simulate()` for those. Combine with `--shards` for multicore.
+
+### Native "extreme" tier
+
+`simulateNativeBatch(binPath, opts)` runs a native build of the **same**
+`kernel.zig` (with `std.Thread` parallelism, so one call uses every core) for
+offline certification at billion-spin scale - measured **~1.65B spins/sec**
+(100M spins in ~60ms on 10 threads). It is **synchronous**:
+
+```ts
+import { simulateNativeBatch } from "@open-rgs/simulator";
+
+const report = simulateNativeBatch("./maths/sim", {
+  spins:       100_000_000,
+  seed:        42,
+  declaredRtp: 0.95,        // required - the native binary carries no RTP
+});
+```
+
+> ⚠️ The native tier is **unsandboxed** and a *separate* build from the WASM
+> you serve, so its soundness rests on a **byte-parity test**: a native
+> single-thread slice must be byte-identical to WASM `sim_batch` for the same
+> seed (same Zig source, both IEEE-754). Run that test whenever the kernel
+> changes, and use the native tier only to certify *your own* math.
+
+`reportFromAggregate(name, version, aggregate, declaredRtp, elapsedMs)` is the
+shared helper both tiers use to turn a raw `{count,sum,sumsq,min,max,hits}`
+aggregate into a `WasmBatchReport`. See `examples/hold-and-win` for a worked
+Zig kernel exercised through both tiers.
+
 ## What you get back
 
 One [`SimulationReport`](src/report.ts) per mode:

--- a/specs/00-guarantees.md
+++ b/specs/00-guarantees.md
@@ -116,7 +116,11 @@ moving money on a bad value.
 - **Enforced by:** multiplier sanitization (non-finite -> hard error, negative
   -> clamp to 0), `assertFundedWin`, the math watchdog (`MATH_TIMEOUT`), and
   RNG fail-closed under `NODE_ENV=production`
-  (`specs/02-orchestrator.md`, `specs/03-math-runtime.md`).
+  (`specs/02-orchestrator.md`, `specs/03-math-runtime.md`). The watchdog is
+  per math runtime: the Lua loader arms a `debug.sethook` count hook; a WASM
+  kernel run via `createMathPool` is bounded by terminating the worker on
+  overrun. (Bare `loadWasmMath` has **no** watchdog and logs a warning at
+  load - use the pool for unbounded or untrusted WASM math.)
 - **Prevents:** a math bug becoming a *maximum* payout (the canonical
   `NaN <= cap` trap), negative settlements, and unauditable randomness in
   real-money play.

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -18,7 +18,7 @@ the same contract is enforced regardless.
 | (subprocess) | spawn + length-prefixed msgpack stdio | Escape hatch for languages that don't WASM well. Slowest, most flexible. |
 
 `@open-rgs/core` ships a Lua loader (`loadLuaMath`) and a WASM loader
-(`loadWasmMath`, simple math; complex is planned). A TS loader
+(`loadWasmMath`, simple math only; complex is not yet supported). A TS loader
 (`loadTsMath`) is a planned peer. All loaders return a
 `Promise<MathModule>` that the manifest's `math:` field accepts. A WASM
 kernel runs ~15x faster than the equivalent Lua math (measured, 1-draw
@@ -28,9 +28,12 @@ construction, and ships as a hashable artifact for certification.
 **WASM watchdog caveat:** unlike the Lua loader, a running WASM call cannot be
 interrupted from JS, so `loadWasmMath` currently has **no per-call timeout** - a
 runaway kernel blocks the event loop (a DoS). Treat WASM kernels as trusted and
-bounded; `loadWasmMath` logs a warning at load to keep this visible. A timeout
-needs the kernel to run in a worker that can be `terminate()`-ed (planned: the
-shared math worker pool, which also moves math off the I/O thread).
+bounded; `loadWasmMath` logs a warning at load to keep this visible. For
+unbounded or untrusted WASM math, run it through **`createMathPool`** instead:
+it executes the kernel in a pool of Worker threads and enforces a per-call
+budget by `terminate()`-ing any worker that overruns (failing the round with
+`MATH_TIMEOUT`), which also moves math off the I/O thread. `loadWasmMath` is
+the fast trusted-kernel path; the pool is the fail-closed one.
 
 ## RNG seam
 
@@ -141,7 +144,7 @@ The loader:
   hidden, and the hook survives `debug = nil`, so sandboxed math cannot
   disable it.
 
-## WASM runtime details (planned)
+## WASM runtime details
 
 A WASM math module exposes these exports:
 
@@ -183,6 +186,14 @@ function, reads the output, then frees both.
 Source language: **Zig is the recommended default** for new WASM math.
 See **Spec 06** for performance rationale. Rust, AssemblyScript,
 TinyGo, and C all work.
+
+**Running a WASM kernel.** `loadWasmMath(path, { rng })` instantiates the
+kernel for direct, synchronous `play()` calls - the fast path, but with no
+execution watchdog (a runaway kernel blocks the event loop). For unbounded or
+untrusted math, `createMathPool({ wasmPath, size, timeoutMs })` runs the same
+kernel across Worker threads and enforces the per-call budget by terminating a
+worker that overruns - the fail-closed production path (see Guarantee 5). Both
+default to the secure `cryptoRng` and honor the same RNG seam described above.
 
 ## TS runtime details
 
@@ -232,9 +243,8 @@ restart                math is reloaded fresh; carry rehydrates from session.car
   workload (see **Spec 06**).
 - The same Lua source produces identical outputs given identical RNG
   sequences across two independent loader invocations.
-- A WASM math module conforming to the exports/imports above (when the
-  WASM loader ships) is interchangeable with a Lua module via a
-  manifest entry change only.
+- A WASM math module conforming to the exports/imports above is
+  interchangeable with a Lua module via a manifest entry change only.
 
 ## Open questions
 

--- a/specs/09-roadmap.md
+++ b/specs/09-roadmap.md
@@ -17,6 +17,19 @@ A living document. Updated when work lands or reprioritises.
 - Spec corpus 00-10 (overview through design philosophy).
 - ADR seed (001-006).
 - `CLAUDE.md` handoff doc for AI session continuity.
+- `@open-rgs/simulator` - per-mode RTP / hit-rate simulator + reports, with
+  multi-process `--shards`, plus fast batch tiers: `simulateWasmBatch`
+  (in-kernel `sim_batch`, ~216M spins/s single-threaded) and
+  `simulateNativeBatch` (native Zig + `std.Thread`, ~1.65B spins/s,
+  byte-parity with the WASM kernel).
+- WASM math loader (`loadWasmMath`) - load a Zig/Rust-authored `.wasm` kernel
+  directly (simple math).
+- Math worker pool (`createMathPool`) - runs WASM math in Worker threads with
+  a per-call `terminate()` timeout (the fail-closed watchdog for the WASM tier).
+- Secure-by-default outcome RNG (`cryptoRng` via WebCrypto -> BoringSSL) with
+  production fail-closed (the operator must choose an RNG explicitly) and an
+  opt-in deterministic `seed-expand` replay mode (xoshiro256++).
+- Worked examples on Zig kernels (e.g. `examples/hold-and-win`).
 
 ## Architectural decisions captured (A1-A10)
 
@@ -78,7 +91,6 @@ J  - public-surface freeze v0.5: pending
 |------|------|-------|
 | Prometheus metrics + W3C tracing | 06 | Operating blind today |
 | Graceful shutdown + drain mode | 02, 07 | K8s rolling restarts drop sessions |
-| WASM math loader | 03 | Open the door for Zig-authored maths |
 | Public/private state split (`view(state)`) | 01, 03, 08 | Required for honest exploit testing |
 | Bonus engine abstraction (promo -> BonusCampaign) | 02 | Jackpots, tournaments, gamification points |
 | `@open-rgs/cli fuzz` & `optimize` | 08 | Round out the math-author DX |

--- a/specs/10-design-philosophy.md
+++ b/specs/10-design-philosophy.md
@@ -38,7 +38,8 @@ No "auth helper #1 vs #2 vs #3  - pick your favourite."
 - One canonical JWT
 - One canonical mTLS
 - One canonical session store (in-memory)
-- One canonical math loader (Lua via wasmoon)
+- One canonical math loader per source form (Lua via wasmoon; WASM via
+  `loadWasmMath` for compiled/Zig kernels, optionally pooled by `createMathPool`)
 
 If someone needs exotic, they bring their own. Optionality compounds;
 pick one.


### PR DESCRIPTION
Audited the whole doc surface (specs + ADRs, the live site, every README) against the current code, then fixed what was now **false/stale** and added the missing **Zig/WASM** coverage you asked for. Used three parallel read-only audits, then verified every line-level claim (and every documented signature) against source before editing.

## Lies / staleness fixed

- **`specs/03-math-runtime`** — the math **worker pool** and the **WASM loader** were both described as *"planned"*. Both shipped. Now: `loadWasmMath` (fast, **no** watchdog, warns at load) vs `createMathPool` (fail-closed via terminate-on-timeout). Removed "(planned)" heading and "when the WASM loader ships".
- **`specs/09-roadmap`** — moved "WASM math loader" out of *Planned*; recorded what actually shipped (simulator + WASM/native batch tiers, `loadWasmMath`, `createMathPool`, secure-default + fail-closed RNG, `seed-expand`, Zig examples).
- **`specs/00-guarantees` (Guarantee 5)** — clarified the watchdog is **per runtime**: Lua `debug.sethook`; WASM bounded only via `createMathPool`; bare `loadWasmMath` has none. (Trust-accuracy — the prior text implied a blanket watchdog.)
- **`specs/10`** — "one canonical math loader (Lua)" → per source form (Lua + WASM).
- **`README.md`** — Lua-only framing → Lua/WASM; refreshed `@open-rgs/core` + `@open-rgs/simulator` blurbs; added a "compiled math" extend bullet; stale **`v1.0.0`** status → `v1.x`.
- **`site/index.astro` + `site/boot.astro`** — copy-paste bug: `startingBalance: 100_00` → `100_000` (didn't match MockPlatform's real default of `100_000`).

## Zig / WASM added

- **NEW `packages/core/README.md`** — core had **none**. Math-runtimes table (`loadLuaMath` / `loadWasmMath` / `createMathPool`), the secure-RNG policy, why Zig, and the Zig→WASM+native byte-parity story.
- **`packages/simulator/README.md`** — documented `simulateWasmBatch` (~216M spins/s), `simulateNativeBatch` (native Zig, ~1.65B spins/s, byte-parity), and `reportFromAggregate` — **signatures verified against source** (`simulateWasmBatch` async returns a report, `seed` is a number; `simulateNativeBatch` sync, `declaredRtp` required).
- **`site/math.astro`** — new "Compiled math (WASM / Zig)" + "RNG (secure by default)" sections; `host.rng_next` noted as a secure CSPRNG.
- **`site/overview.astro`** — architecture diagram + roles now say Lua **or** WASM (Zig).

## What was already fine (verified, not touched)

`specs/06-performance` (full Zig section + both batch tiers with real numbers — done earlier this cycle), `specs/01-public-contracts` (contract types only), `specs/04`/`05`, the wasm-fixtures README, and `examples/hold-and-win/README`.

Docs-only — no `packages/*/src` touched (so the new changeset gate doesn't fire; no release changeset needed — these READMEs ride along with the next publish). **Site build + typecheck green; new `/math` + `/overview` content rendered and verified.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)