### PR TITLE
fix(core): serialize guarded Lua invocations per VM

### DIFF
--- a/.changeset/lua-vm-invoke-serialization.md
+++ b/.changeset/lua-vm-invoke-serialization.md
@@ -1,0 +1,19 @@
+---
+"@open-rgs/core": patch
+---
+
+Fix two defects in the guarded (watchdog) Lua invocation path that killed a
+game-server process under real traffic. (1) STACK LEAK: wasmoon's
+callByteCode moves a chunk's return value onto the global Lua stack to read
+it but never pops it - every guarded call leaked one slot, and after ~40
+calls the VM faulted (WASM "Out of bounds memory access") and all later
+interop pushes failed ("metatable not found: js_proxy"); a pod died after a
+few dozen spins, sequentially, no concurrency needed. The loader now
+restores a stack watermark after every guarded chunk. (2) INTERLEAVING: the
+guarded path writes call args as VM globals and then runs an async doString
+chunk; the orchestrator's per-session lock only serializes one session, so
+concurrent sessions could interleave arg-writes into an in-flight chunk.
+Guarded invocations now take a per-VM turnstile. Money was never at risk -
+failed calls fail closed before any wallet RPC - but a production pod shed
+most of its traffic as INTERNAL_ERROR. The watchdog-off direct path
+(trusted bulk simulation) is unchanged.

--- a/packages/core/src/lua-math.ts
+++ b/packages/core/src/lua-math.ts
@@ -130,8 +130,7 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
   // math is CALLED FROM a doString chunk (the JS function bridge runs on a
   // context where the hook does not carry), so when the watchdog is on we
   // invoke math through `__open_rgs_invoke` inside a doString and read the
-  // result back as that chunk's return value  - race-free because wasmoon
-  // executes the chunk synchronously (no await between arg-set and the call).
+  // result back as that chunk's return value.
   const timeoutMs = opts?.timeoutMs ?? 1000;
   const watchdog = timeoutMs > 0;
   let deadline = Infinity;
@@ -140,21 +139,57 @@ export async function loadLuaMath(path: string, opts?: LoadLuaMathOptions): Prom
       ? new RGSError("MATH_TIMEOUT", `math exceeded its ${timeoutMs}ms execution budget`)
       : null;
 
+  // One math = one VM, but a server runs MANY sessions against it, and the
+  // orchestrator's per-session lock only serializes operations of a SINGLE
+  // session. The guarded path below is two steps (write args as VM globals,
+  // then run an async doString chunk) - if a second call's arg-writes land
+  // while a first chunk is still in flight, wasmoon's interop state corrupts
+  // ("metatable not found: js_proxy"; under heavier overlap the WASM heap
+  // itself faults). So guarded invocations take a per-VM turnstile: each
+  // call's arg-set + chunk run as one unit, queued behind the previous one.
+  // Calls are micro/millisecond-scale and MATH_TIMEOUT aborts a runaway
+  // chunk, so the queue cannot wedge.
+  let vmTurn: Promise<unknown> = Promise.resolve();
+
+  /** wasmoon's callByteCode (the engine of every doString) moves the chunk's
+   *  return value onto the GLOBAL stack to read it but never pops it  - each
+   *  guarded call leaks one global-stack slot, and once Lua's unchecked
+   *  headroom (~40 slots) runs out the VM faults ("Out of bounds memory
+   *  access") and interop metatable lookups fail from then on ("metatable
+   *  not found: js_proxy"). Restore the stack to a pre-call watermark after
+   *  every guarded chunk; we hold the per-VM turnstile, so nothing else
+   *  owns the slots above it. */
+  function restoreStack(base: number): void {
+    for (let top = lua.global.getTop(); top > base; top = lua.global.getTop()) {
+      lua.global.remove(top);
+    }
+  }
+
   /** Invoke a math entry point. With the watchdog off, call it directly
-   *  (synchronous, zero overhead  - for trusted bulk simulation). With it on,
-   *  route through the guarded doString so the abort hook applies. */
+   *  (synchronous, zero overhead  - for trusted bulk simulation; a sync call
+   *  runs to completion on the single JS thread, so it cannot interleave).
+   *  With it on, route through the guarded doString so the abort hook
+   *  applies, serialized per VM with the stack watermark restored. */
   function invoke(fnName: string, args: unknown[]): unknown | Promise<unknown> {
     if (!watchdog) {
       return (api as Record<string, (...a: unknown[]) => unknown>)[fnName]!(...args);
     }
-    deadline = performance.now() + timeoutMs;
-    for (let i = 0; i < args.length; i++) lua.global.set(`__open_rgs_arg${i + 1}`, args[i]);
-    const refs = args.map((_, i) => `__open_rgs_arg${i + 1}`).join(", ");
-    const code = `return __open_rgs_invoke(__open_rgs_math.${fnName}${refs ? ", " + refs : ""})`;
-    return lua.doString(code).then(
-      (raw) => { deadline = Infinity; return raw; },
-      (e) => { deadline = Infinity; throw asTimeout(e) ?? e; },
-    );
+    const run = (): Promise<unknown> => {
+      deadline = performance.now() + timeoutMs;
+      for (let i = 0; i < args.length; i++) lua.global.set(`__open_rgs_arg${i + 1}`, args[i]);
+      const refs = args.map((_, i) => `__open_rgs_arg${i + 1}`).join(", ");
+      const code = `return __open_rgs_invoke(__open_rgs_math.${fnName}${refs ? ", " + refs : ""})`;
+      const base = lua.global.getTop();
+      return lua.doString(code).then(
+        (raw) => { restoreStack(base); deadline = Infinity; return raw; },
+        (e) => { restoreStack(base); deadline = Infinity; throw asTimeout(e) ?? e; },
+      );
+    };
+    const result = vmTurn.then(run, run);
+    // The chain must survive a rejected call (same idiom as the
+    // orchestrator's per-session lock): swallow, never reuse.
+    vmTurn = result.then(() => undefined, () => undefined);
+    return result;
   }
 
   /** Apply a Lua->TS adapter to an invoke() result, awaiting if guarded. */

--- a/packages/core/test/fixtures/burn.lua
+++ b/packages/core/test/fixtures/burn.lua
@@ -1,0 +1,23 @@
+-- Simple math with a deterministic busy loop. Exists for the VM endurance +
+-- serialization tests: real maths spend real time inside the VM (which is
+-- what makes concurrent guarded invocations overlap), and the loop runs
+-- >100k Lua instructions so the watchdog's count hook actually fires during
+-- the call - the production shape. Still far under any watchdog budget.
+return {
+  kind = "simple",
+  name = "test-burn",
+  version = "1.0.0",
+  rtp = 1.0,
+  play = function(prev, ctx)
+    local x = 1
+    for _ = 1, 50000 do
+      x = (x * 31 + 7) % 1000003
+    end
+    local r = host.rng_next()
+    return {
+      multiplier = (r < 0.5) and 2 or 0,
+      ops = { { kind = "result", burn = x } },
+      type = (r < 0.5) and "win" or "loss",
+    }
+  end,
+}

--- a/packages/core/test/lua-concurrency.test.ts
+++ b/packages/core/test/lua-concurrency.test.ts
@@ -1,0 +1,81 @@
+// One math = one Lua VM, and a server runs that VM for the lifetime of the
+// process across MANY sessions. Two defects used to kill it in production
+// shapes that the orchestrator-level tests (which mostly drive TS test
+// maths) never exercised:
+//
+// 1. LEAK: wasmoon's callByteCode moves a chunk's return value onto the
+//    global stack to read it but never pops it. Every guarded call leaked
+//    one global-stack slot, and once Lua's unchecked headroom (~40 slots)
+//    ran out the VM faulted ("Out of bounds memory access") and every
+//    later interop push failed ("metatable not found: js_proxy"). A pod
+//    died after ~40 spins - sequentially, no concurrency needed. The
+//    loader now restores a stack watermark after every guarded chunk.
+//
+// 2. INTERLEAVING: the guarded path is two steps (write args as VM
+//    globals, then run an async doString chunk). The orchestrator's
+//    per-session lock serializes ONE session; concurrent sessions could
+//    interleave caller B's arg-writes into caller A's in-flight chunk.
+//    Guarded invocations now take a per-VM turnstile.
+//
+// Money was never at risk (failed calls fail closed before any wallet
+// RPC), but a production pod would shed most traffic as INTERNAL_ERROR.
+// These tests drive the public math surface exactly like the orchestrator
+// does and require every call to succeed.
+
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadLuaMath } from "../src/lua-math.js";
+import type { SimpleMath } from "@open-rgs/contract";
+
+const here = fileURLToPath(new URL(".", import.meta.url));
+const BURN = resolve(here, "fixtures/burn.lua");
+const SIMPLE = resolve(here, "fixtures/simple.lua");
+
+describe("guarded Lua invocation endurance (stack watermark)", () => {
+  test("300 sequential heavy play() calls - far past the ~40-call cliff", async () => {
+    // burn.lua runs >100k Lua instructions per call, so the watchdog hook
+    // actually fires - this is the production shape, not a toy.
+    const m = (await loadLuaMath(BURN, { rng: () => 0.25, timeoutMs: 1000 })) as SimpleMath;
+    for (let i = 0; i < 300; i++) {
+      const out = await m.play(undefined, { mode: "default" });
+      expect(out.multiplier).toBe(2);
+    }
+  });
+
+  test("MATH_TIMEOUT aborts do not poison later calls", async () => {
+    const LOOP = resolve(here, "fixtures/loop.lua");
+    const m = (await loadLuaMath(LOOP, { rng: () => 0.5, timeoutMs: 100 })) as SimpleMath;
+    await expect(Promise.resolve(m.play(undefined, { mode: "default" }))).rejects.toThrow();
+    // The VM must still be intact for a different math? No - same VM, same
+    // math: a second runaway call still times out cleanly (stack restored,
+    // turnstile advanced), rather than corrupting.
+    await expect(Promise.resolve(m.play(undefined, { mode: "default" }))).rejects.toThrow();
+  });
+});
+
+describe("guarded Lua invocations serialize per VM", () => {
+  test("32 concurrent play() calls (different sessions) all succeed", async () => {
+    const m = (await loadLuaMath(BURN, { rng: () => 0.25, timeoutMs: 1000 })) as SimpleMath;
+    const calls = Array.from({ length: 32 }, () =>
+      Promise.resolve(m.play(undefined, { mode: "default" })),
+    );
+    const results = await Promise.allSettled(calls);
+    const failed = results.filter((r) => r.status === "rejected");
+    expect(failed.map((f) => String((f as PromiseRejectedResult).reason))).toEqual([]);
+    for (const r of results) {
+      expect((r as PromiseFulfilledResult<{ multiplier: number }>).value.multiplier).toBe(2);
+    }
+  });
+
+  test("interleaved waves keep returning correct results", async () => {
+    const m = (await loadLuaMath(SIMPLE, { rng: () => 0.75, timeoutMs: 1000 })) as SimpleMath;
+    for (let wave = 0; wave < 5; wave++) {
+      const calls = Array.from({ length: 16 }, () =>
+        Promise.resolve(m.play(undefined, { mode: "default" })),
+      );
+      const results = await Promise.all(calls);
+      for (const r of results) expect(r.multiplier).toBe(0); // rng 0.75 -> loss
+    }
+  });
+});

--- a/specs/03-math-runtime.md
+++ b/specs/03-math-runtime.md
@@ -108,6 +108,24 @@ The loader:
   `MATH_TIMEOUT` once it passes the deadline. The hook, its `sethook`
   handle, and the deadline check are captured as upvalues then hidden, and
   the hook survives `debug = nil`, so sandboxed math cannot disable it.
+- Serializes guarded invocations per VM. One math = one VM, and the
+  orchestrator's per-session lock only serializes a single session  - two
+  different sessions spin concurrently against the same VM. The guarded
+  path is two steps (write call args as VM globals, run an async `doString`
+  chunk), so without a turnstile a second call's arg-writes land while a
+  first chunk is in flight and the interop state corrupts. Guarded calls
+  therefore queue per VM: arg-set + chunk execute as one unit. Calls are
+  micro/millisecond-scale and `MATH_TIMEOUT` aborts a runaway chunk, so the
+  queue cannot wedge. The watchdog-off direct path stays unqueued  - a
+  synchronous call runs to completion on the single JS thread and cannot
+  interleave.
+- Restores a global-stack watermark after every guarded chunk. wasmoon's
+  `callByteCode` moves a chunk's return value onto the global Lua stack to
+  read it but never pops it; left alone, each guarded call leaks one slot
+  and the VM faults once the unchecked headroom (~40 slots) runs out  - a
+  process would die after a few dozen spins. The loader records the stack
+  top before each guarded call and removes anything above it afterwards,
+  inside the same per-VM turn.
 
 ## WASM runtime details (planned)
 


### PR DESCRIPTION
## Finding

Discovered while load-testing a multi-replica deployment locally: under 8 concurrent sessions on a 2-replica fleet, **~80% of spins failed with INTERNAL_ERROR**. Root-causing produced TWO defects in the guarded (watchdog) Lua invocation path - both invisible to the existing suite, which mostly drives TS test maths.

## Defect 1 - stack leak (the killer)

wasmoon's `callByteCode` moves a chunk's return value onto the **global Lua stack** to read it, but never pops it (`finally` removes only the thread). Every guarded call leaks one slot; once Lua's unchecked headroom (~40 slots) runs out, the VM faults (WASM `Out of bounds memory access`) and every later interop push fails with `metatable not found: js_proxy`.

**A pod died after a few dozen spins - sequentially. No concurrency required.** Probe: 50 sequential `play()` calls → 41 ok, 9 fail; with the fix → 1000/1000 ok.

Fix: record the global-stack top before each guarded call, remove everything above it afterwards, inside the same per-VM turn.

## Defect 2 - cross-session interleaving

The guarded path is two steps (write args as VM globals → run an async `doString` chunk). The orchestrator's per-session lock serializes ONE session; two sessions on the same process could interleave arg-writes into an in-flight chunk. Guarded invocations now take a per-VM turnstile (the orchestrator's own swallow-and-chain idiom). `MATH_TIMEOUT` still aborts runaway chunks, so the queue cannot wedge.

## Money safety

Never at risk: every failed call failed closed before any wallet RPC - verified externally with a ledger-conservation harness (every wallet balance matched an independent running model across all failure runs). This is a throughput/availability bug, not a money bug - but it contradicts spec 06's targets the moment a pod serves real traffic.

## Proof

- `packages/core/test/lua-concurrency.test.ts`: **300 sequential heavy calls** (past the old ~40-call cliff, watchdog hook firing - fails pre-fix at call ~41 with the exact production error), timeout-abort non-poisoning, 32 concurrent calls, interleaved waves.
- `burn.lua` fixture runs >100k Lua instructions/call so the count hook actually fires - the production shape.
- Full suite 286 pass / 0 fail; typecheck clean.
- Spec: `03-math-runtime.md` gains the per-VM serialization + stack-watermark rules (spec+code together per CLAUDE.md).
- Watchdog-off direct path (trusted bulk simulation) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)