### PR TITLE
docs(contract): make reversal thread-safety and durability normative

### DIFF
--- a/.changeset/reverse-round-contract-docs.md
+++ b/.changeset/reverse-round-contract-docs.md
@@ -1,0 +1,11 @@
+---
+"@open-rgs/contract": patch
+---
+
+Harden the reversal contract docs with two normative rules. `reverseRound` is
+wallet-initiated, so it arrives outside the orchestrator's per-session lock  -
+adapters MUST implement it to be safe under concurrent invocation with
+settle/open/close on the same session. A real adapter MUST also persist its
+reversed-round tracking (receipts, reversed set, latest-first ordering basis)
+durably, since a restart that forgets prior reversals turns a retried reversal
+into a second credit. Docs only  - no runtime changes.

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -532,7 +532,22 @@ export interface RoundReceipt {
  *  a session may be reversed; an adapter MUST reject an attempt to reverse an
  *  older round while newer rounds sit on top of it (restoring an old round's
  *  pre-state would silently discard the newer rounds and over-refund). A wallet
- *  reversing a span of rounds reverses them newest-to-oldest. */
+ *  reversing a span of rounds reverses them newest-to-oldest.
+ *
+ *  CONCURRENCY  - because reversal is wallet-initiated, it arrives OUTSIDE the
+ *  orchestrator's per-session lock; that lock serializes only client-driven
+ *  traffic, so nothing upstream of the adapter orders a reversal against an
+ *  in-flight settle/open/close on the same session. An adapter MUST implement
+ *  reverseRound to be safe under concurrent invocation with those calls (its
+ *  own per-session mutex, an upstream transaction  - the mechanism is the
+ *  adapter's choice).
+ *
+ *  DURABILITY  - a real adapter MUST persist its reversed-round tracking (the
+ *  reversal receipts it replays, the set of already-reversed rounds, and the
+ *  ordering basis behind latest-first) durably, so it survives a process
+ *  restart. An adapter that forgets prior reversals on restart turns a retried
+ *  reversal into a second credit. The reference mock's in-memory stack is a
+ *  mock-only convenience, not a model for production. */
 export interface ReverseRound {
   sessionId: string;
   /** The round to reverse. MUST be the latest un-reversed round on the session. */
@@ -544,6 +559,11 @@ export interface ReverseRound {
   idempotencyKey?: string;
 }
 
+/** Result of a reversal. Receipts are part of the adapter's durable
+ *  reversed-round record: a repeated reversal of the same round (or a repeated
+ *  idempotency key) MUST replay the stored receipt rather than credit again,
+ *  which only holds if the receipts survive a process restart  - see
+ *  DURABILITY on {@link ReverseRound}. */
 export interface ReverseReceipt {
   roundId: string;
   /** Balance after the reversal  - restored to the round's pre-settle value. */
@@ -598,8 +618,13 @@ export interface PlatformAdapter {
   /** Reverse an already-settled round (chargeback / reconciliation). Optional  -
    *  implement only if your upstream supports reversal. MUST undo money AND
    *  carry together, latest-first; see {@link ReverseRound} (Guarantee 2,
-   *  "One Round, One Record"). The reference @open-rgs/platform-mock implements
-   *  it correctly and the conformance suite checks it. */
+   *  "One Round, One Record"). Because it is wallet-initiated it is NOT
+   *  covered by the orchestrator's per-session lock  - it MUST be safe to
+   *  invoke concurrently with settleSimple/openComplex/closeComplex on the
+   *  same session  - and a real adapter MUST keep its reversed-round tracking
+   *  durable across restarts. The reference @open-rgs/platform-mock implements
+   *  the semantics correctly (in memory  - it's a mock) and the conformance
+   *  suite checks them. */
   reverseRound?(req: ReverseRound): Promise<ReverseReceipt>;
 
   onEvent(handler: (e: PlatformEvent) => void): void;

--- a/specs/05-platform-protocol.md
+++ b/specs/05-platform-protocol.md
@@ -114,11 +114,25 @@ When implemented, it MUST honour Guarantee 2 (`specs/00-guarantees.md`):
 - **No-op, not error, when nothing to reverse.** An unknown or already-reversed
   round returns `{ reversed: false, reason }` and moves no money  - reversing
   twice must not credit twice. Idempotency-key dedupe applies as elsewhere.
+- **Safe under concurrency.** Because reversal is wallet-initiated, it arrives
+  *outside* the orchestrator's per-session lock  - that lock serializes only
+  client-driven traffic, so nothing upstream of the adapter orders a reversal
+  against an in-flight `settleSimple`/`openComplex`/`closeComplex` on the same
+  session. An adapter MUST implement `reverseRound` to be safe under concurrent
+  invocation with those calls (its own per-session mutex, an upstream
+  transaction  - the mechanism is the adapter's choice).
+- **Durable tracking.** A real adapter MUST persist its reversed-round
+  tracking  - the reversal receipts it replays on a repeat, the set of
+  already-reversed rounds, and the ordering basis behind latest-first  -
+  durably, so it survives a process restart. An adapter that forgets prior
+  reversals on restart turns a retried reversal into a second credit.
 
-The reference `@open-rgs/platform-mock` implements this correctly (a per-session
-LIFO stack of `(roundId, balanceBefore, carryBefore)` snapshots); the
-conformance suite asserts the whole-record, latest-first, and no-double-credit
-properties.
+The reference `@open-rgs/platform-mock` implements these semantics correctly (a
+per-session LIFO stack of `(roundId, balanceBefore, carryBefore)` snapshots,
+plus a receipt map for idempotent replay). It keeps all of that **in memory**  -
+by design, it is a dev mock  - so it is deliberately not a model for the
+durable-tracking rule above. The conformance suite asserts the whole-record,
+latest-first, and no-double-credit properties.
 
 ### Health
 


### PR DESCRIPTION
## What

Hardens the `reverseRound` contract docs with two normative rules from a production-readiness audit. Docs only — no runtime changes. Touches the jsdoc on `ReverseRound`, `ReverseReceipt`, and `PlatformAdapter.reverseRound` in `packages/contract/src/index.ts`, the reversal section of `specs/05-platform-protocol.md`, and adds a patch changeset for `@open-rgs/contract`.

## The two rules

**1. Safe under concurrency.** `reverseRound` is wallet-initiated, so it arrives *outside* the orchestrator's per-session lock — that lock serializes only client-driven traffic, and nothing upstream of the adapter orders a reversal against an in-flight `settleSimple`/`openComplex`/`closeComplex` on the same session. Adapters MUST implement `reverseRound` to be safe under concurrent invocation with those calls (own per-session mutex, upstream transaction — mechanism is the adapter's choice).

**2. Durable tracking.** A real adapter MUST persist its reversed-round tracking — the reversal receipts it replays on a repeat, the set of already-reversed rounds, and the ordering basis behind latest-first — durably across restarts. An adapter that forgets prior reversals on restart turns a retried reversal into a second credit.

## On the reference mock

`@open-rgs/platform-mock` keeps its reversal LIFO stack, reversed set, and receipt map **in memory — by design**: it is a dev mock, and that is now called out explicitly in the spec and jsdoc so nobody mistakes it for a model of the durable-tracking rule. Its whole-record / latest-first / no-double-credit semantics remain the reference, and the conformance suite continues to assert them.

## Verification

`bun run typecheck` passes across all packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)