### PR TITLE
feat(deploy): out-of-the-box observability pack

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -22,6 +22,8 @@ See `examples/` in this repo for fully-worked references.
 - `docker/compose.yml`  - local dev stack with the mock wallet.
 - `k8s/deployment.yml`  - minimal Deployment + Service manifests.
 - `k8s/hpa.yml`  - HorizontalPodAutoscaler for CPU-driven scaling.
+- `observability/`  - Prometheus scrape config + alert rules and a
+  Grafana dashboard for the standard `rgs_*` series.
 
 ## Quick start (local Docker)
 

--- a/deploy/observability/README.md
+++ b/deploy/observability/README.md
@@ -1,0 +1,82 @@
+# Observability pack
+
+Out-of-the-box monitoring for any open-rgs game server: a Prometheus
+scrape config, an alert rule group, and a Grafana dashboard built
+against the standard `rgs_*` series (see `packages/core/src/metrics-rgs.ts`
+for the authoritative list, and the "Instance identity & metrics
+scraping" section of `specs/07-deployment.md` for the contract).
+
+## Scraping /admin/metrics
+
+The metrics endpoint sits behind the admin bearer token
+(`OPEN_RGS_ADMIN_TOKEN`). Minimum viable job:
+
+```yaml
+scrape_configs:
+  - job_name: rgs
+    metrics_path: /admin/metrics
+    authorization:
+      type: Bearer
+      credentials: <admin-token>
+    static_configs:
+      - targets: ["rgs-1.internal:8080"]
+```
+
+Metrics are pod-local. Scrape **every** instance and aggregate in
+queries - never scrape through a load balancer.
+
+`prometheus-scrape.example.yml` has the full version: the static job
+above plus a `kubernetes_sd_configs` pod-discovery job that follows
+the HPA, filters on the `app: rgs-<game-id>` pod label, and normalizes
+the job label to `rgs`.
+
+## Kubernetes: make instance ids match pod names
+
+The server self-generates an `rgs-<8 hex>` instance id unless told
+otherwise. In K8s, pass the pod name via the downward API so
+`rgs_build_info{instance_id}`, `/healthz`, logs, and `kubectl` all
+agree:
+
+```yaml
+env:
+  - name: OPEN_RGS_INSTANCE_ID
+    valueFrom: { fieldRef: { fieldPath: metadata.name } }
+```
+
+Add that to the container in `deploy/k8s/deployment.yml`.
+
+## Dashboard
+
+Import `grafana-dashboard.json` (Dashboards -> New -> Import). Grafana
+prompts for a Prometheus datasource on import (`${DS_PROMETHEUS}`
+input). The `job` variable defaults to `rgs`; switch it if you named
+your scrape job differently.
+
+Panels: instance table (from `rgs_build_info`), spin rate per
+instance, platform RPC p50/p95/p99, instance births & deaths,
+sessions/WS, platform SLA (connected / flaps / errors), GGR per
+currency, live RTP vs declared, stakes/wins flow.
+
+## Alerts
+
+Load `alerts.yml` via `rule_files` in your `prometheus.yml`:
+
+```yaml
+rule_files:
+  - alerts.yml
+```
+
+What fires and why:
+
+| Alert | Severity | Meaning |
+|---|---|---|
+| `RgsPlatformDisconnected` | critical | a wallet link is down |
+| `RgsWalletSilent` | critical | connected but no successful RPC in 30s |
+| `RgsPlatformFlapping` | warning | connection bouncing |
+| `RgsRtpDrift` | warning | 6h live RTP off the declared line (noisy by nature - read the comment in the file) |
+| `RgsNegativeGgrHour` | info | house paid out more than it took in this hour; expected occasionally |
+| `RgsInstanceChurn` | warning | instance count moving fast - crash loops or eager autoscaling |
+| `RgsErrorBudget` | warning | >5% of platform RPCs failing |
+
+Thresholds are defaults for a moderately busy fleet - tune them to
+your volume before wiring a pager.

--- a/deploy/observability/alerts.yml
+++ b/deploy/observability/alerts.yml
@@ -1,0 +1,126 @@
+# Prometheus alert rules for an open-rgs fleet. Load via rule_files in
+# prometheus.yml. Thresholds are sensible defaults - tune to your
+# traffic. All series are documented in specs/07-deployment.md
+# ("Instance identity & metrics scraping").
+
+groups:
+  - name: open-rgs
+    rules:
+      # The wallet is gone for at least one instance. Players on that
+      # instance cannot bet - page someone.
+      - alert: RgsPlatformDisconnected
+        expr: min(rgs_platform_connected) == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Platform adapter disconnected"
+          description: >-
+            At least one RGS instance reports rgs_platform_connected == 0
+            for over a minute. The wallet is unreachable from that
+            instance; rounds there cannot settle.
+
+      # The connected-but-silent wallet: the socket is up but no RPC has
+      # succeeded fleet-wide in 30s. This catches a hung wallet that a
+      # connectivity gauge alone would miss.
+      - alert: RgsWalletSilent
+        expr: >-
+          (time() - max(rgs_platform_last_ok_timestamp_seconds)) > 30
+          and (min(rgs_platform_connected) == 1)
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Wallet connected but not answering"
+          description: >-
+            No RGS instance has had a successful platform RPC in over 30s
+            even though every adapter still reports connected. The wallet
+            is up but silent - likely hung or deadlocked upstream.
+
+      # Connection flapping - the wallet link is unstable even if it is
+      # nominally "up" right now.
+      - alert: RgsPlatformFlapping
+        expr: sum(rate(rgs_platform_connection_transitions_total[10m])) * 60 > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Platform connection flapping"
+          description: >-
+            The fleet is averaging more than 2 platform connection
+            transitions per minute over the last 10 minutes. Check the
+            wallet endpoint and the network path.
+
+      # Live RTP drifting from the declared line. NOTE: short-window RTP
+      # is noisy BY NATURE - a single max-win hit moves a quiet fleet by
+      # whole percentage points. 6h / 5pp is a compromise; widen both
+      # for low-traffic deployments before trusting this alert.
+      - alert: RgsRtpDrift
+        expr: >-
+          abs(
+            sum(increase(rgs_wins_minor_total[6h]))
+              / sum(increase(rgs_bets_minor_total[6h]))
+            - avg(rgs_declared_rtp)
+          ) > 0.05
+        for: 30m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Live RTP drifting from declared"
+          description: >-
+            Live RTP over the last 6h differs from the declared RTP by
+            more than 5 percentage points. Could be variance (big hits on
+            low volume), could be a math or config regression - check
+            round volume first, then the math version in rgs_build_info.
+
+      # Negative GGR for an hour: the house paid out more than it took
+      # in. EXPECTED occasionally - big hits happen, that is what max
+      # win caps are for. This is a look-at-it signal, not a page.
+      - alert: RgsNegativeGgrHour
+        expr: >-
+          sum(increase(rgs_bets_minor_total{funding="real"}[1h]))
+            - sum(increase(rgs_wins_minor_total[1h]))
+          < 0
+        for: 5m
+        labels:
+          severity: info
+        annotations:
+          summary: "Negative GGR over the last hour"
+          description: >-
+            Wins paid exceeded real stakes over the last hour. This is
+            expected occasionally - a single big hit can flip an hour
+            negative. Glance at the win distribution; only investigate
+            if it repeats or correlates with an RTP drift alert.
+
+      # Instances appearing/disappearing rapidly - crash loops or an
+      # over-eager autoscaler. Each rgs_build_info series is one
+      # instance; the count moving a lot means churn.
+      - alert: RgsInstanceChurn
+        expr: changes(count(rgs_build_info)[30m:1m]) > 6
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "RGS instance count churning"
+          description: >-
+            The number of live instances (rgs_build_info series) changed
+            more than 6 times in 30 minutes. Normal HPA scaling moves
+            this too - tune the threshold to your autoscaler's cadence,
+            but sustained churn usually means crash-looping pods.
+
+      # Platform RPC error budget: more than 5% of wallet calls failing.
+      - alert: RgsErrorBudget
+        expr: >-
+          sum(rate(rgs_platform_call_errors_total[5m]))
+            / sum(rate(rgs_platform_call_duration_seconds_count[5m]))
+          > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Platform RPC error rate above 5%"
+          description: >-
+            More than 5% of platform adapter RPCs failed over the last
+            5 minutes. Break down rgs_platform_call_errors_total by
+            method and reason (timeout / disconnected / ...) to locate
+            the failing call.

--- a/deploy/observability/grafana-dashboard.json
+++ b/deploy/observability/grafana-dashboard.json
@@ -1,0 +1,225 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping /admin/metrics on every RGS instance",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    { "type": "datasource", "id": "prometheus", "name": "Prometheus", "version": "1.0.0" }
+  ],
+  "uid": "open-rgs-fleet",
+  "title": "open-rgs fleet",
+  "tags": ["open-rgs"],
+  "timezone": "browser",
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "schemaVersion": 39,
+  "templating": {
+    "list": [
+      {
+        "name": "job",
+        "label": "job",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+        "query": "label_values(rgs_build_info, job)",
+        "refresh": 2,
+        "current": { "text": "rgs", "value": "rgs" },
+        "includeAll": false,
+        "multi": false
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Live instances",
+      "gridPos": { "h": 5, "w": 4, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "refId": "A", "expr": "count(up{job=\"$job\"} == 1)" }],
+      "options": { "colorMode": "value", "graphMode": "area" },
+      "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "none" }, "overrides": [] }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Platform connected (fleet)",
+      "gridPos": { "h": 5, "w": 4, "x": 4, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "refId": "A", "expr": "sum(rgs_platform_connected{job=\"$job\"}) / count(rgs_platform_connected{job=\"$job\"})" }],
+      "options": { "colorMode": "background", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "yellow", "value": 0.5 },
+            { "color": "green", "value": 1 }
+          ] }
+        }, "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Wallet silence (s since last OK answer)",
+      "gridPos": { "h": 5, "w": 4, "x": 8, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "refId": "A", "expr": "max(time() - rgs_platform_last_ok_timestamp_seconds{job=\"$job\"})" }],
+      "options": { "colorMode": "background", "graphMode": "none" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s", "decimals": 1,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "green", "value": null },
+            { "color": "yellow", "value": 10 },
+            { "color": "red", "value": 30 }
+          ] }
+        }, "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "table",
+      "title": "Instances",
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{ "refId": "A", "expr": "rgs_build_info{job=\"$job\"}", "format": "table", "instant": true }],
+      "transformations": [
+        { "id": "organize", "options": { "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true }, "renameByName": { "instance_id": "instance id", "instance": "scrape target" } } }
+      ],
+      "options": {},
+      "fieldConfig": { "defaults": {}, "overrides": [] }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Spin rate per instance (rounds/s)",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{
+        "refId": "A",
+        "expr": "sum by (instance_id) (rate(rgs_round_total{job=\"$job\"}[$__rate_interval]) * on(instance) group_left(instance_id) rgs_build_info{job=\"$job\"})",
+        "legendFormat": "{{instance_id}}"
+      }],
+      "options": { "legend": { "displayMode": "table", "placement": "right", "calcs": ["lastNotNull"] } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 12, "lineWidth": 2 }, "unit": "ops" }, "overrides": [] }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Platform RPC latency (p50 / p95 / p99)",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "histogram_quantile(0.50, sum by (le) (rate(rgs_platform_call_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])))", "legendFormat": "p50" },
+        { "refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(rgs_platform_call_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])))", "legendFormat": "p95" },
+        { "refId": "C", "expr": "histogram_quantile(0.99, sum by (le) (rate(rgs_platform_call_duration_seconds_bucket{job=\"$job\"}[$__rate_interval])))", "legendFormat": "p99" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 8, "lineWidth": 2 }, "unit": "s" }, "overrides": [] }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Instances over time (births & deaths)",
+      "gridPos": { "h": 7, "w": 8, "x": 0, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "count(up{job=\"$job\"} == 1)", "legendFormat": "scrape-up" },
+        { "refId": "B", "expr": "count(rgs_build_info{job=\"$job\"})", "legendFormat": "build_info series" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 15, "lineWidth": 2, "stepAfter": true }, "min": 0, "unit": "none", "decimals": 0 }, "overrides": [] }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Sessions & WS connections per instance",
+      "gridPos": { "h": 7, "w": 8, "x": 8, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance_id) (rgs_sessions_active{job=\"$job\"} * on(instance) group_left(instance_id) rgs_build_info{job=\"$job\"})", "legendFormat": "sessions {{instance_id}}" },
+        { "refId": "B", "expr": "sum by (instance_id) (rgs_ws_connections_active{job=\"$job\"} * on(instance) group_left(instance_id) rgs_build_info{job=\"$job\"})", "legendFormat": "ws {{instance_id}}" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 8, "lineWidth": 1 }, "min": 0 }, "overrides": [] }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "Platform SLA: connected / flaps / errors",
+      "gridPos": { "h": 7, "w": 8, "x": 16, "y": 13 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "min(rgs_platform_connected{job=\"$job\"})", "legendFormat": "all connected (min)" },
+        { "refId": "B", "expr": "sum(rate(rgs_platform_connection_transitions_total{job=\"$job\"}[$__rate_interval])) * 60", "legendFormat": "flaps/min" },
+        { "refId": "C", "expr": "sum(rate(rgs_platform_call_errors_total{job=\"$job\"}[$__rate_interval])) * 60", "legendFormat": "rpc errors/min" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 10, "lineWidth": 2 }, "min": 0 }, "overrides": [] }
+    },
+    {
+      "id": 10,
+      "type": "stat",
+      "title": "GGR per currency (since deploy, minor units)",
+      "gridPos": { "h": 6, "w": 6, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [{
+        "refId": "A",
+        "expr": "sum by (currency) (rgs_bets_minor_total{job=\"$job\",funding=\"real\"}) - sum by (currency) (rgs_wins_minor_total{job=\"$job\"})",
+        "legendFormat": "{{currency}}",
+        "instant": true
+      }],
+      "options": { "colorMode": "value", "graphMode": "area", "textMode": "value_and_name" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none", "decimals": 0,
+          "thresholds": { "mode": "absolute", "steps": [
+            { "color": "red", "value": null },
+            { "color": "green", "value": 0 }
+          ] }
+        }, "overrides": []
+      }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Live RTP (1h window) vs declared",
+      "gridPos": { "h": 6, "w": 9, "x": 6, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum(increase(rgs_wins_minor_total{job=\"$job\"}[1h])) / sum(increase(rgs_bets_minor_total{job=\"$job\"}[1h]))", "legendFormat": "live RTP (1h)" },
+        { "refId": "B", "expr": "avg(rgs_declared_rtp{job=\"$job\"})", "legendFormat": "declared" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": {
+        "defaults": { "custom": { "fillOpacity": 8, "lineWidth": 2 }, "unit": "percentunit", "min": 0, "max": 1.5 },
+        "overrides": [
+          { "matcher": { "id": "byName", "options": "declared" }, "properties": [
+            { "id": "custom.lineStyle", "value": { "dash": [10, 10], "fill": "dash" } },
+            { "id": "color", "value": { "mode": "fixed", "fixedColor": "orange" } }
+          ] }
+        ]
+      }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Stakes vs wins flow (minor units / s)",
+      "gridPos": { "h": 6, "w": 9, "x": 15, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "targets": [
+        { "refId": "A", "expr": "sum by (currency) (rate(rgs_bets_minor_total{job=\"$job\"}[$__rate_interval]))", "legendFormat": "stakes {{currency}}" },
+        { "refId": "B", "expr": "sum by (currency) (rate(rgs_wins_minor_total{job=\"$job\"}[$__rate_interval]))", "legendFormat": "wins {{currency}}" }
+      ],
+      "options": { "legend": { "displayMode": "list", "placement": "bottom" } },
+      "fieldConfig": { "defaults": { "custom": { "fillOpacity": 10, "lineWidth": 2 }, "min": 0 }, "overrides": [] }
+    }
+  ]
+}

--- a/deploy/observability/prometheus-scrape.example.yml
+++ b/deploy/observability/prometheus-scrape.example.yml
@@ -1,0 +1,55 @@
+# Example Prometheus scrape config for open-rgs game servers.
+#
+# /admin/metrics is bearer-token protected (OPEN_RGS_ADMIN_TOKEN on the
+# server side). Metrics are pod-local: scrape EVERY instance and
+# aggregate in dashboards - never put a load balancer between
+# Prometheus and the pods.
+#
+# Two jobs below - static targets and Kubernetes pod discovery. Pick
+# the one that matches your environment; you don't need both. Keep the
+# job label "rgs" either way (the dashboard and alert rules default to
+# it).
+
+scrape_configs:
+  # --- Option A: static targets (bare metal / docker compose) --------
+  - job_name: rgs
+    metrics_path: /admin/metrics
+    authorization:
+      type: Bearer
+      credentials: <admin-token>          # = OPEN_RGS_ADMIN_TOKEN
+      # ...or keep it out of this file:
+      # credentials_file: /etc/prometheus/secrets/rgs-admin-token
+    static_configs:
+      - targets:
+          - rgs-1.internal:8080
+          - rgs-2.internal:8080
+
+  # --- Option B: Kubernetes pod discovery ----------------------------
+  # Discovers every pod of the Deployment, so scraping follows the HPA.
+  - job_name: rgs-k8s
+    metrics_path: /admin/metrics
+    authorization:
+      type: Bearer
+      credentials_file: /etc/prometheus/secrets/rgs-admin-token
+    kubernetes_sd_configs:
+      - role: pod
+        namespaces:
+          names: [<namespace>]
+    relabel_configs:
+      # Keep only the game-server pods (app: rgs-<game-id> in
+      # deploy/k8s/deployment.yml).
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: rgs-.*
+        action: keep
+      # Scrape the named "ws" container port (admin shares it).
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        regex: ws
+        action: keep
+      # Normalize the job label so dashboards/alerts see job="rgs".
+      - target_label: job
+        replacement: rgs
+      # Pod name as the instance label - matches OPEN_RGS_INSTANCE_ID
+      # when set via the downward API, so `instance` and `instance_id`
+      # line up one-to-one.
+      - source_labels: [__meta_kubernetes_pod_name]
+        target_label: instance

--- a/specs/07-deployment.md
+++ b/specs/07-deployment.md
@@ -309,6 +309,8 @@ await createServer({ manifest: gambleCherry, platform, transport: binaryTranspor
 - Should we publish a Helm chart? **Probably eventually**; Spec 09
   tracks it.
 - Should the deploy template include a Prometheus ServiceMonitor?
-  Metrics ship today on `/admin/metrics` (see "Instance identity &
-  metrics scraping" above); a ServiceMonitor example lands with the
-  observability pack under `deploy/`. **Open: template only.**
+  **Resolved: plain scrape config instead.** The observability pack
+  (`deploy/observability/` - scrape config, alert rules, Grafana
+  dashboard) uses a raw `kubernetes_sd_configs` job, which works on
+  any Prometheus; prometheus-operator users can transcribe it into a
+  ServiceMonitor/PodMonitor trivially.


### PR DESCRIPTION
## What

New `deploy/observability/` - monitoring that works on import for any open-rgs game server, generalized from a dashboard and scrape setup proven against the real metric series.

- **`prometheus-scrape.example.yml`** - one static-target job and one `kubernetes_sd_configs` pod-discovery job, both bearer-auth against `/admin/metrics`. The k8s job follows the HPA, filters on the `app: rgs-<game-id>` label, normalizes `job="rgs"`, and sets `instance` to the pod name so it lines up with `OPEN_RGS_INSTANCE_ID` from the downward API.
- **`alerts.yml`** - 7 rules, `promtool check rules` clean:
  | Alert | Severity |
  |---|---|
  | RgsPlatformDisconnected | critical |
  | RgsWalletSilent (connected-but-silent wallet) | critical |
  | RgsPlatformFlapping | warning |
  | RgsRtpDrift (annotated: short-window RTP is noisy by nature) | warning |
  | RgsNegativeGgrHour (annotated: expected occasionally - look-at-it signal) | info |
  | RgsInstanceChurn | warning |
  | RgsErrorBudget | warning |
- **`grafana-dashboard.json`** - fleet dashboard: instances table from `rgs_build_info`, spin rate per `instance_id`, platform RPC p50/p95/p99, instances over time, sessions/WS, platform SLA row, GGR per currency, live RTP vs declared, stakes/wins flow. Testbed-only labels (`replica_id`, `rig_state`) and the rig datasource uid removed; uses the `${DS_PROMETHEUS}` input convention (Grafana prompts on import) and a templated `job` variable defaulting to `rgs`.
- **`README.md`** - terse wiring guide matching `deploy/README.md`'s voice.

Also: `deploy/README.md` gains an `observability/` bullet, and the spec 07 open question about a ServiceMonitor is resolved in favor of a plain scrape config (spec + code land together).

## Verification

- `promtool check rules alerts.yml` - 7 rules, SUCCESS
- `promtool check config --syntax-only prometheus-scrape.example.yml` - SUCCESS
- Dashboard JSON parses
- `bun run typecheck` - clean (no code touched)

No changeset: `deploy/` templates aren't a published package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)