### PR TITLE
example(blackjack): simulating a game with many options + optimal policy

### DIFF
--- a/examples/blackjack/README.md
+++ b/examples/blackjack/README.md
@@ -1,0 +1,69 @@
+# Example: blackjack — simulating a game with options
+
+Blackjack is the canonical "many options" game, and it makes one point
+unavoidable: **a game with choices has no single RTP — only an RTP per policy.**
+This example is a *simulation study*: the same game played under five different
+player policies, measured with the simulator's pluggable strategy.
+
+```
+blackjack RTP by player policy  (1,000,000 hands each)
+
+  policy                          RTP       hands/s
+  basic strategy (optimal-ish)    97.69%     ~660,000
+  mimic dealer (hit < 17)         94.36%     ~620,000
+  random                          65.77%     ~680,000
+  always stand                    84.08%     ~820,000
+  always hit                      11.49%     ~580,000
+```
+
+"What's the RTP of blackjack?" is only answerable as **"under which strategy?"**
+Optimal play (basic strategy) is the ceiling; everything else bleeds. That's the
+number a regulator cares about for a skill game — the most a player can extract.
+
+## How it works
+
+`src/blackjack.ts` is an open-rgs **complex math** (`open → step* → close`),
+currency-blind and RNG-injected like any other. Each decision emits the **public
+context** in `ops` (`{ total, soft, dealerUp }`) — exactly what a real player
+sees. The policy is a simulator `StrategyFn` that reads that context:
+
+```ts
+import { simulate } from "@open-rgs/simulator";
+import { basicStrategy } from "./strategy.js";
+
+const [report] = await simulate(manifest, { complexStrategy: basicStrategy });
+```
+
+`basicStrategy` reads the public `ops` and returns hit/stand — it never sees the
+opaque `state`, so the simulated policy can't cheat on hidden cards. Swap in
+`mimicDealer`, `alwaysStand`, `randomPlay`, or your own optimal solver.
+
+## Rules (fixed)
+
+Infinite deck (cards i.i.d.), dealer **stands on all 17 (S17)**, blackjack pays
+**3:2**, **hit/stand only**.
+
+## Why hit/stand only (the honest part)
+
+Double and split **change the wager mid-round**. open-rgs deliberately fixes the
+bet at round open and moves money **at most twice** (open debit, close credit) —
+there is no mid-round debit. So double/split don't fit a *faithful served game*
+without modeling the bet as the pre-committed maximum (reserve 2× at open). They
+also break naive RTP measurement: a doubled win pays on 2× stake while the
+denominator still counts 1× (an early version of this example measured a bogus
+108% RTP for exactly that reason). Hit/stand keeps every round at one unit, so
+the measured RTP is honest. Split / double / surrender are a natural extension
+for the [examples gallery](https://github.com/open-rgs/open-rgs-examples).
+
+## Run
+
+```bash
+bun examples/blackjack/src/study.ts   # the policy comparison above
+```
+
+## Two tiers (recap)
+
+This example uses the **host-driven** strategy tier — flexible, runs any policy
+(even an optimal solver) at ~100k–1M rounds/s. For a *fixed* policy at native
+speed, bake it into the kernel and self-play in WASM — see
+[`examples/cash-ladder`](../cash-ladder) (`sim_ladder`).

--- a/examples/blackjack/src/blackjack.ts
+++ b/examples/blackjack/src/blackjack.ts
@@ -1,0 +1,110 @@
+// Blackjack as an open-rgs COMPLEX math, for studying "options" in simulation.
+// open() deals; step() takes hit / stand / double; close() plays the dealer and
+// settles. The point of the example: the RTP depends entirely on the player's
+// POLICY, and the optimal policy (basic strategy) is a state-dependent function
+// of the public context the math exposes via `ops`.
+//
+// Rules (fixed, documented): infinite deck (cards i.i.d.), dealer stands on all
+// 17 (S17), blackjack pays 3:2, double on any first two cards. NO split /
+// surrender / insurance - see README for why (split/double change the WAGER,
+// which open-rgs's fixed-bet, money-moves-<=-twice model doesn't move mid-round;
+// double here is expressed as a 2x multiplier for RTP measurement).
+//
+// Currency-blind + RNG-injected, like any open-rgs math: it never sees the bet,
+// only returns a multiplier; all randomness comes from the injected `rng`.
+
+import type { ComplexMath, RoundState, SpinContext, PlayerAction } from "../../../packages/contract/src/index.js";
+
+interface BJState {
+  p: number[];   // player card ranks (1=A, 2..13)
+  du: number;    // dealer upcard rank
+  dh: number;    // dealer hole rank (drawn at open, hidden until close)
+  doubled: boolean;
+  done: boolean;
+  ret: number | null; // resolved return (naturals / bust); null => close plays dealer
+}
+
+/** Best total <= 21 for a set of ranks, and whether it's "soft" (an ace still
+ *  counted as 11). */
+export function handTotal(ranks: number[]): { total: number; soft: boolean } {
+  let total = 0;
+  let acesAt11 = 0;
+  for (const r of ranks) {
+    if (r === 1) { acesAt11 += 1; total += 11; }
+    else total += r >= 10 ? 10 : r;
+  }
+  while (total > 21 && acesAt11 > 0) { total -= 10; acesAt11 -= 1; }
+  return { total, soft: acesAt11 > 0 };
+}
+
+const retType = (m: number): string => (m === 0 ? "lose" : m === 1 ? "push" : "win");
+
+/** Build a blackjack ComplexMath driven by the injected `rng` (in [0,1)). */
+export function makeBlackjack(rng: () => number): ComplexMath {
+  const draw = (): number => 1 + Math.floor(rng() * 13); // rank 1..13
+
+  // The public context a player/strategy can see at a decision point.
+  const ctxOps = (s: BJState): unknown[] => {
+    const { total, soft } = handTotal(s.p);
+    return [{ total, soft, dealerUp: s.du === 1 ? 11 : s.du >= 10 ? 10 : s.du }];
+  };
+  // hit / stand only. Double & split CHANGE THE WAGER mid-round, which open-rgs's
+  // fixed-bet model (money moves <= twice: open debit, close credit) doesn't do -
+  // so they're out of a faithful served game (see README). That also keeps the
+  // RTP denominator honest: every round wagers exactly the base bet.
+  const options = (): unknown[] => ["hit", "stand"];
+
+  return {
+    kind: "complex",
+    name: "blackjack",
+    version: "1.0.0",
+    rtp: 0.99, // metadata; real RTP is policy-dependent (measured in the study)
+
+    open(_prev: RoundState | undefined, _ctx: SpinContext) {
+      const s: BJState = { p: [draw(), draw()], du: draw(), dh: draw(), doubled: false, done: false, ret: null };
+      const player = handTotal(s.p).total;
+      const dealer = handTotal([s.du, s.dh]).total;
+      const playerBJ = player === 21;
+      const dealerBJ = dealer === 21;
+      if (playerBJ || dealerBJ) {
+        s.done = true;
+        s.ret = playerBJ && dealerBJ ? 1 : playerBJ ? 2.5 : 0; // 3:2 blackjack
+        return { state: JSON.stringify(s), ops: ctxOps(s), awaiting: undefined };
+      }
+      return { state: JSON.stringify(s), ops: ctxOps(s), awaiting: { type: "act", options: options() } };
+    },
+
+    step(stateStr: RoundState, action: PlayerAction) {
+      const s: BJState = JSON.parse(stateStr);
+      const move = String(action["value"] ?? "stand");
+      if (move === "hit") {
+        s.p.push(draw());
+        if (handTotal(s.p).total > 21) { s.done = true; s.ret = 0; return { state: JSON.stringify(s), ops: ctxOps(s), awaiting: undefined }; }
+        return { state: JSON.stringify(s), ops: ctxOps(s), awaiting: { type: "act", options: options() } };
+      }
+      // stand
+      s.done = true;
+      return { state: JSON.stringify(s), ops: ctxOps(s), awaiting: undefined };
+    },
+
+    isTerminal(stateStr: RoundState): boolean {
+      return (JSON.parse(stateStr) as BJState).done;
+    },
+
+    close(stateStr: RoundState) {
+      const s: BJState = JSON.parse(stateStr);
+      if (s.ret !== null) return { multiplier: s.ret, ops: [], type: s.ret >= 2 ? "blackjack" : retType(s.ret) };
+      // Player stood or doubled without busting: play the dealer (S17).
+      const dealer = [s.du, s.dh];
+      let dt = handTotal(dealer);
+      while (dt.total < 17) { dealer.push(draw()); dt = handTotal(dealer); }
+      const pt = handTotal(s.p).total;
+      let base: number;
+      if (dt.total > 21 || pt > dt.total) base = 2;     // dealer bust or player higher -> win
+      else if (pt === dt.total) base = 1;               // push
+      else base = 0;                                    // lose
+      const mult = base * (s.doubled ? 2 : 1);
+      return { multiplier: mult, ops: [], type: retType(base) };
+    },
+  };
+}

--- a/examples/blackjack/src/strategy.ts
+++ b/examples/blackjack/src/strategy.ts
@@ -1,0 +1,43 @@
+// Blackjack policies as simulator StrategyFns. Each reads only the PUBLIC
+// context (the latest `ops` the math emitted + the offered `awaiting.options`),
+// never the opaque state - exactly what a real player sees. `basicStrategy` is
+// the optimal-ish policy (basic strategy for S17, double any two, no split).
+
+import type { StrategyFn } from "../../../packages/simulator/src/index.js";
+
+interface HandCtx { total: number; soft: boolean; dealerUp: number }
+
+/** Basic strategy for a hit/stand game (S17, no double/split): the optimal
+ *  hit-vs-stand decision per hand total and dealer upcard (2..11, ace = 11). */
+export function basicMove({ total, soft, dealerUp: d }: HandCtx): "hit" | "stand" {
+  if (soft) {
+    if (total >= 19) return "stand";              // soft 19+
+    if (total === 18) return d <= 8 ? "stand" : "hit"; // A,7: stand vs 2-8, hit 9/10/A
+    return "hit";                                 // soft <= 17
+  }
+  if (total >= 17) return "stand";
+  if (total >= 13) return d <= 6 ? "stand" : "hit";  // 13-16: stand vs 2-6
+  if (total === 12) return d >= 4 && d <= 6 ? "stand" : "hit";
+  return "hit";                                   // <= 11
+}
+
+const latest = (ops: unknown[]): HandCtx => ops[ops.length - 1] as HandCtx;
+
+/** Optimal hit/stand policy: basic strategy reading the public ops. */
+export const basicStrategy: StrategyFn = ({ awaiting, ops }) =>
+  ({ type: awaiting.type, value: basicMove(latest(ops)) });
+
+// --- naive baselines, to show how much the policy matters ---------------
+export const mimicDealer: StrategyFn = ({ awaiting, ops }) =>
+  ({ type: awaiting.type, value: latest(ops).total < 17 ? "hit" : "stand" });
+
+export const alwaysStand: StrategyFn = ({ awaiting }) =>
+  ({ type: awaiting.type, value: "stand" });
+
+export const alwaysHit: StrategyFn = ({ awaiting }) =>
+  ({ type: awaiting.type, value: "hit" });
+
+export const randomPlay: StrategyFn = ({ awaiting, rng }) => {
+  const opts = awaiting.options as string[];
+  return { type: awaiting.type, value: opts[Math.floor(rng() * opts.length)] };
+};

--- a/examples/blackjack/src/study.ts
+++ b/examples/blackjack/src/study.ts
@@ -1,0 +1,47 @@
+// RTP-by-policy study for blackjack: the same game, simulated under five
+// different player policies. A game with options has no single RTP - the number
+// you certify depends entirely on the strategy. Optimal (basic strategy) is
+// near-fair; naive policies bleed.
+//
+//   bun examples/blackjack/src/study.ts
+
+import { simulate, type StrategyFn } from "../../../packages/simulator/src/index.js";
+import { defineGame } from "../../../packages/contract/src/index.js";
+import { makeBlackjack } from "./blackjack.js";
+import { basicStrategy, mimicDealer, alwaysStand, alwaysHit, randomPlay } from "./strategy.js";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SPINS = 1_000_000;
+const policies: Array<[string, StrategyFn]> = [
+  ["basic strategy (optimal-ish)", basicStrategy],
+  ["mimic dealer (hit < 17)", mimicDealer],
+  ["random", randomPlay],
+  ["always stand", alwaysStand],
+  ["always hit", alwaysHit],
+];
+
+console.log(`blackjack RTP by player policy  (${SPINS.toLocaleString()} hands each)\n`);
+console.log("  policy                          RTP       hands/s");
+for (const [name, strat] of policies) {
+  const math = makeBlackjack(mulberry32(12345)); // same starting deals per policy
+  const manifest = defineGame({
+    id: "blackjack", declaredRtp: 0.99, defaultMode: "default",
+    modes: { default: { math, stakeMultiplier: 1 } },
+  });
+  const t0 = performance.now();
+  const [r] = await simulate(manifest, { spinsPerMode: SPINS, complexStrategy: strat, seed: 7 });
+  const dt = performance.now() - t0;
+  const hps = Math.round((SPINS / dt) * 1000).toLocaleString();
+  console.log(`  ${name.padEnd(30)}  ${(r!.rtp.measured * 100).toFixed(2)}%   ${hps.padStart(9)}`);
+}
+console.log("\nSame game, a huge RTP spread - ~98% (optimal) down to ~11% (always hit).");
+console.log("'What's the RTP?' is only answerable as 'under which strategy?' - optimal is the ceiling.");

--- a/examples/blackjack/test/rtp.test.ts
+++ b/examples/blackjack/test/rtp.test.ts
@@ -1,0 +1,47 @@
+// Blackjack RTP is policy-relative: basic strategy is near-fair and the ceiling;
+// naive policies bleed. Also a sanity check on the hand evaluator.
+
+import { describe, expect, test } from "bun:test";
+import { simulate, type StrategyFn } from "../../../packages/simulator/src/index.js";
+import { defineGame } from "../../../packages/contract/src/index.js";
+import { makeBlackjack, handTotal } from "../src/blackjack.js";
+import { basicStrategy, mimicDealer, alwaysHit } from "../src/strategy.js";
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const rtpUnder = async (strat: StrategyFn): Promise<number> => {
+  const math = makeBlackjack(mulberry32(999)); // same deals per policy
+  const manifest = defineGame({
+    id: "blackjack", declaredRtp: 0.99, defaultMode: "default",
+    modes: { default: { math, stakeMultiplier: 1 } },
+  });
+  const [r] = await simulate(manifest, { spinsPerMode: 300_000, complexStrategy: strat, seed: 3 });
+  return r!.rtp.measured;
+};
+
+describe("blackjack: RTP is policy-relative", () => {
+  test("hand evaluator handles soft aces", () => {
+    expect(handTotal([1, 6])).toEqual({ total: 17, soft: true }); // A,6
+    expect(handTotal([1, 6, 10])).toEqual({ total: 17, soft: false }); // A counted as 1
+    expect(handTotal([13, 13, 2])).toEqual({ total: 22, soft: false }); // K,K,2 bust
+  });
+
+  test("basic strategy is near-fair and beats naive play", async () => {
+    const basic = await rtpUnder(basicStrategy);
+    const mimic = await rtpUnder(mimicDealer);
+    const hit = await rtpUnder(alwaysHit);
+    expect(basic).toBeGreaterThan(0.96); // hit/stand basic strategy ~97.7%
+    expect(basic).toBeLessThanOrEqual(1.0); // a real house edge -> no player advantage
+    expect(basic).toBeGreaterThan(mimic); // optimal beats mimic-the-dealer
+    expect(mimic).toBeGreaterThan(0.9); // mimic ~94%
+    expect(hit).toBeLessThan(0.5); // always-hit busts -> bleeds
+  }, 30_000);
+});


### PR DESCRIPTION
The "many options in blackjack" half of the question. A simulation **study** that makes the point unavoidable: a game with choices has **no single RTP — only an RTP per policy.**

```
blackjack RTP by player policy  (1,000,000 hands each)

  policy                          RTP
  basic strategy (optimal-ish)    97.69%   <- the ceiling
  mimic dealer (hit < 17)         94.36%
  always stand                    84.08%
  random                          65.77%
  always hit                      11.49%
```

"What's the RTP of blackjack?" → only answerable as **"under which strategy?"** Optimal play is the ceiling — the number a regulator cares about for a skill game.

## How

`src/blackjack.ts` is an open-rgs **complex math** (`open → step* → close`), currency-blind + RNG-injected. Each decision emits the **public context** in `ops` (`{total, soft, dealerUp}`) — what a real player sees. The policies are simulator `StrategyFn`s (from #35) that read **only** that public context, never the opaque `state`, so a simulated policy can't cheat on hidden cards. `basicStrategy` is the optimal hit/stand table.

## Honest scope (the interesting constraint)

**Hit/stand only.** Double & split **change the wager mid-round**, which open-rgs's fixed-bet, money-moves-≤-twice model doesn't do — *and* they break naive RTP measurement: a doubled win pays on 2× stake while the denominator still counts 1×. (An early draft of this example measured a bogus **108%** for exactly that reason — caught and removed.) Hit/stand keeps every round at one unit, so the RTP is honest. Split/double/surrender are a natural [examples-gallery](https://github.com/open-rgs/open-rgs-examples) extension. Rules: infinite deck, dealer S17, BJ pays 3:2.

## Tests
Hand evaluator (soft aces); basic strategy is near-fair (~97.7%), beats mimic-dealer (~94%), trounces always-hit (~11%).

Examples-only — no `packages/*/src`, no changeset. Full suite **322 pass / 0 fail**; typecheck + site green. Merging to main only — no publish.

This is the **host-driven** strategy tier (flexible, any policy). The complement — a *fixed* policy baked into a WASM kernel for native-speed sweeps — is `examples/cash-ladder` (`sim_ladder`, from #35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)