### PR TITLE
fix(core): baseline platformLastOk at boot - idle instance read as silent-since-epoch

### DIFF
--- a/.changeset/platform-last-ok-boot-baseline.md
+++ b/.changeset/platform-last-ok-boot-baseline.md
@@ -1,0 +1,8 @@
+---
+"@open-rgs/core": patch
+---
+
+Baseline `rgs_platform_last_ok_timestamp_seconds` to boot time so an
+instance that has not yet served a round reads as "silent since boot"
+rather than "silent since the Unix epoch" in `time() - x` alert
+expressions.

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -192,7 +192,10 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
 
   // Platform SLA watcher: connected gauge + flap counter, sampled every
   // second off the adapter's own isHealthy. platformLastOk is stamped by
-  // the orchestrator on every successful RPC.
+  // the orchestrator on every successful RPC - baseline it to boot time so
+  // an instance that hasn't served a round yet reads as "silent since
+  // boot", not "silent since the epoch".
+  metrics.platformLastOk.set(Date.now() / 1000);
   let platformWasHealthy = cfg.platform.isHealthy;
   metrics.platformConnected.set(platformWasHealthy ? 1 : 0);
   const platformWatch = setInterval(() => {


### PR DESCRIPTION
An instance that had not yet served a round left the gauge at 0, so
time() - rgs_platform_last_ok_timestamp_seconds rendered as the full
Unix epoch on dashboards/alerts (caught live on the testbed's fleet
dashboard when an autoscaler-spawned replica had no traffic yet).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
