### PR TITLE
feat(core): financial metrics aggregated in-process - bets/wins counters, derived GGR/RTP, snapshot log

### DIFF
--- a/.changeset/financial-metrics.md
+++ b/.changeset/financial-metrics.md
@@ -1,0 +1,16 @@
+---
+"@open-rgs/core": minor
+---
+
+Financial metrics, aggregated in-process. New counters in the currency's
+minor unit - `rgs_bets_minor_total{currency,mode,funding}` (funding=real is
+the actual debit, funding=promo the notional free-round bet) and
+`rgs_wins_minor_total{currency,mode,funding}` - plus `rgs_declared_rtp{mode}`
+as the theoretical target line. GGR and live RTP are derived at query time
+from the counters (the only way ratios aggregate correctly across a fleet).
+Each instance also emits a `financial_snapshot` log line on an interval
+(`financialLogIntervalMs`, default 10 min, 0 disables) with lifetime
+per-currency bets/wins/GGR/RTP read straight from the in-memory counters.
+`Counter` gains a `snapshot()` read-back method; bring-your-own RgsMetrics
+implementations gain three required members (`betsMinor`, `winsMinor`,
+`declaredRtp`).

--- a/packages/core/src/metrics-rgs.ts
+++ b/packages/core/src/metrics-rgs.ts
@@ -38,6 +38,21 @@ export interface RgsMetrics {
    *  `time() - rgs_platform_last_ok_timestamp_seconds` to catch a wallet
    *  that is "connected" but not answering. */
   platformLastOk: Gauge;
+  /** Stakes, in the currency's minor unit. funding="real" counts the actual
+   *  debit (the effective cost incl. price/stake multipliers - fractional
+   *  ante costs allowed); funding="promo" counts the NOTIONAL bet of a
+   *  platform-funded free round (no player debit). Monotonic in-process
+   *  counters: GGR and RTP are DERIVED at query time, which is the only way
+   *  ratios aggregate correctly across a fleet -
+   *    GGR  = sum(rgs_bets_minor_total{funding="real"}) - sum(rgs_wins_minor_total)
+   *    RTP  = sum(increase(rgs_wins_minor_total[w])) / sum(increase(rgs_bets_minor_total[w])) */
+  betsMinor: Counter;           // {currency, mode, funding}
+  /** Wins credited, in the currency's minor unit, labelled by the funding
+   *  of the round that produced them. */
+  winsMinor: Counter;           // {currency, mode, funding}
+  /** Declared/theoretical RTP per mode - the target line dashboards draw
+   *  against live RTP. */
+  declaredRtp: Gauge;           // {mode}
 }
 
 export function createRgsMetrics(): RgsMetrics {
@@ -97,6 +112,21 @@ export function createRgsMetrics(): RgsMetrics {
     platformLastOk: registry.gauge(
       "rgs_platform_last_ok_timestamp_seconds",
       "Unix time of the last successful platform RPC.",
+    ),
+    betsMinor: registry.counter(
+      "rgs_bets_minor_total",
+      "Stakes in minor units. funding=real is the actual debit; funding=promo the notional free-round bet.",
+      ["currency", "mode", "funding"],
+    ),
+    winsMinor: registry.counter(
+      "rgs_wins_minor_total",
+      "Wins credited in minor units, by the round's funding.",
+      ["currency", "mode", "funding"],
+    ),
+    declaredRtp: registry.gauge(
+      "rgs_declared_rtp",
+      "Declared/theoretical RTP per mode.",
+      ["mode"],
     ),
   };
 }

--- a/packages/core/src/metrics.ts
+++ b/packages/core/src/metrics.ts
@@ -7,6 +7,10 @@ export interface LabelMap { readonly [k: string]: string }
 
 export interface Counter {
   inc(value?: number, labels?: LabelMap): void;
+  /** Read back current values per label-set (key = `k=v,k=v` in label-name
+   *  order, "" for unlabelled). For in-process consumers - e.g. the
+   *  financial snapshot log - that want the totals without scraping. */
+  snapshot(): ReadonlyArray<{ labels: string; value: number }>;
 }
 export interface Gauge {
   set(value: number, labels?: LabelMap): void;
@@ -98,6 +102,10 @@ class CounterImpl implements Counter, Metric {
   inc(value = 1, labels?: LabelMap): void {
     const k = labelKey(labels, this.labelNames);
     this.values.set(k, (this.values.get(k) ?? 0) + value);
+  }
+
+  snapshot(): ReadonlyArray<{ labels: string; value: number }> {
+    return [...this.values].map(([labels, value]) => ({ labels, value }));
   }
 
   expose(): string {

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -102,6 +102,35 @@ async function timedPlatformCall<T>(
   }
 }
 
+/** Financial counters - in-process, monotonic, aggregated at query time.
+ *  funding="real" counts the actual debit (effectiveCost - may be fractional
+ *  for ante-style stakes); funding="promo" counts the NOTIONAL bet of a
+ *  platform-funded round (the player paid nothing). GGR/RTP are derived in
+ *  PromQL from these, never stored as ratios (ratios don't aggregate across
+ *  a fleet; counters do). */
+function incBets(
+  metrics: RgsMetrics | undefined,
+  s: { currency: string },
+  mode: string,
+  betInfo: { bet: number; effectiveCost: number; promoId?: string },
+): void {
+  if (!metrics) return;
+  const funding = betInfo.promoId ? "promo" : "real";
+  const amount = betInfo.promoId ? betInfo.bet : betInfo.effectiveCost;
+  metrics.betsMinor.inc(amount, { currency: s.currency, mode, funding });
+}
+
+function incWins(
+  metrics: RgsMetrics | undefined,
+  s: { currency: string },
+  mode: string,
+  win: number,
+  promoId: string | undefined,
+): void {
+  if (!metrics || win <= 0) return;
+  metrics.winsMinor.inc(win, { currency: s.currency, mode, funding: promoId ? "promo" : "real" });
+}
+
 function errorReason(msg: string): string {
   if (/InsufficientFunds/i.test(msg))         return "insufficient_funds";
   if (/SessionInvalid/i.test(msg))            return "session_invalid";
@@ -575,6 +604,8 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
 
     metrics?.roundTotal.inc(1, { kind: "simple", mode: requestedMode, type: cappedOutcome.type });
     metrics?.roundDuration.observe((performance.now() - roundStart) / 1000, { kind: "simple", mode: requestedMode });
+    incBets(metrics, s, requestedMode, betInfo);
+    incWins(metrics, s, requestedMode, win, betInfo.promoId);
 
     sessions.setBalance(s.sessionId, receipt.balance);
     sessions.setCarry(s.sessionId, cappedOutcome.carry, cappedOutcome.nextMode);
@@ -657,6 +688,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     }
 
     sessions.setBalance(s.sessionId, receipt.balance);
+    incBets(metrics, s, requestedMode, betInfo);
     s.openRound = {
       roundId: receipt.roundId,
       modeId: requestedMode,
@@ -667,6 +699,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       actionLog: [],
       opsLog: [...open.ops],
       openedAt: Date.now(),
+      ...(betInfo.promoId ? { promoId: betInfo.promoId } : {}),
     };
     recordAudit(mode, {
       sessionId: s.sessionId, roundId: receipt.roundId, kind: "open",
@@ -797,6 +830,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
 
     metrics?.roundTotal.inc(1, { kind: "complex", mode: open.modeId, type: cappedClose.type });
     metrics?.roundDuration.observe((Date.now() - roundStart) / 1000, { kind: "complex", mode: open.modeId });
+    incWins(metrics, s, open.modeId, win, open.promoId);
 
     sessions.setBalance(s.sessionId, receipt.balance);
     sessions.setCarry(s.sessionId, cappedClose.carry, cappedClose.nextMode);
@@ -953,6 +987,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
 
     metrics?.roundTotal.inc(1, { kind: "complex", mode: open.modeId, type: cappedClose.type });
     metrics?.roundDuration.observe((Date.now() - open.openedAt) / 1000, { kind: "complex", mode: open.modeId });
+    incWins(metrics, s, open.modeId, win, open.promoId);
 
     sessions.setBalance(s.sessionId, receipt.balance);
     sessions.setCarry(

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -79,6 +79,11 @@ export interface ServerConfig {
    *  block-and-fail a complex-round step if dropped (for jurisdictions that
    *  require a server-side action log). Default "best-effort". */
   auditMode?: "best-effort" | "mandatory";
+  /** Interval for the in-process financial snapshot log line (lifetime
+   *  bets/wins per currency + derived GGR and RTP, read straight from the
+   *  in-memory counters - no external aggregation involved). Default
+   *  600_000 (10 min). Set 0 to disable. */
+  financialLogIntervalMs?: number;
   /** Graceful-shutdown drain window in ms. Default 30_000. */
   shutdownDrainMs?: number;
   /** Install a SIGTERM handler that calls stop(). Default true; set
@@ -196,6 +201,51 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
   // an instance that hasn't served a round yet reads as "silent since
   // boot", not "silent since the epoch".
   metrics.platformLastOk.set(Date.now() / 1000);
+  // Declared RTP per mode - the target line dashboards draw live RTP against.
+  for (const [modeId, mode] of Object.entries(cfg.manifest.modes)) {
+    metrics.declaredRtp.set(mode.math.rtp ?? cfg.manifest.declaredRtp, { mode: modeId });
+  }
+
+  // Financial snapshot log: lifetime totals straight from the in-memory
+  // counters - the server aggregates its own money picture, no database
+  // round-trip. Per currency: raw components + the two standard
+  // derivations (GGR = real bets - all wins paid; RTP = wins / stakes).
+  const finLogMs = cfg.financialLogIntervalMs ?? 600_000;
+  const finLog = finLogMs > 0 ? setInterval(() => {
+    const byCurrency = new Map<string, Record<string, number>>();
+    const fold = (rows: ReadonlyArray<{ labels: string; value: number }>, kind: "bets" | "wins") => {
+      for (const { labels, value } of rows) {
+        // label key format: `k="v",k="v"` in label-name order
+        const l = Object.fromEntries(labels.split(",").map((kv) => {
+          const eq = kv.indexOf("=");
+          return [kv.slice(0, eq), kv.slice(eq + 1).replace(/^"|"$/g, "")] as [string, string];
+        }));
+        const cur = l["currency"] ?? "?";
+        const slot = byCurrency.get(cur) ?? { bets_real: 0, bets_promo: 0, wins_real: 0, wins_promo: 0 };
+        slot[`${kind}_${l["funding"] ?? "real"}`] = (slot[`${kind}_${l["funding"] ?? "real"}`] ?? 0) + value;
+        byCurrency.set(cur, slot);
+      }
+    };
+    fold(metrics.betsMinor.snapshot(), "bets");
+    fold(metrics.winsMinor.snapshot(), "wins");
+    if (byCurrency.size === 0) return;
+    const fin: Record<string, unknown> = {};
+    for (const [cur, t] of byCurrency) {
+      const stakes = t["bets_real"]! + t["bets_promo"]!;
+      const wins = t["wins_real"]! + t["wins_promo"]!;
+      fin[cur] = {
+        ...t,
+        ggr_minor: t["bets_real"]! - wins,
+        rtp_lifetime: stakes > 0 ? Number((wins / stakes).toFixed(4)) : null,
+      };
+    }
+    log.info("Financial snapshot (lifetime, this instance)", {
+      "event.category": "financial",
+      "event.action":   "financial_snapshot",
+      "financial":      fin,
+    });
+  }, finLogMs) : undefined;
+
   let platformWasHealthy = cfg.platform.isHealthy;
   metrics.platformConnected.set(platformWasHealthy ? 1 : 0);
   const platformWatch = setInterval(() => {
@@ -316,6 +366,7 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
       "drain.ms":       drainMs,
     });
     clearInterval(platformWatch);
+    if (finLog) clearInterval(finLog);
     try {
       // 1. Stop accepting new connections + drain in-flight requests.
       const transportStop = cfg.transport.stop({ drainMs });

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -45,6 +45,10 @@ export interface OpenRound {
   opsLog: Op[];
   /** Wall-clock ms epoch when the round opened. */
   openedAt: number;
+  /** Promo pool id when this round is platform-funded (no player debit).
+   *  Threaded to the close so financial metrics label wins by the funding
+   *  of the round that produced them. */
+  promoId?: string;
 }
 
 export interface LocalSession {

--- a/packages/core/test/financial-metrics.test.ts
+++ b/packages/core/test/financial-metrics.test.ts
@@ -1,0 +1,88 @@
+// Financial counters: in-process, monotonic, per {currency, mode, funding}.
+// GGR and RTP are derived at query time from these - the server itself only
+// increments. These tests drive the real orchestrator and read the counters
+// back through both surfaces: Prometheus exposition and Counter.snapshot()
+// (the in-memory read the financial snapshot log uses).
+
+import { describe, expect, test } from "bun:test";
+import { createOrchestrator } from "../src/index.js";
+import { createRgsMetrics } from "../src/metrics-rgs.js";
+import {
+  defineGame,
+  type PlatformAdapter, type SessionInfo, type SettleSimple, type OpenComplex,
+  type CloseComplex, type RoundReceipt, type SimpleMath,
+  type ConnectionMeta, type PlatformEvent,
+} from "@open-rgs/contract";
+
+class Wallet implements PlatformAdapter {
+  isHealthy = true;
+  diagnostics = {};
+  balance = 100_000;
+  private seq = 0;
+  async connect() {}
+  disconnect() {}
+  async openSession(sessionId: string): Promise<SessionInfo> {
+    return { sessionId, currency: "USD", currencyDecimals: 2, balance: this.balance, allowedBets: [100], defaultBetIndex: 0 };
+  }
+  async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+    this.balance += -req.bet + req.win;
+    return { roundId: `s${++this.seq}`, balance: this.balance };
+  }
+  async openComplex(req: OpenComplex): Promise<RoundReceipt> { this.balance -= req.bet; return { roundId: `r${++this.seq}`, balance: this.balance }; }
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> { this.balance += req.win; return { roundId: req.roundId, balance: this.balance }; }
+  onEvent(_h: (e: PlatformEvent) => void) {}
+}
+
+const half: SimpleMath = {
+  kind: "simple", name: "half", version: "1", rtp: 0.5,
+  play: () => ({ multiplier: 0.5, ops: [], type: "win" }),
+};
+
+function setup() {
+  const platform = new Wallet();
+  const metrics = createRgsMetrics();
+  const manifest = defineGame({
+    id: "g", declaredRtp: 0.5, defaultMode: "base", maxWinMultiplier: 1000,
+    modes: { base: { math: half, stakeMultiplier: 1 } },
+  });
+  const orch = createOrchestrator({ manifest, platform, metrics });
+  const conn: ConnectionMeta = { connectionId: "c", sessionId: null, demo: false };
+  return { orch, metrics, conn };
+}
+
+describe("financial counters (bets/wins minor units)", () => {
+  test("a settled spin increments bets and wins with funding=real", async () => {
+    const { orch, metrics, conn } = setup();
+    await orch.init({ sid: "fin" }, conn);
+    await orch.spin({ betIndex: 0 }, conn);   // bet 100, win 50 (0.5x)
+    await orch.spin({ betIndex: 0 }, conn);
+
+    const text = metrics.registry.expose();
+    expect(text).toContain('rgs_bets_minor_total{currency="USD",mode="base",funding="real"} 200');
+    expect(text).toContain('rgs_wins_minor_total{currency="USD",mode="base",funding="real"} 100');
+  });
+
+  test("snapshot() exposes the same totals for the in-process financial log", async () => {
+    const { orch, metrics, conn } = setup();
+    await orch.init({ sid: "fin2" }, conn);
+    await orch.spin({ betIndex: 0 }, conn);
+
+    const bets = metrics.betsMinor.snapshot();
+    expect(bets).toEqual([{ labels: 'currency="USD",mode="base",funding="real"', value: 100 }]);
+    const wins = metrics.winsMinor.snapshot();
+    expect(wins).toEqual([{ labels: 'currency="USD",mode="base",funding="real"', value: 50 }]);
+  });
+
+  test("zero-win rounds increment bets only", async () => {
+    const loss: SimpleMath = { kind: "simple", name: "loss", version: "1", rtp: 0, play: () => ({ multiplier: 0, ops: [], type: "loss" }) };
+    const metrics = createRgsMetrics();
+    const manifest = defineGame({ id: "g2", declaredRtp: 0, defaultMode: "base", maxWinMultiplier: 1000, modes: { base: { math: loss, stakeMultiplier: 1 } } });
+    const orch = createOrchestrator({ manifest, platform: new Wallet(), metrics });
+    const conn: ConnectionMeta = { connectionId: "c", sessionId: null, demo: false };
+    await orch.init({ sid: "z" }, conn);
+    await orch.spin({ betIndex: 0 }, conn);
+    const text = metrics.registry.expose();
+    expect(text).toContain('rgs_bets_minor_total{currency="USD",mode="base",funding="real"} 100');
+    expect(text).toContain("rgs_wins_minor_total 0"); // no win series materialized
+  });
+});

--- a/specs/07-deployment.md
+++ b/specs/07-deployment.md
@@ -217,6 +217,31 @@ wallet there, and is it answering":
 | `rgs_platform_call_duration_seconds{method}` | RPC latency histogram |
 | `rgs_platform_call_errors_total{method,reason}` | errors, reason includes `timeout` / `disconnected` |
 
+Financial series are in-process monotonic counters in the currency's minor
+unit; the server only increments, and GGR / RTP are DERIVED at query time
+(ratios don't aggregate across a fleet - counters do):
+
+| Series | Meaning |
+|---|---|
+| `rgs_bets_minor_total{currency,mode,funding}` | stakes; `funding=real` = actual debit (effective cost), `funding=promo` = notional free-round bet |
+| `rgs_wins_minor_total{currency,mode,funding}` | wins credited, by the round's funding |
+| `rgs_declared_rtp{mode}` | the theoretical target line |
+
+```promql
+# GGR per currency (house view: real stakes minus all wins paid)
+sum by (currency) (rgs_bets_minor_total{funding="real"})
+  - sum by (currency) (rgs_wins_minor_total)
+
+# Live RTP over a window, vs the declared line
+sum(increase(rgs_wins_minor_total[1h]))
+  / sum(increase(rgs_bets_minor_total[1h]))
+```
+
+Each instance also logs a `financial_snapshot` line on an interval
+(`financialLogIntervalMs`, default 10 min, 0 = off): lifetime per-currency
+bets/wins/GGR/RTP read straight from the in-memory counters - the money
+picture survives in plain logs even with no metrics stack attached.
+
 ## Platform adapter packaging
 
 Three patterns:


### PR DESCRIPTION
rgs_bets_minor_total{currency,mode,funding} + rgs_wins_minor_total{...}:
monotonic in-process counters in minor units. funding=real counts the
actual debit (effective cost incl. price/stake multipliers); funding=promo
the notional bet of a platform-funded round. Complex rounds thread promoId
onto the in-memory openRound so wins at close are labelled by the funding
that produced them. rgs_declared_rtp{mode} draws the target line.

GGR and live RTP are DERIVED at query time from summed counters - ratios
don't aggregate across a fleet, counters do:

  GGR = sum(bets{funding="real"}) - sum(wins)
  RTP = sum(increase(wins[w])) / sum(increase(bets[w]))

Each instance also logs a financial_snapshot line on an interval
(financialLogIntervalMs, default 10 min, 0 = off): lifetime per-currency
bets/wins/GGR/RTP read straight from the in-memory counters via the new
Counter.snapshot() - the money picture survives in plain logs with no
metrics stack attached, no database aggregation anywhere.

Tests drive the real orchestrator and read back through both surfaces
(exposition + snapshot). Spec 07 documents the series + PromQL formulas.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
