### PR TITLE
chore: repository.url git+ form (publint clean for release)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git"
+    "url": "git+https://github.com/open-rgs/open-rgs.git"
   },
   "homepage": "https://open-rgs.dev",
   "workspaces": [

--- a/packages/adapter-kit/package.json
+++ b/packages/adapter-kit/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/adapter-kit"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/adapter-test-kit/package.json
+++ b/packages/adapter-test-kit/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/adapter-test-kit"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/client"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/contract"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/core"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/log/package.json
+++ b/packages/log/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/log"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/platform-mock/package.json
+++ b/packages/platform-mock/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/platform-mock"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",

--- a/packages/simulator/package.json
+++ b/packages/simulator/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/open-rgs/open-rgs.git",
+    "url": "git+https://github.com/open-rgs/open-rgs.git",
     "directory": "packages/simulator"
   },
   "homepage": "https://github.com/open-rgs/open-rgs",


### PR DESCRIPTION
Pre-release polish: `publint` flagged `repository.url` as a *suggestion* (use the `git+https://…git` form). Applied across the root + all 8 packages.

After: `bunx publint packages/core` and `packages/simulator` both report **All good!** (was the lone suggestion).

Metadata only — no code, no behavior, no version bump; `changeset-check` does not apply (no `packages/*/src` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)