### PR TITLE
docs: ADR-007 - cross-pod resume via wallet-returned open round (design only)

### DIFF
--- a/specs/02-orchestrator.md
+++ b/specs/02-orchestrator.md
@@ -228,9 +228,12 @@ resume: {
 }
 ```
 
-Cross-process resume (after a server restart) requires a wallet
-inquiry endpoint not yet specified. Until then, restart-recovery
-operates per `manifest.recovery.onRestart` (planned).
+Cross-process resume (after a server restart or pod move) is
+wallet-driven: the fresh INIT's `wallet.openSession` returns
+`SessionInfo.openRound`, and the orchestrator re-hydrates
+`LocalSession.openRound` from it  - see **ADR-007** and Spec 05
+§"Open-round persistence & resume" (v1.7; until adapters populate it,
+restart-recovery operates per `manifest.recovery.onRestart`).
 
 ## Per-session serialization
 
@@ -305,5 +308,6 @@ to allow with a boot-time warning. Interventions are counted in
   games, run several processes (spec 07, "Multi-game deployments").
 - Should we expose a "drain" mode (reject new INITs but let in-flight
   rounds finish) for graceful shutdown? **Pending.**
-- Cross-process resume needs a `wallet.getOpenRound(sessionId)` call.
-  Should that be optional on `PlatformAdapter`? **Pending.**
+- ~~Cross-process resume needs a `wallet.getOpenRound(sessionId)`
+  call.~~ **Decided  - no new call** (ADR-007): `openSession` is the
+  inquiry; the wallet returns `SessionInfo.openRound`.

--- a/specs/05-platform-protocol.md
+++ b/specs/05-platform-protocol.md
@@ -91,6 +91,40 @@ The wallet guarantees:
 - `BalanceChangedEvent` is emitted whenever the balance changes for any
   reason (round settle, deposit, withdrawal, manual adjustment).
 
+### Open-round persistence & resume (v1.7  - adapters MAY omit until then)
+
+Decided in **ADR-007**: cross-pod / post-restart resume is
+wallet-driven  - `openSession` is the inquiry, `SessionInfo.openRound`
+is the answer. No separate `getOpenRound` RPC.
+
+While a complex round is open, the wallet MUST persist, keyed by
+session:
+
+- the `roundId` (from its own `openComplex` receipt);
+- the `bet` (plus `betIndex` / `priceMultiplier` for its native audit
+  trail  - already on `OpenComplex`);
+- the mode the round was opened in;
+- the **initial state** (`OpenComplex.initialState`) and the **last
+  state checkpoint** (the most recent `UpdateComplex.state`; the
+  initial state when no checkpoint has arrived);
+- the open timestamp.
+
+This record is cleared (or marked closed) by `closeComplex`, including
+autoclose.
+
+On `openSession`, when such a record exists, the adapter SHOULD return
+it as `SessionInfo.openRound` so a fresh INIT on **any** pod can
+re-hydrate the round (Spec 02 §Resume on reconnect). Ops never cross
+to the wallet (see below), so a wallet-built `OpenRoundResume` MAY
+carry empty `ops` / `actionLog`  - resume is then state-correct but
+render-degraded; same-pod resume keeps full fidelity.
+
+Until v1.7, adapters MAY omit all of this; the orchestrator treats an
+absent `openRound` as "nothing to resume" and
+`manifest.recovery.onRestart` applies. The autoclose backstop above is
+**unchanged**  - resume rescues the player who returns; the backstop
+settles the round of the player who never does.
+
 ### Reversal (optional)  - Guarantee 2, "One Round, One Record"
 
 `reverseRound` is **optional** and **wallet-initiated**: it exists for
@@ -259,10 +293,10 @@ specific provider's brand, product id, or wire shape.
 
 ## Open questions
 
-- Should `PlatformAdapter` expose `getOpenRound(sessionId)` for
-  cross-process resume? Optional method, only providers that support it
-  populate it; orchestrator falls back to recovery policy otherwise.
-  **Pending decision** based on which wallets we integrate next.
+- ~~Should `PlatformAdapter` expose `getOpenRound(sessionId)` for
+  cross-process resume?~~ **Decided  - no** (ADR-007): `openSession` is
+  the inquiry; the wallet returns `SessionInfo.openRound` per
+  §"Open-round persistence & resume" above.
 - Should `PlatformAdapter` expose a `listOpenSessions()` for boot-time
   recovery? Same caveats. **Pending**.
 - Idempotency key forwarding is currently not in the contract. Adding

--- a/specs/09-roadmap.md
+++ b/specs/09-roadmap.md
@@ -97,7 +97,7 @@ J  - public-surface freeze v0.5: pending
 
 | Item | Spec | Status |
 |------|------|--------|
-| Cross-process restart recovery | 02, 05 | platform adapter inquiry endpoint TBD |
+| Cross-process restart recovery | 02, 05, ADR-007 | designed  - ADR-007 (wallet returns `SessionInfo.openRound` on `openSession`); implementation v1.7 |
 | ~~Idempotency keys end-to-end~~ (core side done) | 04, 05 | orchestrator derives/generates a key on every money-moving call; forwarding onto the provider wire is each adapter's job |
 | ~~Adapter-owns-state migration~~ (done) | 04, 05 | orchestrator rebuilds sessions from SessionInfo.carry/nextMode/mathVersion (ADR-004) |
 | External API surface (casino-facing) | NEW | sketched during an early provider analysis; not yet specced |

--- a/specs/adr/007-cross-pod-resume.md
+++ b/specs/adr/007-cross-pod-resume.md
@@ -1,0 +1,111 @@
+# ADR 007  - Cross-pod resume via wallet-returned open round
+
+**Status:** Accepted
+**Date:** 2026-06-10
+
+## Context
+
+ADR-006 made the orchestrator stateless modulo an in-memory session
+cache. The cost it recorded: a mid-complex-round session survives a
+*disconnect* (same-pod resume from `LocalSession.openRound`) but not a
+*process restart or pod move*  - the cache evaporates and Spec 02 said
+"cross-process resume requires a wallet inquiry endpoint not yet
+specified."
+
+Meanwhile the contract already has the answer half-built:
+`SessionInfo.openRound?: OpenRoundResume` exists on the
+`wallet.openSession` return type. The gap is purely normative  - Spec 05
+never required adapters to persist what's needed to populate it, so no
+adapter does. This ADR closes that gap for v1.7.
+
+## Decision
+
+**1. Primary mechanism: the wallet returns the open round on
+`openSession`.** No new RPC. A fresh INIT on *any* pod calls
+`wallet.openSession` (Spec 02 fresh path); the adapter returns
+`SessionInfo.openRound` when a complex round is open, and the
+orchestrator re-hydrates `LocalSession.openRound` from it. To make that
+possible, the wallet MUST persist alongside `openComplex`  - and keep
+current via `updateComplex` checkpoints  - the round id, bet, mode, and
+initial/last state checkpoint, clearing on `closeComplex`. Normative
+wording lives in Spec 05 §"Open-round persistence & resume (v1.7)".
+
+This keeps ADR-006 intact: the wallet was already the source of truth
+for money and carry (ADR-004); it now also answers "is a round open?"
+Correctness needs **no shared store** and no sticky routing.
+
+**2. No separate `getOpenRound(sessionId)` inquiry method.**
+`openSession` *is* the inquiry  - one RPC, one source of truth, no
+second round-trip on the INIT hot path. This resolves the open
+questions in Specs 02 and 05.
+
+**3. `SessionStore` stays a deferred, optional peer package**
+(e.g. `@open-rgs/session-store-redis`  - future, not committed). It is a
+latency optimization for operators who want fast same-state failover of
+the in-memory cache, never a correctness requirement. Sketch, to be
+added to `@open-rgs/contract` only when an implementation ships:
+
+```ts
+interface SessionStore {
+  get(sid: string): Promise<StoredSession | undefined>;
+  put(sid: string, s: StoredSession, ttlMs?: number): Promise<void>;
+  touch(sid: string, ttlMs?: number): Promise<void>;  // extend TTL on activity
+  delete(sid: string): Promise<void>;
+}
+interface StoredSession {
+  openRound?: OpenRoundResume & { state: RoundState };
+  carry?: CarryState;
+  nextMode?: string;
+  balanceSeq: number;  // monotonic fence  - reject stale balance writes
+}
+```
+
+TTL semantics: an expired entry is a **cache miss** (fall through to
+wallet-driven resume), never an autoclose trigger (ADR-003 stands).
+Implementation is **deferred** (KISS): wallet-driven resume already
+covers correctness, and a store adds an infra dependency core has
+avoided so far  - no Redis to operate, back up, or fail over. We record
+the shape now so the future package can't drift into being a second
+source of truth.
+
+**4. Autoclose is reduced, not removed.** Wallet-driven resume rescues
+the round whose player *comes back*. The round whose player never
+returns still needs the Spec 05 autoclose backstop (wallet deadline,
+`sessionClosed` cascade, or adapter-derived deadline). That hard
+conformance requirement is unchanged.
+
+## Consequences
+
+**Upsides:**
+
+- Cross-pod and post-restart resume with zero new infrastructure; any
+  LB, no stickiness needed for correctness.
+- One persistence rule for adapters, enforced by the conformance suite
+  (`@open-rgs/adapter-test-kit`) once v1.7 lands.
+- The `SessionStore` shape is recorded before anyone builds it wrong.
+
+**Costs:**
+
+- Adapters take on a persistence duty (most wallets already store open
+  rounds for their own books; this codifies it). Marked v1.7  -
+  adapters MAY omit until then, and `manifest.recovery.onRestart`
+  applies as before.
+- Degraded resume fidelity cross-pod: ops never cross the wallet
+  boundary (Spec 05 §"What the wallet does NOT see"), so a
+  wallet-built `OpenRoundResume` MAY carry empty `ops`/`actionLog`.
+  Full-fidelity replay remains a same-pod feature; v1.7
+  implementation may add an optional math hook to regenerate render
+  ops and the `awaiting` hint from a state checkpoint.
+
+## Alternatives considered
+
+- **Dedicated `wallet.getOpenRound(sessionId)` RPC.** A second call on
+  every INIT, and two ways to ask one question. `openSession` already
+  returns `SessionInfo`; the field exists. Rejected.
+- **Mandatory shared session store (Redis) for resume.** Correctness
+  would then depend on infra core has never required; store-vs-wallet
+  divergence becomes a new bug class. Violates ADR-006. Rejected as a
+  requirement; kept as the optional cache above.
+- **Sticky sessions as the whole answer.** Helps reconnects, does
+  nothing for pod death or rolling restarts, and pushes a routing
+  requirement onto every operator. Rejected.

--- a/specs/adr/README.md
+++ b/specs/adr/README.md
@@ -39,6 +39,7 @@ probably writing a spec instead.
 | 004 | [Adapter owns state, RGS is pass-through](./004-adapter-owns-state.md) | Accepted |
 | 005 | [RGS generates round IDs](./005-rgs-generated-round-id.md) | Accepted |
 | 006 | [RGS is stateless modulo session cache](./006-stateless-rgs.md) | Accepted |
+| 007 | [Cross-pod resume via wallet-returned open round](./007-cross-pod-resume.md) | Accepted |
 
 ## When to write an ADR
 


### PR DESCRIPTION
## Summary

Design-only PR (no implementation, no changeset) specifying the v1.7 cross-pod resume story. Closes the gap recorded in Spec 02 ("cross-process resume requires a wallet inquiry endpoint not yet specified") and the In-flight roadmap row.

### New ADR-007 (`specs/adr/007-cross-pod-resume.md`)

- **Primary mechanism - wallet-driven resume.** `SessionInfo.openRound` already exists on the contract; the gap was purely normative. The wallet MUST persist the open round (round id, initial/last state checkpoint, bet, mode) alongside `openComplex`/`updateComplex` and SHOULD return it on `openSession` - a fresh INIT on any pod re-hydrates from it. `openSession` *is* the inquiry: no new `getOpenRound` RPC. ADR-006 statelessness intact - no shared store needed for correctness.
- **Optional `SessionStore`** (future `@open-rgs/session-store-redis` peer package) sketched in the ADR (`get`/`put`/`touch`/`delete` by sid, TTL = cache miss never autoclose, `openRound` + `carry` + `balanceSeq` payload) and **explicitly deferred** (KISS: wallet-driven resume covers correctness; a store adds an infra dependency core has avoided so far). Latency optimization only.
- **Autoclose backstop reduced, not removed** - resume rescues the player who returns; the backstop settles the round of the player who never does.

### Spec edits

- **Spec 05**: new normative subsection "Open-round persistence & resume (v1.7 - adapters MAY omit until then)"; `getOpenRound` open question resolved.
- **Spec 02**: "Resume on reconnect" cross-process paragraph now points at ADR-007; open question resolved.
- **Spec 09**: In-flight row "Cross-process restart recovery" -> "designed - ADR-007; implementation v1.7".
- **ADR index** updated.

## Verification

- `bun run typecheck` passes - no code touched (specs/ADR only, hence no changeset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)