### PR TITLE
docs(examples): measure Lua↔Zig speed, correct ~15× to measured ~14× (+ committed benches)

### DIFF
--- a/.changeset/wasm-math.md
+++ b/.changeset/wasm-math.md
@@ -2,8 +2,8 @@
 "@open-rgs/core": minor
 ---
 
-feat(core): `loadWasmMath` — WASM math kernels (simple), ~15× faster than Lua
+feat(core): `loadWasmMath` — WASM math kernels (simple), ~14× faster than Lua
 
-New `loadWasmMath(path, opts)` loads a `.wasm` math kernel conforming to the spec ABI (specs/03-math-runtime.md) and adapts it to `MathModule` — the orchestrator can't tell it from a Lua math. A WASM kernel runs **~15× faster than the equivalent Lua math** (measured, 1-draw distribution): it calls the `host.rng_next` import directly with no per-draw JS↔WASM proxy tax, stays **sandboxed by construction**, and ships as a **hashable artifact** for certification. I/O is MessagePack over linear memory; RNG resolution is shared with `loadLuaMath` (secure system CSPRNG by default, fail-closed in production). A reference Zig kernel and the built `.wasm` are in the core test fixtures.
+New `loadWasmMath(path, opts)` loads a `.wasm` math kernel conforming to the spec ABI (specs/03-math-runtime.md) and adapts it to `MathModule` — the orchestrator can't tell it from a Lua math. A WASM kernel runs **~14× faster than the equivalent Lua math** (measured on identical math; reproduce with `examples/twin-slot/src/bench.ts`): it calls the `host.rng_next` import directly with no per-draw JS↔WASM proxy tax, stays **sandboxed by construction**, and ships as a **hashable artifact** for certification. I/O is MessagePack over linear memory; RNG resolution is shared with `loadLuaMath` (secure system CSPRNG by default, fail-closed in production). A reference Zig kernel and the built `.wasm` are in the core test fixtures.
 
 Scope: **simple** math (single `play`). Complex (`open`/`step`/`close`/`is_terminal`) is planned — it needs in-kernel msgpack-decode of state — and currently throws a clear error. Internal: the Lua→TS outcome adapters were extracted to a shared `math-adapt` module so both loaders normalise outcomes identically, and `resolveRng` is shared so the WASM loader inherits the exact secure-default / fail-closed policy.

--- a/apps/site/src/pages/math.astro
+++ b/apps/site/src/pages/math.astro
@@ -110,7 +110,8 @@ const math = await loadLuaMath("./maths/spin.lua", {
       WebAssembly - typically in <strong>Zig</strong> (Rust, TinyGo, C also
       work) - and load it instead of Lua. Same <code>MathModule</code>
       contract; the orchestrator can't tell the difference. A WASM kernel runs
-      ~15x faster than the equivalent Lua and ships as one hashable artifact.
+      ~14x faster than the equivalent Lua (measured; reproduce with
+      <code>examples/twin-slot/src/bench.ts</code>) and ships as one hashable artifact.
     </p>
 
     <p>Build the kernel to WASM with zig, then point a manifest mode at the <code>.wasm</code>:</p>

--- a/examples/twin-gamble/src/bench.ts
+++ b/examples/twin-gamble/src/bench.ts
@@ -1,0 +1,50 @@
+// Head-to-head speed for a COMPLEX round: the same fair double-or-nothing in Lua
+// vs Zig/WASM, timing a full open + 3 gambles + close. Reproducer for the docs'
+// ~14x figure on the complex path - the marshalling cost is paid per call, so a
+// multi-call round shows the same gap as a single play().
+//
+//   bun examples/twin-gamble/src/bench.ts
+
+import { resolve } from "node:path";
+import { loadLuaMath, loadWasmMath } from "../../../packages/core/src/index.js";
+import type { ComplexMath, PlayerAction, OpenOutcome, StepOutcome } from "../../../packages/contract/src/index.js";
+
+const ctx = { mode: "default" } as const;
+const here = import.meta.dir;
+const GAMBLE: PlayerAction = { type: "gamble" };
+
+function bench(fn: () => unknown, n: number, reps = 7): number {
+  for (let i = 0; i < (n >> 2); i++) fn(); // warm up
+  let best = Infinity;
+  for (let r = 0; r < reps; r++) {
+    const t = performance.now();
+    for (let i = 0; i < n; i++) fn();
+    best = Math.min(best, performance.now() - t);
+  }
+  return (best / n) * 1e3; // us per round
+}
+
+// open + 3 gambles + close. open/step/close are synchronous here (wasmoon's
+// bridge and the WASM call both return sync), so we cast rather than await -
+// awaiting a non-promise would add a microtask per call and skew the numbers.
+const roundOf = (m: ComplexMath) => (): void => {
+  let s = (m.open(undefined, ctx) as OpenOutcome).state;
+  for (let k = 0; k < 3; k++) s = (m.step(s, GAMBLE) as StepOutcome).state;
+  m.close(s);
+};
+
+// rng=()=>0: base wins, every gamble succeeds -> a fixed 3-gamble round.
+const luaOn = (await loadLuaMath(resolve(here, "../maths/gamble.lua"), { rng: () => 0 })) as ComplexMath;
+const luaOff = (await loadLuaMath(resolve(here, "../maths/gamble.lua"), { rng: () => 0, timeoutMs: 0 })) as ComplexMath;
+const wasm = (await loadWasmMath(resolve(here, "../maths/gamble.wasm"), { rng: () => 0 })) as ComplexMath;
+
+const N = 100_000;
+const a = bench(roundOf(luaOn), N);
+const b = bench(roundOf(luaOff), N);
+const c = bench(roundOf(wasm), N);
+
+console.log(`twin-gamble - per full round = open + 3 gambles + close (${N.toLocaleString()} rounds x7, best rep)\n`);
+console.log(`  lua  (watchdog on, default):  ${a.toFixed(2).padStart(7)} us`);
+console.log(`  lua  (watchdog off):          ${b.toFixed(2).padStart(7)} us`);
+console.log(`  wasm (zig):                   ${c.toFixed(2).padStart(7)} us`);
+console.log(`\n  -> wasm is ${(a / c).toFixed(1)}x faster than Lua (default), ${(b / c).toFixed(1)}x with the watchdog off`);

--- a/examples/twin-slot/src/bench.ts
+++ b/examples/twin-slot/src/bench.ts
@@ -1,0 +1,46 @@
+// Head-to-head speed: the SAME slot math in Lua vs Zig/WASM. This is the
+// reproducer behind the docs' "~14x faster than Lua" figure - run it on your own
+// hardware. The *ratio* is fairly stable; the absolute ns are machine- and
+// Bun-version-dependent.
+//
+//   bun examples/twin-slot/src/bench.ts
+//
+// What dominates: wasmoon marshals a fresh Lua table across the JS<->Lua bridge
+// on every call; the WASM kernel just writes MessagePack into linear memory. The
+// RNG itself is a rounding error either way (try cryptoRng - the ratio barely
+// moves), so we time the runtime with a cheap rng.
+
+import { resolve } from "node:path";
+import { loadLuaMath, loadWasmMath } from "../../../packages/core/src/index.js";
+import type { SimpleMath } from "../../../packages/contract/src/index.js";
+
+const ctx = { mode: "default" } as const;
+const here = import.meta.dir;
+// cheap, varying DEMO-only rng so we measure the runtime, not the RNG.
+const makeCheap = (): (() => number) => { let x = 0.123; return () => { x = (x + 0.6180339887498949) % 1; return x; }; };
+
+function bench(fn: () => unknown, n: number, reps = 7): number {
+  for (let i = 0; i < (n >> 2); i++) fn(); // warm up
+  let best = Infinity;
+  for (let r = 0; r < reps; r++) {
+    const t = performance.now();
+    for (let i = 0; i < n; i++) fn();
+    best = Math.min(best, performance.now() - t);
+  }
+  return (best / n) * 1e6; // ns per call
+}
+
+const luaOn = (await loadLuaMath(resolve(here, "../maths/slot.lua"), { rng: makeCheap() })) as SimpleMath;
+const luaOff = (await loadLuaMath(resolve(here, "../maths/slot.lua"), { rng: makeCheap(), timeoutMs: 0 })) as SimpleMath;
+const wasm = (await loadWasmMath(resolve(here, "../maths/slot.wasm"), { rng: makeCheap() })) as SimpleMath;
+
+const N = 300_000;
+const a = bench(() => luaOn.play(undefined, ctx), N);
+const b = bench(() => luaOff.play(undefined, ctx), N);
+const c = bench(() => wasm.play(undefined, ctx), N);
+
+console.log(`twin-slot - per play() call (${N.toLocaleString()} calls x7, best rep)\n`);
+console.log(`  lua  (watchdog on, default):  ${a.toFixed(0).padStart(6)} ns`);
+console.log(`  lua  (watchdog off):          ${b.toFixed(0).padStart(6)} ns`);
+console.log(`  wasm (zig):                   ${c.toFixed(0).padStart(6)} ns`);
+console.log(`\n  -> wasm is ${(a / c).toFixed(1)}x faster than Lua (default), ${(b / c).toFixed(1)}x with the watchdog off`);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -39,7 +39,7 @@ one of three source forms - same contract, swappable by a manifest entry:
 | Loader | Source | Use case |
 |--------|--------|----------|
 | `loadLuaMath(path, opts?)` | `.lua` via wasmoon (Lua 5.4 -> WASM) | Default. Cheap to write, hot-reloadable. Per-call watchdog (`debug.sethook`). |
-| `loadWasmMath(path, opts?)` | `.wasm` kernel (typically **Zig** or Rust) | Production-grade, certification-friendly, ~15x faster than Lua. Simple or complex. |
+| `loadWasmMath(path, opts?)` | `.wasm` kernel (typically **Zig** or Rust) | Production-grade, certification-friendly, ~14x faster than Lua (measured - `examples/twin-slot/src/bench.ts`). Simple or complex. |
 | `createMathPool(opts)` | the same `.wasm` kernel, in a Worker pool | Off the I/O thread; **fails the round** closed on a per-call timeout. Worker-kill is best-effort/platform-dependent (see below). |
 
 ### Compiled (WASM / Zig) math

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -21,8 +21,9 @@ the same contract is enforced regardless.
 (`loadWasmMath`, both simple and complex math). A TS loader
 (`loadTsMath`) is a planned peer. All loaders return a
 `Promise<MathModule>` that the manifest's `math:` field accepts. A WASM
-kernel runs ~15x faster than the equivalent Lua math (measured, 1-draw
-distribution) with no per-draw boundary tax, stays sandboxed by
+kernel runs ~14x faster than the equivalent Lua math (measured on
+*identical* math - see `examples/twin-slot` / `examples/twin-gamble` and their
+`src/bench.ts`) with no per-draw boundary tax, stays sandboxed by
 construction, and ships as a hashable artifact for certification.
 
 **WASM watchdog caveat:** unlike the Lua loader, a running WASM call cannot be


### PR DESCRIPTION
## What

Closes the loop on the long-asserted **"~15× faster than Lua"** figure, which the
earlier perf-claims audit flagged as having *no committed benchmark*. Now that
`twin-slot` and `twin-gamble` run identical math in both runtimes, the gap is
directly measurable — so this pins it to a real number and ships the reproducer.

**Adds**
- `examples/twin-slot/src/bench.ts` — per `play()` call, Lua vs Zig/WASM
- `examples/twin-gamble/src/bench.ts` — per full round (open + 3 gambles + close)

**Measured** (Bun 1.3.11, macOS arm64, best-of-7):

| pair | wasm | lua (default) | ratio |
|---|---:|---:|---:|
| twin-slot (1 draw) | ~1.2 µs | ~17 µs | **~14.2×** (13.4× watchdog off) |
| twin-gamble (full round) | ~6.3 µs | ~94 µs | **~14.9×** (13.7× watchdog off) |

The gap is **wasmoon's per-call JS↔Lua table marshalling**, not the RNG —
`cryptoRng` barely moves the ratio (the system CSPRNG is ~15 ns/draw, a rounding
error against Lua's ~17 µs/call bridge). The Lua `debug.sethook` watchdog costs a
few %.

**Corrects** `~15×` → `~14×` and cites the reproducer in:
- `specs/03-math-runtime.md`
- `packages/core/README.md`
- `apps/site/src/pages/math.astro`
- `.changeset/wasm-math.md`

## Notes
- No package `src/` touched → no changeset/release impact (the changeset edit is
  just correcting the figure in an already-staged entry).
- The ratio is a per-machine measurement; the committed benches let anyone
  reproduce it on their own hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
