### PR TITLE
docs: add SECURITY.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,67 @@
+# Contributing to open-rgs
+
+Small, opinionated, rot-resistant  - that's the whole game. Read
+[specs/10-design-philosophy.md](specs/10-design-philosophy.md) before
+your first PR; it explains *why* the rules below exist.
+
+## Dev loop
+
+```bash
+bun install
+bun run typecheck
+bun test
+```
+
+CI gates every PR on: **typecheck + tests + site build +
+changeset-check**. Green locally means green in CI.
+
+## The iron rules
+
+- **Spec and code land together.** Spec is source of truth; a PR that
+  changes behaviour updates the relevant `specs/*.md` in the same PR.
+- **One opinionated way per concern.** No alternative helpers, no
+  "pick your favourite." If you need exotic, bring your own outside
+  core.
+- **No half-features in core.** Either it's done or it's not in.
+- **Every dependency needs a justification**  - a comment in
+  `package.json` saying why it's there and what it would take to
+  remove.
+- **Neutral examples only.** Public packages and specs NEVER name a
+  real provider's wire shape, brand, or product id. Invented names
+  only.
+
+## Money rules
+
+- All amounts are **integers in the currency's minor unit**
+  (USD 1.00 -> `100` at `currencyDecimals = 2`). No floats, ever.
+- Math is **currency-blind and RNG-injected**: a pure function of
+  prior state and injected randomness. It never sees a bet, balance,
+  or clock.
+
+## Releases
+
+Releases are driven by [Changesets](https://github.com/changesets/changesets)
+with **independent versioning** per package:
+
+- A PR that ships a user-visible change adds a changeset:
+  `bun run changeset` (CI rejects `packages/*/src` changes without
+  one; `bunx changeset add --empty` for genuinely no-release edits).
+- A bot opens a "version packages" PR; maintainers merge it to
+  publish. Details in [PUBLISHING.md](PUBLISHING.md).
+
+Docs-only changes (like this file) need no changeset.
+
+## PR etiquette
+
+- **Small PRs, one concern each.** A reviewer should be able to say
+  which guarantee or spec a change touches.
+- **Behaviour changes come with tests** (`bun:test`).
+- **Major decisions get an ADR** in `specs/adr/`.
+- **Bigger changes start as a proposal**, not a PR: open an issue per
+  "How to propose a change" in
+  [specs/09-roadmap.md](specs/09-roadmap.md)  - state the goal, the
+  alternatives considered, your recommendation. Implement after the
+  spec lands; reviewers check both.
+
+Security issues are different: never a public issue  - see
+[SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,63 @@
+# Security Policy
+
+open-rgs moves real money for a living. We treat integrity bugs with
+the same severity as remote-code-execution bugs.
+
+## Reporting a vulnerability
+
+Report privately via **GitHub Security Advisories** on this repo:
+*Security -> Report a vulnerability*. Do **not** open a public issue
+for anything exploitable.
+
+- We acknowledge reports within **72 hours**.
+- We aim for coordinated disclosure within **90 days** of the report
+  (sooner when a fix ships sooner). We'll credit you in the advisory
+  unless you prefer otherwise.
+
+## Supported versions
+
+The **latest published minor** of each `@open-rgs/*` package receives
+security fixes. No backports  - upgrade to the current release.
+
+## Scope: the Seven Guarantees are security properties
+
+The Seven Guarantees ([specs/00-guarantees.md](specs/00-guarantees.md))
+are the engine's safety surface. A **reproducible violation of any of
+them is a security bug**, not a regular bug  - report it privately:
+
+1. **No Money, No Honey**  - game state never persists unless the money
+   for it moved.
+2. **One Round, One Record**  - money and game-state commit together
+   and revert together, latest-first.
+3. **Blind Math**  - the math never sees bet, balance, currency, clock,
+   or I/O.
+4. **The House Computes, The Client Asks**  - outcomes are
+   server-authoritative; the client supplies intent, never results.
+5. **Fail Closed**  - under uncertainty the engine refuses to pay
+   rather than guessing.
+6. **At Most Once**  - a replayed or raced request moves money at most
+   once.
+7. **Bounded Payout**  - every win is capped, and the engine enforces
+   the cap.
+
+Concretely: a double-settle, a payout above the max-win cap, math code
+escaping its sandbox, forging or splicing the tamper-evident audit
+chain, a client-supplied outcome being honoured  - all security bugs.
+
+## Out of scope
+
+- **DoS via the documented WASM watchdog caveat.** `loadWasmMath` has
+  no per-call timeout by design; WASM kernels must be trusted and
+  bounded ([specs/03-math-runtime.md](specs/03-math-runtime.md)).
+  Demonstrating that a hostile kernel can hang a deployment is the
+  documented behaviour, not a finding.
+- Issues that require an already-compromised operator or admin token.
+- Vulnerabilities in consumer game code or platform adapters that live
+  outside this repo  - report those to their authors.
+
+## Supply chain
+
+npm publishes use **OIDC Trusted Publishing with provenance**  - every
+`@open-rgs/*` release is built by the repo's release workflow and
+carries a signed attestation. There are **no long-lived npm tokens**
+to steal. See [PUBLISHING.md](PUBLISHING.md).


### PR DESCRIPTION
Two root trust-surface files the repo was missing.

## SECURITY.md

- **Reporting**  - private vulnerability reporting via GitHub Security Advisories on this repo; no public issues for vulns; 72h acknowledgement; coordinated disclosure within 90 days.
- **Supported versions**  - latest published minor of each `@open-rgs/*` package.
- **Scope**  - the Seven Guarantees (`specs/00-guarantees.md`) listed as security properties: a reproducible violation (double-settle, payout above the cap, sandbox escape, audit-chain forgery, ...) is a security bug.
- **Out of scope**  - DoS via the documented WASM no-watchdog caveat (spec 03), issues requiring a compromised operator/admin token, vulns in consumer game code or out-of-repo adapters.
- **Supply chain**  - npm OIDC Trusted Publishing with provenance, no long-lived tokens.

## CONTRIBUTING.md

- **Dev loop**  - `bun install` / `bun run typecheck` / `bun test`; CI gates (typecheck + tests + site build + changeset-check).
- **Iron rules**  - spec+code in the same PR, one way per concern, no half-features in core, every dep justified, neutral examples only (never a real provider's wire shape, brand, or product id).
- **Money rules**  - integers in minor units; math is currency-blind and RNG-injected.
- **Releases**  - changesets, independent versioning, maintainers merge the "version packages" PR.
- **PR etiquette**  - small one-concern PRs, tests for behaviour changes, ADRs in `specs/adr/`, proposals per specs/09 "How to propose a change".

Docs-only root files  - no changeset (changeset-check only fires on `packages/*/src`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)