### PR TITLE
docs: fix how-to-build-Zig (stale command, dangling link, missing build step)

### DIFF
--- a/apps/site/src/pages/math.astro
+++ b/apps/site/src/pages/math.astro
@@ -113,6 +113,10 @@ const math = await loadLuaMath("./maths/spin.lua", {
       ~15x faster than the equivalent Lua and ships as one hashable artifact.
     </p>
 
+    <p>Build the kernel to WASM with zig, then point a manifest mode at the <code>.wasm</code>:</p>
+
+    <pre><code>{`zig build-exe play.zig -target wasm32-freestanding -fno-entry -rdynamic -OReleaseSmall -femit-bin=play.wasm`}</code></pre>
+
     <pre><code>{`import { loadWasmMath, createMathPool, cryptoRng } from "@open-rgs/core";
 
 // Direct, synchronous calls - the fast path (trusted, bounded kernels).
@@ -130,7 +134,8 @@ const pooled = await createMathPool({
       warns at load). <code>createMathPool</code> is the fail-closed path - it
       enforces the per-call budget by terminating the worker
       (<code>MATH_TIMEOUT</code>). See <code>examples/hold-and-win</code> for a
-      worked Zig kernel and <a href="/build">build</a> for the toolchain.
+      worked Zig kernel (with its <code>zig build-exe</code> commands and a
+      native multithreaded sim).
     </p>
 
     <h2 data-section="§ 8">RNG (secure by default)</h2>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -44,6 +44,17 @@ one of three source forms - same contract, swappable by a manifest entry:
 
 ### Compiled (WASM / Zig) math
 
+Author a kernel (exports `play` / `alloc` / `free`, imports `host.rng_next`;
+see `examples/hold-and-win/maths/play.zig` for a worked one) and build it to
+WASM with zig:
+
+```bash
+zig build-exe play.zig -target wasm32-freestanding -fno-entry -rdynamic \
+  -OReleaseSmall -femit-bin=play.wasm
+```
+
+Then load it:
+
 ```ts
 import { loadWasmMath, cryptoRng } from "@open-rgs/core";
 

--- a/specs/06-performance.md
+++ b/specs/06-performance.md
@@ -169,9 +169,9 @@ In rough order of likelihood:
 ### Zig math kernel: minimum shape
 
 ```zig
-// build with: zig build-lib play.zig -target wasm32-freestanding \
-//   -dynamic --export=play --export=alloc --export=free \
-//   -O ReleaseFast
+// build with: zig build-exe play.zig -target wasm32-freestanding \
+//   -fno-entry -rdynamic -OReleaseSmall -femit-bin=play.wasm
+// (the native simulator binary: zig build-exe sim.zig -OReleaseFast -femit-bin=sim)
 
 const std = @import("std");
 


### PR DESCRIPTION
Follow-up to #32, prompted by "did you tell how to **use** zig in docs?" — turns out the build instructions were incomplete and, in one place, wrong.

## Fixes

- **`specs/06`** showed `zig build-lib … -dynamic --export=play … -O ReleaseFast` — which does **not** match what actually built the shipped `play.wasm` and won't work as written on zig 0.15.2. Corrected to the real form (the one used by the example + fixtures READMEs): `zig build-exe … -fno-entry -rdynamic -OReleaseSmall -femit-bin=play.wasm`, plus the native sim build.
- **`packages/core/README`** explained *why* Zig and how to *load* a kernel but never how to **build** one. Added the `zig build-exe` command so author → build → load is self-contained.
- **`site/math.astro`** §7 linked to `/build` "for the toolchain", but `/build` has **no** Zig content (dangling). Replaced with the actual build command inline + a pointer to the worked example.

The `zig build-exe` command is now **identical** across `specs/06`, the core README, `examples/hold-and-win/README`, and the fixtures README.

Docs-only; site build green, command renders intact, dangling link gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)