### PR TITLE
test+docs: pin down the per-connection scope of the transport replay guard

### DIFF
--- a/.changeset/replay-guard-scope-docs.md
+++ b/.changeset/replay-guard-scope-docs.md
@@ -1,0 +1,8 @@
+---
+"@open-rgs/core": patch
+---
+
+Document the scope of the opt-in transport replay guard: it is per-connection
+by design. A reconnect (same or different pod) starts a fresh `$seq` space with
+an empty response cache; the wallet's idempotency-key dedupe (Spec 05) is the
+cross-connection at-most-once guard. Docs/jsdoc only  - no behavior change.

--- a/packages/core/src/transport-binary.ts
+++ b/packages/core/src/transport-binary.ts
@@ -68,7 +68,10 @@ export interface BinaryTransportConfig {
    *  processes `last+1`, REPLAYS the cached response for a re-sent `last`
    *  (a dropped-response retry -> no re-run, no double settle), and REJECTS a
    *  gap or a frame missing the sequence. A client that opts in must stamp
-   *  every frame; mixing is rejected, by design. */
+   *  every frame; mixing is rejected, by design. Per-connection means per
+   *  socket: a reconnect (same or different pod) starts a fresh `$seq` space
+   *  with an empty cache  - the wallet's idempotency-key dedupe (Spec 05) is
+   *  the cross-connection at-most-once guard. */
   replayGuard?: boolean;
 }
 

--- a/packages/core/test/transport-replay-guard.test.ts
+++ b/packages/core/test/transport-replay-guard.test.ts
@@ -120,6 +120,48 @@ describe("transport replay guard (Guarantee 6)", () => {
     ws.close();
   });
 
+  test("the guard is PER-CONNECTION: a reconnect starts a fresh $seq space", async () => {
+    // Scope check (see specs/04-wire-protocol.md, "Scope"): the sequence and the
+    // cached response die with the socket. A reconnect  - same pod or another
+    // one  - gets no carry-over; cross-connection at-most-once is the wallet's
+    // idempotency-key dedupe, not the transport's.
+    const { api, spins } = countingApi();
+    const port = nextPort++;
+    transport = binaryTransport({ port, replayGuard: true });
+    await transport.start(api);
+
+    // Connection 1: seq 1..2 processed.
+    const ws1 = await openWs(port);
+    await roundtrip(ws1, frame(MSG_SPIN_REQUEST, { betIndex: 0, [WIRE_OPSEQ_KEY]: 1 }));
+    const c1r2 = await roundtrip(ws1, frame(MSG_SPIN_REQUEST, { betIndex: 0, [WIRE_OPSEQ_KEY]: 2 }));
+    expect(c1r2.payload.roundId).toBe("r-2");
+    expect(spins()).toBe(2);
+    const closed = new Promise<void>((res) => ws1.addEventListener("close", () => res()));
+    ws1.close();
+    await closed;
+
+    // Connection 2, same server. Continuing at seq 3 is a GAP (fresh space
+    // expects 1)  - rejected, orchestrator untouched.
+    const ws2 = await openWs(port);
+    const gap = await roundtrip(ws2, frame(MSG_SPIN_REQUEST, { betIndex: 0, [WIRE_OPSEQ_KEY]: 3 }));
+    expect(gap.type).toBe(0xff); // MSG_ERROR
+    expect(gap.payload.code).toBe("INVALID_FORMAT");
+    expect(spins()).toBe(2);
+
+    // Seq 1 on the new connection is a NEW operation (a fresh spin, r-3), not a
+    // replay of connection 1's seq-1 response  - the old cache is gone.
+    const r = await roundtrip(ws2, frame(MSG_SPIN_REQUEST, { betIndex: 0, [WIRE_OPSEQ_KEY]: 1 }));
+    expect(r.payload.roundId).toBe("r-3");
+    expect(spins()).toBe(3);
+
+    // And a re-send of seq 1 replays CONNECTION 2's own cached response (r-3),
+    // proving the two sequence spaces are fully independent.
+    const dup = await roundtrip(ws2, frame(MSG_SPIN_REQUEST, { betIndex: 0, [WIRE_OPSEQ_KEY]: 1 }));
+    expect(dup.payload.roundId).toBe("r-3");
+    expect(spins()).toBe(3);
+    ws2.close();
+  });
+
   test("with the guard OFF (default), a frame without $seq is processed normally", async () => {
     const { api, spins } = countingApi();
     const port = nextPort++;

--- a/specs/04-wire-protocol.md
+++ b/specs/04-wire-protocol.md
@@ -48,6 +48,16 @@ by design. It's the standard monotonic-sequence dedup for an at-least-once
 message channel, applied at the socket so it backstops the wallet's own
 idempotency rather than relying on it.
 
+**Scope.** The guard is **per-connection by design**: the sequence space and
+the cached last-response bytes live and die with the socket. A reconnect  -
+to the same pod or a different one  - starts fresh at `$seq` 1 with an empty
+cache, so a retry that straddles a reconnect gets no transport-level replay
+protection. The cross-connection (and cross-pod) at-most-once guard is the
+wallet's idempotency-key dedupe (`specs/05-platform-protocol.md`)  - that is
+the end-to-end guarantee; the transport guard only tightens the single-socket
+case. Sticky sessions do NOT change this: routing a player back to the same
+pod does not extend the guard across sockets.
+
 ## Message types
 
 | Code | Direction | Logical message            | Payload type |


### PR DESCRIPTION
## What

The opt-in transport replay guard (`binaryTransport({ replayGuard: true })`) is **per-connection** by design: a fresh socket starts a fresh `$seq` space (`lastOpSeq: 0`) and the cached last-response bytes die with the connection. That scope was implemented but never tested across a reconnect, and the spec didn't state the deployment consequence.

## Changes

- **`packages/core/test/transport-replay-guard.test.ts`** - new test: a client with the guard on sends `$seq` 1..2 on connection 1, disconnects, and opens connection 2 to the *same* server. On the new connection, `$seq` 3 is rejected as a gap (the fresh space expects 1), `$seq` 1 runs a **new** round (the old cache is gone), and a re-send of `$seq` 1 replays connection 2's *own* cached response - proving the sequence spaces are fully independent.
- **`specs/04-wire-protocol.md`** - new **Scope** paragraph in the replay-guard section: per-connection by design; reconnects (same or different pod) start fresh with no transport-level replay protection across the boundary; the wallet's idempotency-key dedupe (Spec 05) is the end-to-end at-most-once guard; sticky sessions do NOT extend the guard across sockets. (Edit confined to the replay-guard section to avoid conflicts with branches touching the error table.)
- **`packages/core/src/transport-binary.ts`** - one sentence of that scope note mirrored onto the `replayGuard` option jsdoc. No behavior change.
- Patch changeset for `@open-rgs/core` because changeset-check requires one for any `packages/*/src` touch, even jsdoc-only.

## Verification

- `bun run typecheck` green
- `bun test ./packages/core/test/transport-replay-guard.test.ts` - 5 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)