### PR TITLE
feat(core,contract): enforce ConcurrencyPolicy at INIT - kick-old by default

### DIFF
--- a/.changeset/concurrency-policy-enforcement.md
+++ b/.changeset/concurrency-policy-enforcement.md
@@ -1,0 +1,19 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+---
+
+Enforce `ConcurrencyPolicy` at INIT - BEHAVIOR CHANGE. When a second
+connection INITs a session already attached to another live connection, the
+orchestrator now arbitrates: **kick-old** (new default - the older
+connection gets a `SESSION_IN_USE` error frame and is closed with app close
+code 4000; the newest window always wins), **reject-new** (the newer INIT
+fails with `SESSION_IN_USE`), or **allow** (the previous coexist behaviour;
+set `createServer({ concurrencyPolicy: "allow" })` to keep it). Money was
+safe under any policy; what changes is that two open windows no longer
+silently diverge. A dropped connection detaches first, so reconnects are
+never policed. Contract: `ConcurrencyPolicy` gains `"allow"`,
+`RGSErrorCode` gains `SESSION_IN_USE`, and `ClientTransport` gains the
+optional `closeConnection` capability (a transport without it degrades
+kick-old to allow with a boot warning). New metric:
+`rgs_session_concurrency_actions_total{action}`.

--- a/apps/site/src/pages/errors.astro
+++ b/apps/site/src/pages/errors.astro
@@ -26,6 +26,7 @@ import BaseLayout from "../layouts/BaseLayout.astro";
         <tr><td class="mono">MISSING_SESSION</td><td>request needs <code>sid</code> but none was supplied or attached</td></tr>
         <tr><td class="mono">SESSION_NOT_FOUND</td><td>platform <code>openSession</code> rejected the id</td></tr>
         <tr><td class="mono">SESSION_INVALID</td><td>session exists but is closed / blocked / expired</td></tr>
+        <tr><td class="mono">SESSION_IN_USE</td><td>session attached to another live connection (concurrency policy: rejected new window, or kicked old one before closing it)</td></tr>
         <tr><td class="mono">INSUFFICIENT_BALANCE</td><td>pre-flight check failed for the requested bet</td></tr>
         <tr><td class="mono">INVALID_BET</td><td><code>betIndex</code> out of range, or bet 0 or less</td></tr>
         <tr><td class="mono">INVALID_MODE</td><td>mode id unknown, internal, or wrong <code>kind</code></td></tr>

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -804,6 +804,11 @@ export interface ClientTransport {
   /** Stop accepting new connections. With opts.drainMs > 0, also waits
    *  for in-flight requests to complete (or that ms to elapse). */
   stop(opts?: { drainMs?: number }): void | Promise<void>;
+  /** Push a structured error frame to a connection and close it. Used by
+   *  the orchestrator's concurrencyPolicy "kick-old" to supersede the
+   *  older connection. OPTIONAL  - a transport without it degrades
+   *  kick-old to "allow" (createServer warns at boot). */
+  closeConnection?(connectionId: string, code: RGSErrorCode, reason: string): void;
 }
 
 // --- Idempotency strategy --------------------------------------------------
@@ -834,12 +839,25 @@ export interface IdempotencyConfig {
 
 // --- Concurrency policy ----------------------------------------------------
 
-/** What to do when a second WS connection arrives for an existing session.
- *  NOTE: declared but NOT yet enforced  - second connections to a live
- *  session are currently unmanaged at the transport level (per-session
- *  *operation* serialization exists in the orchestrator; connection-level
- *  policy does not). Tracked in Spec 09 (roadmap). */
-export type ConcurrencyPolicy = "kick-old" | "reject-new";
+/** What to do when a second WS connection INITs a session that is already
+ *  attached to another live connection. Enforced by the orchestrator at
+ *  INIT (configured via `createServer({ concurrencyPolicy })`):
+ *
+ *  - "kick-old" (default): the older connection receives a SESSION_IN_USE
+ *    error frame and is closed; the new connection takes over the session.
+ *    The player's newest window always wins  - opening the game twice never
+ *    leaves a stale window silently diverging.
+ *  - "reject-new": the new connection's INIT fails with SESSION_IN_USE
+ *    while the older connection stays attached.
+ *  - "allow": both connections coexist (the pre-enforcement behaviour).
+ *    Money stays safe either way  - per-session operation serialization +
+ *    wallet idempotency hold regardless  - but coexisting windows see
+ *    diverging balance views; prefer kick-old.
+ *
+ *  A connection that disconnects detaches from its session, so a reconnect
+ *  after a drop is never kicked/rejected  - the policy only arbitrates two
+ *  LIVE connections. */
+export type ConcurrencyPolicy = "kick-old" | "reject-new" | "allow";
 
 // --- Numeric convention ----------------------------------------------------
 
@@ -861,6 +879,10 @@ export type RGSErrorCode =
   | "MISSING_SESSION"
   | "SESSION_NOT_FOUND"
   | "SESSION_INVALID"
+  /** The session is attached to another live connection. Sent to the NEW
+   *  connection under concurrencyPolicy "reject-new", or to the OLD
+   *  connection (followed by a close) when "kick-old" supersedes it. */
+  | "SESSION_IN_USE"
   | "INSUFFICIENT_BALANCE"
   | "INVALID_BET"
   | "INVALID_MODE"

--- a/packages/core/src/metrics-rgs.ts
+++ b/packages/core/src/metrics-rgs.ts
@@ -53,6 +53,10 @@ export interface RgsMetrics {
   /** Declared/theoretical RTP per mode - the target line dashboards draw
    *  against live RTP. */
   declaredRtp: Gauge;           // {mode}
+  /** Concurrency-policy interventions at INIT: an older connection kicked
+   *  ("kick-old") or a newer one refused ("reject-new"). A spike means
+   *  players are multi-windowing - or something is replaying tokens. */
+  sessionConcurrency: Counter;  // {action: kick-old|reject-new}
 }
 
 export function createRgsMetrics(): RgsMetrics {
@@ -127,6 +131,11 @@ export function createRgsMetrics(): RgsMetrics {
       "rgs_declared_rtp",
       "Declared/theoretical RTP per mode.",
       ["mode"],
+    ),
+    sessionConcurrency: registry.counter(
+      "rgs_session_concurrency_actions_total",
+      "Concurrency-policy interventions at INIT (kick-old / reject-new).",
+      ["action"],
     ),
   };
 }

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -40,7 +40,7 @@ import { deriveIdempotencyKey } from "./idempotency.js";
 import type { AuditLog, AuditInput } from "./audit-log.js";
 import { log } from "./log.js";
 import type { RgsMetrics } from "./metrics-rgs.js";
-import type { IdempotencyConfig } from "@open-rgs/contract";
+import type { IdempotencyConfig, ConcurrencyPolicy } from "@open-rgs/contract";
 
 export interface OrchestratorConfig {
   manifest: GameManifest;
@@ -68,6 +68,15 @@ export interface OrchestratorConfig {
   /** Idempotency-key generator + retention. Defaults to uuid-v4 +
    *  5-minute TTL (a hint for upstream caches). */
   idempotency?: IdempotencyConfig;
+  /** What INIT does when the session is already attached to another LIVE
+   *  connection. Default "kick-old". See ConcurrencyPolicy in the
+   *  contract. */
+  concurrencyPolicy?: ConcurrencyPolicy;
+  /** Transport capability to kick a specific connection (sends a
+   *  SESSION_IN_USE error frame, then closes). Wired by createServer from
+   *  ClientTransport.closeConnection. Without it, "kick-old" degrades to
+   *  "allow" (createServer warns at boot). */
+  kickConnection?: (connectionId: string, reason: string) => void;
 }
 
 /** Default idempotency-key generator: crypto.randomUUID (UUID v4). */
@@ -365,6 +374,36 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     if (!req.sid) throw new RGSError("MISSING_SESSION", "sid required");
     if (!platform.isHealthy) throw new RGSError("PLATFORM_UNAVAILABLE", "Platform not connected");
 
+    // Concurrency policy (Spec 02): arbitrate when this sid is already
+    // attached to ANOTHER live connection. A connection that dropped
+    // detaches (connectionId null), so a plain reconnect never trips this.
+    {
+      const prior = sessions.get(req.sid);
+      if (prior && prior.connectionId && prior.connectionId !== conn.connectionId) {
+        const policy = cfg.concurrencyPolicy ?? "kick-old";
+        if (policy === "reject-new") {
+          metrics?.sessionConcurrency.inc(1, { action: "reject-new" });
+          throw new RGSError("SESSION_IN_USE", "session is attached to another live connection");
+        }
+        if (policy === "kick-old") {
+          metrics?.sessionConcurrency.inc(1, { action: "kick-old" });
+          const kicked = prior.connectionId;
+          // Detach BEFORE kicking: the kick triggers the old socket's close
+          // handler -> onDisconnect, which must not unbind the NEW owner.
+          sessions.setConnection(req.sid, null);
+          cfg.kickConnection?.(kicked, "session opened on a newer connection");
+          log.info("Older connection superseded (concurrency policy kick-old)", {
+            "event.category": "orchestrator",
+            "event.action": "session_kick_old",
+            "session.id": req.sid,
+            "connection.kicked": kicked,
+            "connection.new": conn.connectionId,
+          });
+        }
+        // "allow": both connections coexist - the pre-enforcement behaviour.
+      }
+    }
+
     // Resume path: if a session for this sid is already in our cache (e.g.
     // the player disconnected mid-round and reconnected), reuse it. The
     // openRound's full opsLog + actionLog + awaiting tell the new
@@ -379,6 +418,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       // keeps it current). Connection metadata gets updated.
       conn.sessionId = s.sessionId;
       conn.demo = !s.currency;
+      sessions.setConnection(s.sessionId, conn.connectionId);
       info = {
         sessionId: s.sessionId,
         currency: s.currency,
@@ -1020,6 +1060,15 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     if (!conn.sessionId) return;
     const s = sessions.get(conn.sessionId);
     if (!s) return;
+
+    // Ownership guard: a connection that was superseded (kick-old) or
+    // otherwise replaced no longer owns the session - its late close event
+    // must not detach or evict the NEW owner's session.
+    if (s.connectionId !== null && s.connectionId !== conn.connectionId) return;
+
+    // This connection owns the binding - detach it. The session itself may
+    // be retained below (open round) for a resume by a future connection.
+    sessions.setConnection(conn.sessionId, null);
 
     // Keep the session in cache if a round is open  - the player may
     // reconnect within the platform's grace window and resume. Autoclose

--- a/packages/core/src/server.ts
+++ b/packages/core/src/server.ts
@@ -12,7 +12,7 @@
 //     interface unreachable from public ingress.
 
 import type {
-  GameManifest, PlatformAdapter, ClientTransport, IdempotencyConfig,
+  GameManifest, PlatformAdapter, ClientTransport, IdempotencyConfig, ConcurrencyPolicy,
 } from "@open-rgs/contract";
 import { createOrchestrator } from "./orchestrator.js";
 import { createAdminHandler, startAdmin } from "./admin.js";
@@ -89,6 +89,15 @@ export interface ServerConfig {
   /** Install a SIGTERM handler that calls stop(). Default true; set
    *  false in test harnesses. */
   installSignalHandlers?: boolean;
+  /** What INIT does when a session is already attached to another LIVE
+   *  connection: "kick-old" (default - the newest window wins; the older
+   *  connection gets a SESSION_IN_USE error frame and is closed),
+   *  "reject-new" (the newer INIT fails with SESSION_IN_USE), or "allow"
+   *  (coexist - the pre-1.7 behaviour; money stays safe but the windows'
+   *  balance views diverge). Enforced via the transport's closeConnection;
+   *  a custom transport without it degrades kick-old to allow (warns at
+   *  boot). */
+  concurrencyPolicy?: ConcurrencyPolicy;
 }
 
 export interface ServerHandle {
@@ -269,11 +278,26 @@ export async function createServer(cfg: ServerConfig): Promise<ServerHandle> {
     });
   }
 
+  // Concurrency policy: enforcement needs the transport's closeConnection
+  // capability for kick-old. Without it, degrade to "allow" loudly rather
+  // than half-enforce.
+  const concurrencyPolicy = cfg.concurrencyPolicy ?? "kick-old";
+  const canKick = typeof cfg.transport.closeConnection === "function";
+  if (concurrencyPolicy === "kick-old" && !canKick) {
+    log.warn("Transport lacks closeConnection - concurrencyPolicy kick-old degrades to allow", {
+      "event.category": "process",
+      "event.action":   "concurrency_policy_degraded",
+    });
+  }
+
   const orchestrator = createOrchestrator({
     manifest: cfg.manifest,
     platform: cfg.platform,
     cheatsEnabled,
     metrics,
+    concurrencyPolicy: concurrencyPolicy === "kick-old" && !canKick ? "allow" : concurrencyPolicy,
+    ...(canKick ? { kickConnection: (connectionId: string, reason: string) =>
+      cfg.transport.closeConnection!(connectionId, "SESSION_IN_USE", reason) } : {}),
     ...(cfg.idempotency ? { idempotency: cfg.idempotency } : {}),
     ...(cfg.auditSink ? { auditLog: createAuditLog(cfg.auditSink) } : {}),
     ...(cfg.auditMode ? { auditMode: cfg.auditMode } : {}),

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -53,7 +53,11 @@ export interface OpenRound {
 
 export interface LocalSession {
   readonly sessionId: string;
-  readonly connectionId: string;
+  /** Connection currently attached to this session; null once that
+   *  connection dropped (detached). The concurrency policy arbitrates on
+   *  this: a second INIT while non-null hits kick-old / reject-new; a
+   *  reconnect after a drop (null) attaches freely. */
+  connectionId: string | null;
   balance: number;
   readonly currency: string;
   readonly currencyDecimals: number;
@@ -144,6 +148,13 @@ export function openRoundStats(now: number): { open_rounds: number; oldest_open_
 export function setBalance(id: string, balance: number): void {
   const s = sessions.get(id);
   if (s) s.balance = balance;
+}
+
+/** (Re)bind the session to a connection, or detach with null when that
+ *  connection drops. The concurrency policy reads this binding. */
+export function setConnection(id: string, connectionId: string | null): void {
+  const s = sessions.get(id);
+  if (s) s.connectionId = connectionId;
 }
 
 export function setCarry(id: string, carry?: CarryState, nextMode?: string): void {

--- a/packages/core/src/transport-binary.ts
+++ b/packages/core/src/transport-binary.ts
@@ -80,6 +80,9 @@ export interface BinaryClientTransport extends ClientTransport {
    *  transport's port. Idempotent; last write wins. Must be called
    *  BEFORE start(). */
   setExtraFetch(fn: (req: Request) => Promise<Response | undefined> | Response | undefined): void;
+  /** Push a structured ERROR frame to a live connection, then close it
+   *  (app close code 4000). Drives concurrencyPolicy "kick-old". */
+  closeConnection(connectionId: string, code: RGSErrorCode, reason: string): void;
 }
 
 export function binaryTransport(cfg: BinaryTransportConfig): BinaryClientTransport {
@@ -88,9 +91,27 @@ export function binaryTransport(cfg: BinaryTransportConfig): BinaryClientTranspo
   let accepting = true;
   let inflight = 0;
   let extraFetch = cfg.extraFetch;
+  // Live sockets by connectionId - lets the orchestrator kick one specific
+  // connection (concurrencyPolicy "kick-old") without the transport knowing
+  // anything about sessions.
+  const socks = new Map<string, Bun.ServerWebSocket<WsData>>();
 
   return {
     setExtraFetch(fn) { extraFetch = fn; },
+
+    closeConnection(connectionId, code, reason) {
+      const ws = socks.get(connectionId);
+      if (!ws) return;
+      socks.delete(connectionId);
+      try { sendError(ws, code, reason); } catch { /* socket already gone */ }
+      try { ws.close(4000, reason.slice(0, 120)); } catch { /* ditto */ }
+      log.info("Connection closed by policy", {
+        "event.category": "transport",
+        "event.action": "connection_kicked",
+        "connection.id": connectionId,
+        "error.code": code,
+      });
+    },
 
     async start(api: OrchestratorAPI): Promise<{ port: number }> {
       server = Bun.serve<WsData>({
@@ -128,6 +149,7 @@ export function binaryTransport(cfg: BinaryTransportConfig): BinaryClientTranspo
           open(ws) {
             ws.data.connectedAt = Date.now();
             ws.data.lastOpSeq = 0;
+            socks.set(ws.data.connectionId, ws);
             cfg.onConnect?.();
             log.info("Client connected", {
               "event.category": "transport",
@@ -180,6 +202,7 @@ export function binaryTransport(cfg: BinaryTransportConfig): BinaryClientTranspo
             }
           },
           close(ws) {
+            socks.delete(ws.data.connectionId);
             api.onDisconnect(ws.data);
             cfg.onDisconnect?.();
             log.info("Client disconnected", {

--- a/packages/core/test/concurrency-policy.test.ts
+++ b/packages/core/test/concurrency-policy.test.ts
@@ -1,0 +1,195 @@
+// ConcurrencyPolicy enforcement (Spec 02): when a second connection INITs a
+// session that is already attached to another LIVE connection, the
+// orchestrator arbitrates - kick-old (default), reject-new, or allow. A
+// dropped connection detaches first, so a plain reconnect is never policed.
+//
+// Unit tests drive the orchestrator with a fake kick capability; the
+// integration test runs the real binaryTransport and asserts the kicked
+// socket receives a SESSION_IN_USE error frame followed by a close.
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { encode, decode } from "@msgpack/msgpack";
+import { createOrchestrator } from "../src/index.js";
+import { binaryTransport, MSG_INIT_REQUEST, MSG_INIT_RESPONSE, MSG_ERROR, type BinaryClientTransport } from "../src/transport-binary.js";
+import {
+  defineGame, RGSError,
+  type PlatformAdapter, type SessionInfo, type SettleSimple, type OpenComplex,
+  type CloseComplex, type RoundReceipt, type SimpleMath,
+  type ConnectionMeta, type PlatformEvent, type ConcurrencyPolicy,
+} from "@open-rgs/contract";
+
+class Wallet implements PlatformAdapter {
+  isHealthy = true;
+  diagnostics = {};
+  balance = 100_000;
+  private seq = 0;
+  async connect() {}
+  disconnect() {}
+  async openSession(sessionId: string): Promise<SessionInfo> {
+    return { sessionId, currency: "USD", currencyDecimals: 2, balance: this.balance, allowedBets: [100], defaultBetIndex: 0 };
+  }
+  async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+    this.balance += -req.bet + req.win;
+    return { roundId: `s${++this.seq}`, balance: this.balance };
+  }
+  async openComplex(req: OpenComplex): Promise<RoundReceipt> { this.balance -= req.bet; return { roundId: `r${++this.seq}`, balance: this.balance }; }
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> { this.balance += req.win; return { roundId: req.roundId, balance: this.balance }; }
+  onEvent(_h: (e: PlatformEvent) => void) {}
+}
+
+const half: SimpleMath = {
+  kind: "simple", name: "half", version: "1", rtp: 0.5,
+  play: () => ({ multiplier: 0.5, ops: [], type: "win" }),
+};
+
+function setup(policy?: ConcurrencyPolicy) {
+  const kicked: string[] = [];
+  const manifest = defineGame({
+    id: "g", declaredRtp: 0.5, defaultMode: "base", maxWinMultiplier: 1000,
+    modes: { base: { math: half, stakeMultiplier: 1 } },
+  });
+  const orch = createOrchestrator({
+    manifest, platform: new Wallet(),
+    ...(policy ? { concurrencyPolicy: policy } : {}),
+    kickConnection: (id) => kicked.push(id),
+  });
+  const conn = (id: string): ConnectionMeta => ({ connectionId: id, sessionId: null, demo: false });
+  return { orch, kicked, conn };
+}
+
+describe("ConcurrencyPolicy - orchestrator", () => {
+  test("kick-old (default): second window supersedes, first is kicked", async () => {
+    const { orch, kicked, conn } = setup();
+    const a = conn("conn-a"), b = conn("conn-b");
+    await orch.init({ sid: "p1" }, a);
+    await orch.init({ sid: "p1" }, b);
+    expect(kicked).toEqual(["conn-a"]);
+    // The new owner can play.
+    const r = await orch.spin({ betIndex: 0 }, b);
+    expect(r.bet).toBe(100);
+  });
+
+  test("kicked connection's late disconnect does not evict the new owner", async () => {
+    const { orch, conn } = setup();
+    const a = conn("conn-a"), b = conn("conn-b");
+    await orch.init({ sid: "p2" }, a);
+    await orch.init({ sid: "p2" }, b);
+    // Old socket's close event arrives after the takeover.
+    orch.onDisconnect(a);
+    const r = await orch.spin({ betIndex: 0 }, b);   // session must still exist
+    expect(r.balance).toBeGreaterThan(0);
+  });
+
+  test("reject-new: second INIT fails with SESSION_IN_USE, first keeps playing", async () => {
+    const { orch, kicked, conn } = setup("reject-new");
+    const a = conn("conn-a"), b = conn("conn-b");
+    await orch.init({ sid: "p3" }, a);
+    let err: unknown;
+    try { await orch.init({ sid: "p3" }, b); } catch (e) { err = e; }
+    expect((err as RGSError).code).toBe("SESSION_IN_USE");
+    expect(kicked).toEqual([]);
+    const r = await orch.spin({ betIndex: 0 }, a);
+    expect(r.bet).toBe(100);
+  });
+
+  test("reject-new: after the first connection drops, a new one attaches freely", async () => {
+    const { orch, conn } = setup("reject-new");
+    const a = conn("conn-a"), b = conn("conn-b");
+    await orch.init({ sid: "p4" }, a);
+    orch.onDisconnect(a);                             // detach
+    const resp = await orch.init({ sid: "p4" }, b);   // no SESSION_IN_USE
+    expect(resp.sid).toBe("p4");
+  });
+
+  test("allow: both connections coexist, nobody kicked", async () => {
+    const { orch, kicked, conn } = setup("allow");
+    const a = conn("conn-a"), b = conn("conn-b");
+    await orch.init({ sid: "p5" }, a);
+    await orch.init({ sid: "p5" }, b);
+    expect(kicked).toEqual([]);
+    const ra = await orch.spin({ betIndex: 0 }, a);
+    const rb = await orch.spin({ betIndex: 0 }, b);
+    expect(ra.roundId).not.toBe(rb.roundId);
+  });
+
+  test("same connection re-INIT is not policed", async () => {
+    const { orch, kicked, conn } = setup();
+    const a = conn("conn-a");
+    await orch.init({ sid: "p6" }, a);
+    await orch.init({ sid: "p6" }, a);
+    expect(kicked).toEqual([]);
+  });
+});
+
+// --- integration: real transport, real sockets -------------------------------
+
+function frame(type: number, payload: unknown): Uint8Array {
+  const body = encode(payload);
+  const out = new Uint8Array(body.length + 1);
+  out[0] = type;
+  out.set(body, 1);
+  return out;
+}
+
+interface Caught { type: number; payload: Record<string, unknown> }
+
+function tapWs(port: number): Promise<{ ws: WebSocket; frames: Caught[]; closed: Promise<{ code: number }> }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}/wss`);
+    ws.binaryType = "arraybuffer";
+    const frames: Caught[] = [];
+    let closeResolve: (v: { code: number }) => void;
+    const closed = new Promise<{ code: number }>((r) => { closeResolve = r; });
+    ws.onmessage = (ev) => {
+      const bytes = new Uint8Array(ev.data as ArrayBuffer);
+      frames.push({ type: bytes[0]!, payload: (bytes.length > 1 ? decode(bytes.subarray(1)) : {}) as Record<string, unknown> });
+    };
+    ws.onclose = (ev) => closeResolve({ code: ev.code });
+    ws.onopen = () => resolve({ ws, frames, closed });
+    ws.onerror = () => reject(new Error("ws connect failed"));
+  });
+}
+
+async function until(cond: () => boolean, ms = 2_000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!cond() && Date.now() < deadline) await Bun.sleep(10);
+  if (!cond()) throw new Error("condition not reached");
+}
+
+let transport: BinaryClientTransport | undefined;
+afterEach(() => { transport?.stop(); transport = undefined; });
+
+describe("ConcurrencyPolicy - transport integration (kick-old)", () => {
+  test("old socket gets SESSION_IN_USE error frame, then close 4000; new socket wins", async () => {
+    const manifest = defineGame({
+      id: "g", declaredRtp: 0.5, defaultMode: "base", maxWinMultiplier: 1000,
+      modes: { base: { math: half, stakeMultiplier: 1 } },
+    });
+    const port = 19_431;
+    transport = binaryTransport({ port });
+    const t = transport;
+    const orch = createOrchestrator({
+      manifest, platform: new Wallet(),
+      // Same wiring createServer does: orchestrator kick -> transport close.
+      kickConnection: (id, reason) => t.closeConnection(id, "SESSION_IN_USE", reason),
+    });
+    await transport.start(orch);
+
+    const w1 = await tapWs(port);
+    w1.ws.send(frame(MSG_INIT_REQUEST, { sid: "dup" }));
+    await until(() => w1.frames.some((f) => f.type === MSG_INIT_RESPONSE));
+
+    const w2 = await tapWs(port);
+    w2.ws.send(frame(MSG_INIT_REQUEST, { sid: "dup" }));
+    await until(() => w2.frames.some((f) => f.type === MSG_INIT_RESPONSE));
+
+    // The first socket was kicked: a structured error frame, then the close.
+    await until(() => w1.frames.some((f) => f.type === MSG_ERROR));
+    const err = w1.frames.find((f) => f.type === MSG_ERROR)!;
+    expect(err.payload["code"]).toBe("SESSION_IN_USE");
+    const closed = await w1.closed;
+    expect(closed.code).toBe(4000);
+
+    w2.ws.close();
+  });
+});

--- a/specs/02-orchestrator.md
+++ b/specs/02-orchestrator.md
@@ -254,9 +254,31 @@ for closes  - see Spec 05) are the wallet-level backstop. Operations on
 *different* sessions are unaffected and run concurrently.
 
 The lock guards in-process ordering only; it is not a substitute for the
-wallet being the source of truth across processes. Enforcing a
-`ConcurrencyPolicy` for a *second connection* to a live session (kick-old
-vs reject-new) is separate and still pending.
+wallet being the source of truth across processes.
+
+### Connection concurrency (`ConcurrencyPolicy`)
+
+INIT arbitrates when the session is already attached to ANOTHER live
+connection (`createServer({ concurrencyPolicy })`):
+
+- **kick-old** (default): the older connection receives a
+  `SESSION_IN_USE` error frame and is closed (app close code 4000); the
+  new connection takes over. The player's newest window always wins  - two
+  open windows never silently diverge.
+- **reject-new**: the newer INIT fails with `SESSION_IN_USE`; the older
+  connection stays attached.
+- **allow**: both coexist (the pre-enforcement behaviour). Money stays
+  safe under any policy  - the per-session lock and wallet idempotency
+  hold regardless  - but coexisting windows see diverging balance views.
+
+A connection that disconnects DETACHES from its session first, so a plain
+reconnect after a drop is never policed: the policy only ever arbitrates
+two live connections. A kicked connection's late close event is ignored
+(it no longer owns the binding), so it cannot evict the new owner's
+session. Enforcement needs the transport's optional `closeConnection`
+capability for the kick; a custom transport without it degrades kick-old
+to allow with a boot-time warning. Interventions are counted in
+`rgs_session_concurrency_actions_total{action}`.
 
 ## Acceptance criteria
 

--- a/specs/04-wire-protocol.md
+++ b/specs/04-wire-protocol.md
@@ -146,6 +146,10 @@ DECODE_ERROR             msgpack payload couldn't be decoded
 MISSING_SESSION          sid required, not provided
 SESSION_NOT_FOUND        sid valid but no session in cache (INIT first)
 SESSION_INVALID          wallet rejected the session
+SESSION_IN_USE           session attached to another live connection
+                         (reject-new: sent to the NEW connection's INIT;
+                         kick-old: sent to the OLD connection, which is
+                         then closed with app close code 4000)
 INSUFFICIENT_BALANCE     pre-flight or wallet rejection on funds
 INVALID_BET              betIndex out of range, or invalid combination
 INVALID_MODE             requested mode not in manifest, or wrong kind


### PR DESCRIPTION
When a second connection INITs a session already attached to another LIVE
connection, the orchestrator now arbitrates instead of silently letting
both coexist:

- kick-old (default): the older connection receives a SESSION_IN_USE
  error frame and is closed (app code 4000); the newest window wins.
- reject-new: the newer INIT fails with SESSION_IN_USE.
- allow: the pre-enforcement coexist behaviour, kept as an escape hatch.

Money was always safe (per-session lock + wallet idempotency); what this
closes is the UX/cert gap where two open windows silently diverged - the
exact failure shape reproduced on demand in a multi-replica load test
(window balances 101850 vs 101650 against one wallet truth).

Mechanics: sessions now track a nullable connection binding; a dropped
connection DETACHES first, so a plain reconnect is never policed, and a
kicked connection's late close event no longer owns the binding so it
cannot evict the new owner's session (ownership guard in onDisconnect).
The kick travels orchestrator -> transport via the new OPTIONAL
ClientTransport.closeConnection capability (binaryTransport implements
it; a custom transport without it degrades kick-old to allow with a
boot-time warning). Interventions are counted in
rgs_session_concurrency_actions_total{action}.

Contract: ConcurrencyPolicy gains "allow"; RGSErrorCode gains
SESSION_IN_USE; ClientTransport gains closeConnection?. Specs 02/04 and
the site error table document the semantics. Tests: 6 orchestrator-level
(policies, reconnect-after-drop, late-close ownership) + 1 real-socket
integration (error frame then close 4000).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
