### PR TITLE
feat(core): self-generated instance identity + platform SLA metrics

### DIFF
--- a/.changeset/instance-identity-platform-sla.md
+++ b/.changeset/instance-identity-platform-sla.md
@@ -1,0 +1,15 @@
+---
+"@open-rgs/core": minor
+---
+
+Instance identity + platform SLA metrics. Every server now resolves a unique
+instance id at boot (config `instanceId` > `OPEN_RGS_INSTANCE_ID` env > a
+self-generated `rgs-<8 hex>`), surfaced as `rgs_build_info{instance_id,...}`
+on /admin/metrics, `instance_id` in /healthz, and `service.instance.id` on
+every log line - per-instance metrics, logs, and health correlate on one key.
+New platform-adapter SLA series: `rgs_platform_connected` (gauge),
+`rgs_platform_connection_transitions_total{direction}` (flap counter), and
+`rgs_platform_last_ok_timestamp_seconds` (last successful wallet RPC - alert
+on its age to catch a connected-but-silent platform). Note for bring-your-own
+`RgsMetrics` implementations: the interface gains four required members
+(`buildInfo`, `platformConnected`, `platformTransitions`, `platformLastOk`).

--- a/packages/core/src/admin.ts
+++ b/packages/core/src/admin.ts
@@ -61,6 +61,11 @@ export interface AdminConfig {
    *  as game_version in /healthz. Default "unknown"  - callers should
    *  pass their package.json version through createServer({ version }). */
   gameVersion?: string;
+  /** Unique id of this running instance (createServer resolves it:
+   *  config > OPEN_RGS_INSTANCE_ID env > self-generated). Surfaced as
+   *  instance_id in /healthz so health checks, metrics (`rgs_build_info`)
+   *  and logs (`service.instance.id`) correlate on one key. */
+  instanceId?: string;
   /** Bearer token required on /admin/* and the detailed /healthz. When set,
    *  requests must send `Authorization: Bearer <authToken>` (constant-time
    *  compared). createServer reads it from `adminToken` or the
@@ -240,6 +245,7 @@ export function createAdminHandler(cfg: AdminConfig): AdminHandler {
     }
     return {
       status:               cfg.platform.isHealthy ? "healthy" : "reconnecting",
+      instance_id:          cfg.instanceId ?? "unknown",
       core_version:         CORE_VERSION,
       game_version:         cfg.gameVersion ?? "unknown",
       game:                 cfg.manifest.id,

--- a/packages/core/src/log.ts
+++ b/packages/core/src/log.ts
@@ -15,12 +15,15 @@ let inner: Logger = createLogger({
 
 interface CoreLog extends Logger {
   /** Re-init the singleton with service identity. Called once from
-   *  createServer(). Safe to call before any log lines are emitted. */
-  init(name: string, version: string, isDev: boolean): void;
+   *  createServer(). Safe to call before any log lines are emitted.
+   *  `instanceId` (when given) is bound onto EVERY line as
+   *  `service.instance.id`, so logs correlate with the `instance_id`
+   *  metric label and /healthz. */
+  init(name: string, version: string, isDev: boolean, instanceId?: string): void;
 }
 
 export const log: CoreLog = {
-  init(name: string, version: string, isDev: boolean) {
+  init(name: string, version: string, isDev: boolean, instanceId?: string) {
     const env = process.env["LOG_LEVEL"];
     const minLevel: LogLevel | undefined =
       env === "debug" || env === "info" || env === "warn" || env === "error" || env === "fatal"
@@ -32,6 +35,9 @@ export const log: CoreLog = {
       environment: isDev ? "development" : "production",
       minLevel,
     });
+    // child() shares the ring buffer and level with its parent - swapping
+    // the singleton for a bound child keeps getRecent()/setLevel() intact.
+    if (instanceId) inner = inner.child({ "service.instance.id": instanceId });
   },
   debug: (m, f) => inner.debug(m, f),
   info:  (m, f) => inner.info(m, f),

--- a/packages/core/src/metrics-rgs.ts
+++ b/packages/core/src/metrics-rgs.ts
@@ -25,6 +25,19 @@ export interface RgsMetrics {
   wsConnections: Gauge;
   /** Lua math execution duration, per call (play / open / step / close). */
   mathDuration: Histogram;      // {kind, mode, phase}
+  /** Constant 1 carrying this instance's identity as labels  - the
+   *  node_exporter build_info pattern. Dashboards join on instance_id;
+   *  a fresh series appearing = an instance (re)started. */
+  buildInfo: Gauge;             // {instance_id, game, core_version, game_version}
+  /** 1 while the platform adapter reports healthy, else 0. The
+   *  "is the wallet there at all" SLA gauge. */
+  platformConnected: Gauge;
+  /** Connection state transitions  - flap visibility. */
+  platformTransitions: Counter; // {direction: up|down}
+  /** Unix seconds of the last SUCCESSFUL platform RPC. Alert on
+   *  `time() - rgs_platform_last_ok_timestamp_seconds` to catch a wallet
+   *  that is "connected" but not answering. */
+  platformLastOk: Gauge;
 }
 
 export function createRgsMetrics(): RgsMetrics {
@@ -66,6 +79,24 @@ export function createRgsMetrics(): RgsMetrics {
       "Lua math execution duration, per call phase.",
       undefined,
       ["kind", "mode", "phase"],
+    ),
+    buildInfo: registry.gauge(
+      "rgs_build_info",
+      "Constant 1; labels carry instance identity (instance_id, game, versions).",
+      ["instance_id", "game", "core_version", "game_version"],
+    ),
+    platformConnected: registry.gauge(
+      "rgs_platform_connected",
+      "1 while the platform adapter reports healthy, else 0.",
+    ),
+    platformTransitions: registry.counter(
+      "rgs_platform_connection_transitions_total",
+      "Platform connection state transitions, by direction.",
+      ["direction"],
+    ),
+    platformLastOk: registry.gauge(
+      "rgs_platform_last_ok_timestamp_seconds",
+      "Unix time of the last successful platform RPC.",
     ),
   };
 }

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -90,6 +90,9 @@ async function timedPlatformCall<T>(
   try {
     const out = await fn();
     metrics.platformDuration.observe((performance.now() - start) / 1000, { method });
+    // SLA freshness: the wallet answered. `time() - this` going large while
+    // rgs_platform_connected is still 1 = connected-but-silent wallet.
+    metrics.platformLastOk.set(Date.now() / 1000);
     return out;
   } catch (e) {
     metrics.platformDuration.observe((performance.now() - start) / 1000, { method });

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -29,6 +29,14 @@ export interface ServerConfig {
    *  /healthz as game_version. Pass your package.json version. Default
    *  "unknown"  - pass it so /healthz doesn't lie about what's deployed. */
   version?: string;
+  /** Unique id of THIS running instance. Every instance generates its own
+   *  at boot (`rgs-<8 hex>`); the `OPEN_RGS_INSTANCE_ID` env var overrides
+   *  the generation (e.g. the pod name via the k8s downward API), and an
+   *  explicit value here wins over both. Surfaced as the `instance_id`
+   *  label on `rgs_build_info`, as `instance_id` in /healthz, and as
+   *  `service.instance.id` on every log line  - so per-instance metrics,
+   *  logs, and health all correlate on one key. */
+  instanceId?: string;
   /** HTTP admin port. Default: same as transport port (single-port mode,
    *  routes mounted under /admin/* + /livez + /readyz + /healthz). Set
    *  to a distinct port to spin up a separate admin Bun.serve  - ideally on
@@ -88,6 +96,10 @@ export interface ServerHandle {
 export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
   const isDev       = cfg.isDev ?? process.env["NODE_ENV"] !== "production";
   const gameVersion = cfg.version ?? "unknown";
+  // Self-generated per-boot identity; env (k8s pod name) or config override.
+  const instanceId  = cfg.instanceId
+    ?? process.env["OPEN_RGS_INSTANCE_ID"]
+    ?? `rgs-${crypto.randomUUID().slice(0, 8)}`;
 
   // Forced-outcome cheats: fail closed. Require an explicit opt-in AND a
   // non-production NODE_ENV. The old gate keyed off `isDev`, which defaults
@@ -99,7 +111,7 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
   const cheatsEnabled = !isProduction
     && (cfg.enableCheats ?? process.env["OPEN_RGS_ENABLE_CHEATS"] === "1");
 
-  log.init(`open-rgs-${cfg.manifest.id}`, gameVersion, isDev);
+  log.init(`open-rgs-${cfg.manifest.id}`, gameVersion, isDev, instanceId);
   log.info("RGS starting", {
     "event.category": "process",
     "event.action":   "startup",
@@ -169,6 +181,33 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
 
   const metrics = cfg.metrics ?? createRgsMetrics();
 
+  // Identity series (constant 1) - dashboards join per-instance panels on
+  // instance_id; a new series appearing marks an instance (re)start.
+  metrics.buildInfo.set(1, {
+    instance_id:  instanceId,
+    game:         cfg.manifest.id,
+    core_version: CORE_VERSION,
+    game_version: gameVersion,
+  });
+
+  // Platform SLA watcher: connected gauge + flap counter, sampled every
+  // second off the adapter's own isHealthy. platformLastOk is stamped by
+  // the orchestrator on every successful RPC.
+  let platformWasHealthy = cfg.platform.isHealthy;
+  metrics.platformConnected.set(platformWasHealthy ? 1 : 0);
+  const platformWatch = setInterval(() => {
+    const healthy = cfg.platform.isHealthy;
+    if (healthy !== platformWasHealthy) {
+      metrics.platformTransitions.inc(1, { direction: healthy ? "up" : "down" });
+      log.info(`Platform connection ${healthy ? "restored" : "lost"}`, {
+        "event.category": "platform",
+        "event.action":   healthy ? "platform_up" : "platform_down",
+      });
+      platformWasHealthy = healthy;
+    }
+    metrics.platformConnected.set(healthy ? 1 : 0);
+  }, 1_000);
+
   if (cheatsEnabled) {
     log.warn("CHEATS ENABLED  - forced-outcome hints from params.cheat are active. " +
       "This must NEVER be on for real-money play.", {
@@ -225,6 +264,7 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
       orchestrator,
       metrics,
       gameVersion,
+      instanceId,
       ...adminAuth,
     });
     if (typeof (cfg.transport as { setExtraFetch?: unknown }).setExtraFetch === "function") {
@@ -247,6 +287,7 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
       orchestrator,
       metrics,
       gameVersion,
+      instanceId,
       ...adminAuth,
     });
   }
@@ -271,6 +312,7 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
       "event.action":   "shutdown_start",
       "drain.ms":       drainMs,
     });
+    clearInterval(platformWatch);
     try {
       // 1. Stop accepting new connections + drain in-flight requests.
       const transportStop = cfg.transport.stop({ drainMs });

--- a/packages/core/test/metrics.test.ts
+++ b/packages/core/test/metrics.test.ts
@@ -84,3 +84,21 @@ describe("@open-rgs/core metrics", () => {
     expect(() => r.counter("dupe", "second")).toThrow();
   });
 });
+
+describe("instance identity + platform SLA series", () => {
+  test("createRgsMetrics registers build_info and platform SLA metrics", async () => {
+    const { createRgsMetrics } = await import("../src/metrics-rgs.js");
+    const m = createRgsMetrics();
+    m.buildInfo.set(1, {
+      instance_id: "rgs-test1234", game: "g", core_version: "x", game_version: "y",
+    });
+    m.platformConnected.set(1);
+    m.platformTransitions.inc(1, { direction: "down" });
+    m.platformLastOk.set(1234567890);
+    const text = m.registry.expose();
+    expect(text).toContain('rgs_build_info{instance_id="rgs-test1234",game="g",core_version="x",game_version="y"} 1');
+    expect(text).toContain("rgs_platform_connected 1");
+    expect(text).toContain('rgs_platform_connection_transitions_total{direction="down"} 1');
+    expect(text).toContain("rgs_platform_last_ok_timestamp_seconds 1234567890");
+  });
+});

--- a/specs/07-deployment.md
+++ b/specs/07-deployment.md
@@ -185,6 +185,38 @@ Notes:
 - Sticky sessions are nice-to-have (faster reconnect -> in-memory
   session cache hit) but NOT required for correctness.
 
+### Instance identity & metrics scraping
+
+Every server resolves a unique **instance id** at boot: explicit
+`createServer({ instanceId })` > `OPEN_RGS_INSTANCE_ID` env > a
+self-generated `rgs-<8 hex>`. In K8s, pass the pod name via the downward
+API so the id matches `kubectl` output:
+
+```yaml
+env:
+  - name: OPEN_RGS_INSTANCE_ID
+    valueFrom: { fieldRef: { fieldPath: metadata.name } }
+```
+
+The id is surfaced in three places that correlate one-to-one:
+`rgs_build_info{instance_id,...}` on `/admin/metrics` (the node_exporter
+build_info pattern  - a fresh series appearing = an instance (re)started),
+`instance_id` in `/healthz`, and `service.instance.id` on every log line.
+
+`/admin/metrics` serves Prometheus exposition behind the admin bearer
+token (`authorization.credentials` in the scrape config). Metrics are
+pod-local  - scrape every pod and aggregate in dashboards. Alongside the
+round/math/session series, the platform-adapter SLA series answer "is the
+wallet there, and is it answering":
+
+| Series | Meaning |
+|---|---|
+| `rgs_platform_connected` | 1 while the adapter reports healthy |
+| `rgs_platform_connection_transitions_total{direction}` | flap counter |
+| `rgs_platform_last_ok_timestamp_seconds` | last SUCCESSFUL RPC; alert on `time() - x > 30` to catch a connected-but-silent wallet |
+| `rgs_platform_call_duration_seconds{method}` | RPC latency histogram |
+| `rgs_platform_call_errors_total{method,reason}` | errors, reason includes `timeout` / `disconnected` |
+
 ## Platform adapter packaging
 
 Three patterns:


### PR DESCRIPTION
Every server instance now resolves a unique id at boot - self-generated
(`rgs-<8 hex>`) by default, overridable via OPEN_RGS_INSTANCE_ID (k8s
downward-API pod name) or createServer({ instanceId }). Surfaced in three
places that correlate one-to-one:

- rgs_build_info{instance_id, game, core_version, game_version} = 1
  (node_exporter pattern; a fresh series appearing = instance (re)start)
- instance_id in /healthz
- service.instance.id bound onto EVERY log line (logger child binding;
  ring buffer + level sharing keep getRecent/setLevel intact)

New platform-adapter SLA series, metered in core so ANY adapter gets them
for free:

- rgs_platform_connected            gauge, sampled 1s off isHealthy
- rgs_platform_connection_transitions_total{direction}  flap counter
- rgs_platform_last_ok_timestamp_seconds  stamped on every successful
  platform RPC; alert on its age to catch a connected-but-silent wallet

Watcher interval cleared on stop(). Spec 07 gains an "Instance identity &
metrics scraping" section (downward-API recipe, bearer-token scrape_config
note, SLA series table). BYO-RgsMetrics note: interface gains four
required members (changeset: minor).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
