### PR TITLE
feat(adapter-test-kit): opt-in concurrency certification

### DIFF
--- a/.changeset/adapter-test-kit-concurrency.md
+++ b/.changeset/adapter-test-kit-concurrency.md
@@ -1,0 +1,20 @@
+---
+"@open-rgs/adapter-test-kit": minor
+---
+
+Opt-in concurrency certification: `runConformance(adapter, { concurrency:
+true })` (CLI `--concurrency`) adds four checks for the surface the
+orchestrator's per-session lock does NOT shield an adapter from. Parallel
+settles across distinct sessions must conserve each session's balance; the
+same idempotencyKey fired twice CONCURRENTLY (an in-flight duplicate, not
+the sequential retry the existing dedupe check covers) must settle exactly
+once with one receipt; concurrent reversals of two stacked rounds must stay
+latest-first per the contract's CONCURRENCY rule on `reverseRound`  - both
+legal serializations accepted, over-refund and double-credit failed  - with
+a clean skip when the adapter doesn't implement the optional `reverseRound`;
+and a plain sequential settle must still reconcile after the storms. Off by
+default (reported as skips, like skipComplex) because the checks open
+derived sessions and assume independent balances  - mock/sandbox wallets
+only. Validated against the reference @open-rgs/platform-mock, plus a
+deliberately racy adapter (read-then-write dedupe gap) the new duplicate
+check flags where the sequential one passes it.

--- a/bun.lock
+++ b/bun.lock
@@ -33,7 +33,7 @@
     },
     "packages/adapter-kit": {
       "name": "@open-rgs/adapter-kit",
-      "version": "0.4.1",
+      "version": "1.0.1",
       "dependencies": {
         "@open-rgs/contract": "0.3.1",
         "@open-rgs/log": "0.1.0",
@@ -45,17 +45,20 @@
     },
     "packages/adapter-test-kit": {
       "name": "@open-rgs/adapter-test-kit",
-      "version": "0.2.1",
+      "version": "1.0.1",
       "bin": {
         "open-rgs-adapter-conform": "src/cli.ts",
       },
       "dependencies": {
-        "@open-rgs/contract": "0.3.1",
+        "@open-rgs/contract": "1.1.0",
+      },
+      "devDependencies": {
+        "@open-rgs/platform-mock": "1.2.0",
       },
     },
     "packages/client": {
       "name": "@open-rgs/client",
-      "version": "0.2.1",
+      "version": "1.0.1",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.3",
         "@open-rgs/contract": "0.3.1",
@@ -68,11 +71,11 @@
     },
     "packages/contract": {
       "name": "@open-rgs/contract",
-      "version": "0.3.1",
+      "version": "1.1.0",
     },
     "packages/core": {
       "name": "@open-rgs/core",
-      "version": "0.5.1",
+      "version": "1.6.0",
       "dependencies": {
         "@msgpack/msgpack": "^3.1.3",
         "@open-rgs/contract": "0.3.1",
@@ -82,18 +85,18 @@
     },
     "packages/log": {
       "name": "@open-rgs/log",
-      "version": "0.1.0",
+      "version": "1.0.0",
     },
     "packages/platform-mock": {
       "name": "@open-rgs/platform-mock",
-      "version": "0.3.1",
+      "version": "1.2.0",
       "dependencies": {
-        "@open-rgs/contract": "0.3.1",
+        "@open-rgs/contract": "1.1.0",
       },
     },
     "packages/simulator": {
       "name": "@open-rgs/simulator",
-      "version": "0.2.1",
+      "version": "1.2.0",
       "bin": {
         "open-rgs-sim": "./src/cli.ts",
       },

--- a/packages/adapter-test-kit/README.md
+++ b/packages/adapter-test-kit/README.md
@@ -23,8 +23,8 @@ bunx open-rgs-adapter-conform \
 Required: `--adapter <module>` (npm package or path) and `--export <name>`
 (adapter class export, default `default`). Optional: `--opts <json>` (or
 env `ADAPTER_OPTS_JSON`), `--skip-complex`, `--skip-events`,
-`--timeout-ms <n>`, `--out-json <path>`. Exit code is 0 only if every
-non-skipped check is `ok`.
+`--concurrency`, `--timeout-ms <n>`, `--out-json <path>`. Exit code is 0
+only if every non-skipped check is `ok`.
 
 ## Use (as a library)
 
@@ -52,6 +52,7 @@ if (report.summary.fail > 0) process.exit(1);   // fail your CI
 | simple-round | settleSimple (zero-win + with-win), debits + credits balance     |
 | complex-round | openComplex -> updateComplex (optional) -> closeComplex            |
 | events      | adapter emits at least one event; balanceChanged shape is valid   |
+| concurrency | opt-in (`concurrency: true`): parallel cross-session settles conserve per-session balances; the same idempotencyKey fired twice concurrently settles exactly once; concurrent reversals stay latest-first (no over-refund); a plain settle still reconciles afterwards |
 
 Each check returns one of `ok | warn | fail | skip` with a one-line
 message on non-ok.
@@ -63,8 +64,16 @@ runConformance(adapter, {
   fixture: { bet: 250, betIndex: 3 },   // override the session shape
   skipComplex: true,                    // platform is simple-rounds-only
   skipEvents: true,                     // platform doesn't push events
+  concurrency: true,                    // opt IN to the concurrency checks
 });
 ```
+
+`concurrency: true` is opt-in (reported as skips otherwise) because the
+checks open derived sessions (`<sessionId>-conc-*`) and assume each maps
+to an independent balance  - true for a mock or sandboxed wallet, which is
+the only thing this suite should ever point at. The reversal-interleave
+check runs only when the adapter implements the optional `reverseRound`;
+it skips cleanly otherwise.
 
 ## What it doesn't do
 
@@ -80,5 +89,5 @@ runConformance(adapter, {
 
 ```bash
 bun install
-bun test    # 5 cases against a tiny in-test adapter
+bun test    # in-test adapters + the reference @open-rgs/platform-mock
 ```

--- a/packages/adapter-test-kit/package.json
+++ b/packages/adapter-test-kit/package.json
@@ -40,5 +40,8 @@
   },
   "dependencies": {
     "@open-rgs/contract": "1.1.0"
+  },
+  "devDependencies": {
+    "@open-rgs/platform-mock": "1.2.0"
   }
 }

--- a/packages/adapter-test-kit/src/cli.ts
+++ b/packages/adapter-test-kit/src/cli.ts
@@ -20,6 +20,9 @@
 //                           be read from env ADAPTER_OPTS_JSON.
 //   --skip-complex          skip complex-round checks
 //   --skip-events           skip event checks
+//   --concurrency           opt in to concurrency certification (parallel
+//                           settles, in-flight duplicate keys, reversal
+//                           interleave)  - mock/sandbox adapters only
 //   --timeout-ms <n>        per-check deadline, default 5000
 //   --out-md  <path>        write markdown report here
 //   --out-json <path>       write JSON report here
@@ -38,6 +41,7 @@ interface Args {
   opts?: string;
   skipComplex?: boolean;
   skipEvents?: boolean;
+  concurrency?: boolean;
   timeoutMs?: number;
   outMd?: string;
   outJson?: string;
@@ -58,6 +62,7 @@ function parseArgs(argv: string[]): Args {
       case "--opts":        out.opts       = next(); break;
       case "--skip-complex": out.skipComplex = true; break;
       case "--skip-events":  out.skipEvents  = true; break;
+      case "--concurrency":  out.concurrency = true; break;
       case "--timeout-ms":  out.timeoutMs  = Number(next()); break;
       case "--out-md":      out.outMd      = next(); break;
       case "--out-json":    out.outJson    = next(); break;
@@ -81,6 +86,7 @@ Optional:
   --opts    <json>        JSON constructor options. Or env ADAPTER_OPTS_JSON.
   --skip-complex          skip complex-round checks
   --skip-events           skip event checks
+  --concurrency           opt in to concurrency certification (mock/sandbox only)
   --timeout-ms <n>        per-check deadline (default 5000)
   --out-md  <path>        write markdown report
   --out-json <path>       write JSON report
@@ -125,6 +131,7 @@ const adapter = new (Ctor as new (opts: unknown) => PlatformAdapter)(ctorOpts);
 const runOpts: RunOptions = {};
 if (args.skipComplex) runOpts.skipComplex = true;
 if (args.skipEvents)  runOpts.skipEvents  = true;
+if (args.concurrency) runOpts.concurrency = true;
 if (typeof args.timeoutMs === "number") runOpts.perCheckTimeoutMs = args.timeoutMs;
 
 console.error(`-> Running conformance against ${modSpec} (export=${exportName})`);

--- a/packages/adapter-test-kit/src/runner.ts
+++ b/packages/adapter-test-kit/src/runner.ts
@@ -10,6 +10,12 @@
 //     receipt  - the property the contract relies on (was advertised but
 //     never actually run; audit H13)
 //   - error paths: overspend, unknown session, and bad round id are rejected
+//   - concurrency (opt-in via { concurrency: true }): cross-session parallel
+//     settles conserve per-session balances; the SAME idempotencyKey fired
+//     twice CONCURRENTLY (in-flight duplicate, not the sequential retry
+//     above) settles exactly once; reverseRound stays latest-first under
+//     interleaved reversal fire; and a plain settle still reconciles after
+//     the storms
 //   - each check is bounded by perCheckTimeoutMs (enforced via Promise.race)
 //
 // The suite doesn't mutate real-money state because it expects a mock
@@ -30,6 +36,13 @@ export interface RunOptions {
   skipComplex?: boolean;
   /** Skip event checks (use for a wallet that doesn't push events). */
   skipEvents?: boolean;
+  /** Opt IN to concurrency certification: parallel cross-session settles,
+   *  in-flight duplicate idempotency keys, and reversal interleave. Off by
+   *  default (reported as skips, mirroring skipComplex) because it opens
+   *  extra derived sessions and assumes each maps to an independent balance
+   *  - true for a mock or sandboxed wallet, the only thing this suite
+   *  should ever point at. */
+  concurrency?: boolean;
 }
 
 export async function runConformance(
@@ -291,6 +304,160 @@ export async function runConformance(
         if (e.type !== "balanceChanged") continue;
         if (typeof e.balance !== "number") throw new Error("balanceChanged.balance not a number");
         if (typeof e.reason !== "string")  throw new Error("balanceChanged.reason not a string");
+      }
+    });
+  }
+
+  // --- concurrency (opt-in) ---------------------------------------
+  // The orchestrator serializes client traffic per session, so an adapter
+  // never sees two client-driven calls racing on ONE session  - but it DOES
+  // see parallel traffic across sessions, retried settles whose duplicate
+  // arrives while the original is still in flight, and wallet-initiated
+  // reversals that bypass the per-session lock entirely (the contract's
+  // CONCURRENCY rule on ReverseRound). These checks exercise exactly that
+  // surface. Opt-in: they open derived sessions ("<sessionId>-conc-*") and
+  // assume each has an independent balance, which holds for a mock or
+  // sandboxed wallet.
+  if (!opts.concurrency) {
+    const reason = "concurrency not enabled (opt in with { concurrency: true })";
+    skip("concurrency.parallel-distinct-settles", "concurrency", "parallel settles across distinct sessions conserve each session's balance", reason);
+    skip("concurrency.duplicate-key-parallel", "concurrency", "the same idempotencyKey fired twice concurrently settles exactly once", reason);
+    skip("concurrency.reverse-interleave", "concurrency", "concurrent reversals of two stacked rounds stay latest-first (no over-refund)", reason);
+    skip("concurrency.post-storm-settle", "concurrency", "a plain sequential settle still reconciles after the concurrent storms", reason);
+  } else {
+    const cost = fixture.bet * fixture.priceMultiplier;
+    const settle = (sessionId: string, idempotencyKey: string, win: number): Promise<RoundReceipt> =>
+      adapter.settleSimple({
+        sessionId,
+        bet: fixture.bet,
+        betIndex: fixture.betIndex,
+        priceMultiplier: fixture.priceMultiplier,
+        win,
+        multiplier: win === 0 ? 0 : Math.round(win / fixture.bet),
+        type: win === 0 ? "loss" : "win",
+        roundState: "",
+        idempotencyKey,
+      });
+
+    await run("concurrency.parallel-distinct-settles", "concurrency", "parallel settles across distinct sessions conserve each session's balance", async () => {
+      // N sessions in parallel, M settles sequential WITHIN each session
+      //  - the orchestrator serializes per session, so cross-session
+      // parallelism is the only interleaving a conformant adapter must
+      // survive. Per session: final == start - sum(costs) + sum(wins).
+      const N = 8, M = 5;
+      const problems: string[] = [];
+      await Promise.all(Array.from({ length: N }, async (_, i) => {
+        const sid = `${fixture.sessionId}-conc-p${i}`;
+        const start = (await adapter.openSession(sid, `${fixture.connectionId}-conc-p${i}`)).balance;
+        let wins = 0;
+        let last: RoundReceipt | undefined;
+        for (let j = 0; j < M; j++) {
+          const win = j % 2 === 0 ? 0 : fixture.bet * 2;   // mix losses and wins
+          last = await settle(sid, `conc-p${i}-${j}`, win);
+          wins += win;
+        }
+        const expected = start - M * cost + wins;
+        if (last!.balance !== expected) {
+          problems.push(`${sid}: final balance ${last!.balance} != expected ${expected} (start ${start}, ${M} settles)`);
+        }
+      }));
+      if (problems.length > 0) {
+        throw new Error(`cross-session interference  - per-session conservation broken: ${problems.join("; ")}`);
+      }
+    });
+
+    await run("concurrency.duplicate-key-parallel", "concurrency", "the same idempotencyKey fired twice concurrently settles exactly once", async () => {
+      // The in-flight duplicate race: the sequential dedupe check above
+      // sends the duplicate AFTER the original resolved; here both are in
+      // flight at once (a retry racing its own original). Both must resolve
+      // to the SAME receipt and money must move exactly once.
+      const sid = `${fixture.sessionId}-conc-dup`;
+      const start = (await adapter.openSession(sid, `${fixture.connectionId}-conc-dup`)).balance;
+      const win = fixture.bet * 2;
+      const req: SettleSimple = {
+        sessionId: sid,
+        bet: fixture.bet,
+        betIndex: fixture.betIndex,
+        priceMultiplier: fixture.priceMultiplier,
+        win,
+        multiplier: 2,
+        type: "win",
+        roundState: "",
+        idempotencyKey: "conc-dup-parallel-1",   // SAME key, both calls
+      };
+      const [a, b] = await Promise.all([adapter.settleSimple(req), adapter.settleSimple({ ...req })]);
+      if (a.roundId !== b.roundId) {
+        throw new Error(`concurrent duplicates produced two rounds (${a.roundId} vs ${b.roundId})  - the dedupe has a read-then-write race`);
+      }
+      if (a.balance !== b.balance) {
+        throw new Error(`concurrent duplicates disagree on balance (${a.balance} vs ${b.balance})`);
+      }
+      const after = (await adapter.openSession(sid, `${fixture.connectionId}-conc-dup-2`)).balance;
+      const expected = start - cost + win;
+      if (after !== expected) {
+        throw new Error(`money moved more than once under the in-flight duplicate: balance ${after} != expected ${expected} (start ${start})`);
+      }
+    });
+
+    if (typeof adapter.reverseRound !== "function") {
+      skip("concurrency.reverse-interleave", "concurrency", "concurrent reversals of two stacked rounds stay latest-first (no over-refund)", "adapter does not implement reverseRound (optional)");
+    } else {
+      await run("concurrency.reverse-interleave", "concurrency", "concurrent reversals of two stacked rounds stay latest-first (no over-refund)", async () => {
+        // Settle A then B, then fire reverseRound(A) and reverseRound(B)
+        // concurrently. Reversal is wallet-initiated and bypasses the
+        // per-session lock, so the adapter alone must order these. Two
+        // serializations are legal:
+        //   - A first: A is not latest -> no-op "not-latest-round"; B then
+        //     reverses -> final balance is post-A.
+        //   - B first: B reverses (A becomes latest); A then legally
+        //     reverses too -> final balance is pre-A.
+        // Anything else  - over-refund, double-credit, B refused  - fails.
+        // Both rounds are net LOSSES on purpose: with only debits in play,
+        // "final > pre-A balance" is a strict over-refund invariant (a
+        // reversal credited more than the rounds ever took).
+        const sid = `${fixture.sessionId}-conc-rev`;
+        const bal0 = (await adapter.openSession(sid, `${fixture.connectionId}-conc-rev`)).balance;
+        const rA = await settle(sid, "conc-rev-a", 0);
+        const balA = rA.balance;
+        const rB = await settle(sid, "conc-rev-b", 0);
+        const [revA, revB] = await Promise.all([
+          adapter.reverseRound!({ sessionId: sid, roundId: rA.roundId, reason: "conformance-interleave", idempotencyKey: "conc-rev-key-a" }),
+          adapter.reverseRound!({ sessionId: sid, roundId: rB.roundId, reason: "conformance-interleave", idempotencyKey: "conc-rev-key-b" }),
+        ]);
+        const after = (await adapter.openSession(sid, `${fixture.connectionId}-conc-rev-2`)).balance;
+        if (after > bal0) {
+          throw new Error(`over-refund: balance ${after} > pre-round ${bal0}  - reversals credited more than the rounds moved`);
+        }
+        if (!revB.reversed) {
+          throw new Error(`the latest round (B) must be reversible, got no-op "${revB.reason ?? "(no reason)"}"`);
+        }
+        if (revA.reversed) {
+          // Legal only as the B-first serialization: both undone, balance
+          // back to the pre-A snapshot.
+          if (after !== bal0) {
+            throw new Error(`both rounds reversed but balance ${after} != pre-A ${bal0}  - reversal restored the wrong snapshot`);
+          }
+        } else {
+          if (revA.reason !== "not-latest-round") {
+            throw new Error(`A was refused with "${revA.reason ?? "(no reason)"}"  - expected "not-latest-round" while B sat on top`);
+          }
+          if (after !== balA) {
+            throw new Error(`only B reversed but balance ${after} != post-A ${balA}  - B's reversal restored the wrong snapshot`);
+          }
+        }
+      });
+    }
+
+    await run("concurrency.post-storm-settle", "concurrency", "a plain sequential settle still reconciles after the concurrent storms", async () => {
+      // Re-read a stormed session and run one boring settle  - the adapter's
+      // bookkeeping must come out of the races consistent, not just lucky.
+      const sid = `${fixture.sessionId}-conc-dup`;
+      const before = (await adapter.openSession(sid, `${fixture.connectionId}-conc-after`)).balance;
+      const win = fixture.bet;
+      const r = await settle(sid, "conc-after-1", win);
+      const expected = before - cost + win;
+      if (r.balance !== expected) {
+        throw new Error(`post-storm settle does not reconcile: balance ${r.balance} != expected ${expected} (before ${before})`);
       }
     });
   }

--- a/packages/adapter-test-kit/test/runner.test.ts
+++ b/packages/adapter-test-kit/test/runner.test.ts
@@ -1,9 +1,12 @@
-// Smoke: run conformance against a known-good adapter (MockPlatform-like
-// hand-rolled inside this file so we don't drag platform-mock as a
-// devDependency just for this test).
+// Smoke: run conformance against a known-good adapter (a tiny hand-rolled
+// one for the cheap checks), plus the real reference adapter
+// (@open-rgs/platform-mock, a devDependency) for the opt-in concurrency
+// certification  - that's the adapter the contract points authors at, so the
+// kit and the mock must agree.
 
 import { describe, expect, test } from "bun:test";
 import type { PlatformAdapter, PlatformEvent, SessionInfo, SettleSimple, OpenComplex, CloseComplex, RoundReceipt } from "@open-rgs/contract";
+import { MockPlatform } from "@open-rgs/platform-mock";
 import { runConformance, mdConformanceReport } from "../src/index.js";
 
 // A genuinely SAFE reference adapter: dedupes idempotency keys, rejects
@@ -11,30 +14,33 @@ import { runConformance, mdConformanceReport } from "../src/index.js";
 // teeth (H13), so "known-good" must actually be good.
 class TinyAdapter implements PlatformAdapter {
   private connected = false;
-  private balance = 10_000;
+  private balances = new Map<string, number>();   // per session, like a real wallet
   private nextRoundId = 1;
   private handlers: ((e: PlatformEvent) => void)[] = [];
   private openRoundId: string | undefined;
-  private sessions = new Set<string>();
   private receipts = new Map<string, RoundReceipt>();
 
   async connect()    { this.connected = true; }
   disconnect()       { this.connected = false; }
   get isHealthy()    { return this.connected; }
-  get diagnostics()  { return { adapter: "tiny", version: "0.0.1", balance: this.balance }; }
+  get diagnostics()  { return { adapter: "tiny", version: "0.0.1", sessions: this.balances.size }; }
   onEvent(h: (e: PlatformEvent) => void) { this.handlers.push(h); }
   private emit(e: PlatformEvent) { for (const h of this.handlers) h(e); }
   private replay(k?: string) { return k !== undefined ? this.receipts.get(k) : undefined; }
   private remember(k: string | undefined, r: RoundReceipt) { if (k !== undefined) this.receipts.set(k, r); return r; }
-  private assertSession(id: string) { if (!this.sessions.has(id)) throw new Error(`SessionInvalid: ${id}`); }
+  private mustBalance(id: string): number {
+    const b = this.balances.get(id);
+    if (b === undefined) throw new Error(`SessionInvalid: ${id}`);
+    return b;
+  }
 
   async openSession(sessionId: string): Promise<SessionInfo> {
-    this.sessions.add(sessionId);
+    if (!this.balances.has(sessionId)) this.balances.set(sessionId, 10_000);
     return {
       sessionId,
       currency: "USD",
       currencyDecimals: 2,
-      balance: this.balance,
+      balance: this.balances.get(sessionId)!,
       allowedBets: [10, 50, 100, 500],
       defaultBetIndex: 2,
     };
@@ -43,35 +49,38 @@ class TinyAdapter implements PlatformAdapter {
   async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
     const dup = this.replay(req.idempotencyKey);
     if (dup) return dup;
-    this.assertSession(req.sessionId);
-    if (req.bet > this.balance) throw new Error("InsufficientFunds");
-    this.balance = this.balance - req.bet + req.win;
+    const bal = this.mustBalance(req.sessionId);
+    if (req.bet > bal) throw new Error("InsufficientFunds");
+    const next = bal - req.bet + req.win;
+    this.balances.set(req.sessionId, next);
     const roundId = `r-${this.nextRoundId++}`;
-    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: this.balance, reason: "spin" });
-    return this.remember(req.idempotencyKey, { roundId, balance: this.balance });
+    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: next, reason: "spin" });
+    return this.remember(req.idempotencyKey, { roundId, balance: next });
   }
 
   async openComplex(req: OpenComplex): Promise<RoundReceipt> {
     const dup = this.replay(req.idempotencyKey);
     if (dup) return dup;
-    this.assertSession(req.sessionId);
-    if (req.bet > this.balance) throw new Error("InsufficientFunds");
-    this.balance -= req.bet;
+    const bal = this.mustBalance(req.sessionId);
+    if (req.bet > bal) throw new Error("InsufficientFunds");
+    const next = bal - req.bet;
+    this.balances.set(req.sessionId, next);
     const roundId = `r-${this.nextRoundId++}`;
     this.openRoundId = roundId;
-    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: this.balance, reason: "open" });
-    return this.remember(req.idempotencyKey, { roundId, balance: this.balance });
+    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: next, reason: "open" });
+    return this.remember(req.idempotencyKey, { roundId, balance: next });
   }
 
   async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
     const dup = this.replay(req.idempotencyKey);
     if (dup) return dup;
-    this.assertSession(req.sessionId);
+    const bal = this.mustBalance(req.sessionId);
     if (this.openRoundId !== req.roundId) throw new Error("round mismatch");
-    this.balance += req.win;
+    const next = bal + req.win;
+    this.balances.set(req.sessionId, next);
     this.openRoundId = undefined;
-    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: this.balance, reason: "close" });
-    return this.remember(req.idempotencyKey, { roundId: req.roundId, balance: this.balance });
+    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: next, reason: "close" });
+    return this.remember(req.idempotencyKey, { roundId: req.roundId, balance: next });
   }
 }
 
@@ -120,6 +129,91 @@ class NaiveAdapter implements PlatformAdapter {
   async openComplex(req: OpenComplex): Promise<RoundReceipt> { this.balance -= req.bet; return { roundId: `r-${this.n++}`, balance: this.balance }; }
   async closeComplex(req: CloseComplex): Promise<RoundReceipt> { this.balance += req.win; return { roundId: req.roundId, balance: this.balance }; }
 }
+
+// Racy adapter: dedupes idempotency keys, but with a read-then-write gap  -
+// it checks the receipt map, AWAITS, then records. Sequential retries are
+// deduped fine (the old test would pass it); two IN-FLIGHT duplicates both
+// pass the read before either writes, and money moves twice. This is the
+// race concurrency.duplicate-key-parallel exists to catch.
+class RacyAdapter implements PlatformAdapter {
+  private connected = false;
+  private balances = new Map<string, number>();
+  private receipts = new Map<string, RoundReceipt>();
+  private n = 1;
+  async connect() { this.connected = true; }
+  disconnect() { this.connected = false; }
+  get isHealthy() { return this.connected; }
+  get diagnostics() { return { adapter: "racy", version: "0.0.1" }; }
+  onEvent(_h: (e: PlatformEvent) => void) { /* pushes nothing */ }
+  async openSession(sessionId: string): Promise<SessionInfo> {
+    if (!this.balances.has(sessionId)) this.balances.set(sessionId, 1_000_000);
+    return { sessionId, currency: "USD", currencyDecimals: 2, balance: this.balances.get(sessionId)!, allowedBets: [10, 50, 100, 500], defaultBetIndex: 2 };
+  }
+  async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+    const key = req.idempotencyKey;
+    if (key !== undefined) {
+      const dup = this.receipts.get(key);
+      if (dup) return dup;
+    }
+    // THE BUG: yield between the dedupe read and the write.
+    await new Promise(r => setTimeout(r, 1));
+    const bal = this.balances.get(req.sessionId);
+    if (bal === undefined) throw new Error(`SessionInvalid: ${req.sessionId}`);
+    if (req.bet > bal) throw new Error("InsufficientFunds");
+    const next = bal - req.bet + req.win;
+    this.balances.set(req.sessionId, next);
+    const receipt: RoundReceipt = { roundId: `r-${this.n++}`, balance: next };
+    if (key !== undefined) this.receipts.set(key, receipt);
+    return receipt;
+  }
+  async openComplex(): Promise<RoundReceipt> { throw new Error("not exercised (skipComplex)"); }
+  async closeComplex(): Promise<RoundReceipt> { throw new Error("not exercised (skipComplex)"); }
+}
+
+describe("concurrency certification (opt-in)", () => {
+  test("reported as skips unless { concurrency: true }", async () => {
+    const r = await runConformance(new TinyAdapter());
+    const conc = r.checks.filter(c => c.group === "concurrency");
+    expect(conc.map(c => c.id)).toEqual([
+      "concurrency.parallel-distinct-settles",
+      "concurrency.duplicate-key-parallel",
+      "concurrency.reverse-interleave",
+      "concurrency.post-storm-settle",
+    ]);
+    expect(conc.every(c => c.status === "skip")).toBe(true);
+  });
+
+  test("reference MockPlatform passes the full suite including concurrency", async () => {
+    const r = await runConformance(new MockPlatform(), { concurrency: true });
+    expect(r.summary.fail).toBe(0);
+    const status = (id: string) => r.checks.find(c => c.id === id)?.status;
+    expect(status("concurrency.parallel-distinct-settles")).toBe("ok");
+    expect(status("concurrency.duplicate-key-parallel")).toBe("ok");
+    // MockPlatform implements reverseRound, so the interleave check RUNS.
+    expect(status("concurrency.reverse-interleave")).toBe("ok");
+    expect(status("concurrency.post-storm-settle")).toBe("ok");
+  });
+
+  test("reverse-interleave skips cleanly when the adapter has no reverseRound", async () => {
+    const r = await runConformance(new TinyAdapter(), { concurrency: true });
+    expect(r.summary.fail).toBe(0);   // the other three concurrency checks pass
+    const rev = r.checks.find(c => c.id === "concurrency.reverse-interleave");
+    expect(rev?.status).toBe("skip");
+    expect(rev?.message).toContain("reverseRound");
+  });
+
+  test("an adapter whose dedupe has a read-then-write race is FLAGGED", async () => {
+    const r = await runConformance(new RacyAdapter(), { skipComplex: true, skipEvents: true, concurrency: true });
+    const status = (id: string) => r.checks.find(c => c.id === id)?.status;
+    // Sequential dedupe looks fine - the duplicate arrives after the write...
+    expect(status("idempotency.duplicate-key")).toBe("ok");
+    // ...but the in-flight duplicate settles twice.
+    expect(status("concurrency.duplicate-key-parallel")).toBe("fail");
+    // The race is in the dedupe, not the ledger - distinct keys stay sound.
+    expect(status("concurrency.parallel-distinct-settles")).toBe("ok");
+    expect(status("concurrency.post-storm-settle")).toBe("ok");
+  });
+});
 
 describe("runConformance has teeth (H13)", () => {
   test("an adapter that doesn't dedupe / reject overspend / reject unknown session is FLAGGED", async () => {

--- a/specs/12-adapter-cookbook.md
+++ b/specs/12-adapter-cookbook.md
@@ -278,18 +278,43 @@ inside the same method. Idempotency keys cover the retry case.
 
 ## What the conformance suite does NOT check
 
-These are real concerns that fall outside `runConformance(adapter)`  -
-add adapter-specific tests for them:
+Since the concurrency certification landed, `runConformance(adapter,
+{ concurrency: true })` DOES now check (opt-in, against a mock or
+sandboxed wallet only):
+
+- Parallel settles across distinct sessions conserving each session's
+  balance (the cross-session parallelism the orchestrator's per-session
+  lock does NOT shield the adapter from)
+- The same idempotencyKey fired twice CONCURRENTLY settling exactly
+  once  - the in-flight duplicate race the sequential dedupe check never
+  exercised
+- Concurrent reversals of two stacked rounds staying latest-first:
+  the latest round reverses, an older round under a newer one is
+  refused `not-latest-round` (or legally reverses if the newer round's
+  reversal landed first), and no serialization over-refunds
+- A plain sequential settle still reconciling after the storms
+
+These are real concerns that still fall outside `runConformance(adapter)`
+ - add adapter-specific tests for them:
 
 - Idempotency dedupe on the upstream side (kit-only assertion is "the
   key field is passed; upstream behaviour with it is the upstream's
   problem")
+- Cross-PROCESS duplicate keys  - two RGS pods retrying the same settle
+  against one upstream; the kit races duplicates inside one process,
+  which says nothing about an adapter whose dedupe lives in per-process
+  memory (the contract's DURABILITY rule  - restarts and multi-pod need
+  an external store, and only an integration rig proves it)
+- Durability of reversed-round tracking across adapter restarts (same
+  rule  - the kit can't restart your process mid-run)
 - Currency precision edge cases (kit assumes integer minor units)
-- Concurrent open rounds for the same session (the kit's fixture is
-  single-session, single-round)
+- Concurrent open rounds for the same session (the orchestrator
+  serializes client traffic per session by design; the kit doesn't
+  simulate a misbehaving orchestrator)
 - Bet ladder boundary enforcement (orchestrator enforces; kit doesn't
   exercise)
-- Network resilience under specific failure modes (use chaos tests)
+- Network resilience under specific failure modes  - fault injection,
+  dropped responses mid-settle, reconnect storms (use chaos tests)
 
 ---
 


### PR DESCRIPTION
## What

Additive, opt-in concurrency certification in `@open-rgs/adapter-test-kit`: `runConformance(adapter, { concurrency: true })` (CLI `--concurrency`), reported as clean skips when not enabled — same semantics as `skipComplex`.

The orchestrator serializes client traffic per session, but an adapter still sees (a) parallel traffic across sessions, (b) retried settles whose duplicate arrives while the original is in flight, and (c) wallet-initiated `reverseRound` calls that bypass the per-session lock entirely (the contract's new CONCURRENCY rule). These checks certify exactly that surface.

## New checks (group `concurrency`)

| Check | Certifies |
|---|---|
| `parallel-distinct-settles` | 8 sessions x 5 settles, `Promise.all` across sessions, sequential within — each session's final balance == start − sum(costs) + sum(wins) |
| `duplicate-key-parallel` | the SAME `idempotencyKey` fired twice concurrently resolves to one roundId + one balance, and money moves exactly once (verified via follow-up `openSession` read) — the in-flight race the sequential dedupe check never exercised |
| `reverse-interleave` | settle A then B, fire `reverseRound(A)` + `reverseRound(B)` concurrently; accepts both legal serializations (B reverses + A refused `not-latest-round`, or B lands first and A then legally reverses); fails over-refund / wrong-snapshot / B refused. Both rounds are net losses so `final > pre-A` is a strict over-refund invariant. Skips cleanly when the adapter lacks the optional `reverseRound` |
| `post-storm-settle` | a plain sequential settle on a stormed session still reconciles |

## Validation

- Reference `@open-rgs/platform-mock` (new devDependency of the kit's tests) passes the full suite incl. concurrency.
- A deliberately racy adapter (read-then-write gap in its dedupe) passes the sequential dedupe check but is flagged by `duplicate-key-parallel` — proof the new check has teeth.
- TinyAdapter in the package test now keeps per-session balances like a real wallet.

## Docs

- Spec 12 "what the kit does NOT check": concurrency items moved to a now-checked list; kept honest about what still isn't — cross-process duplicate keys, restart durability of reversed-round tracking, network fault injection.
- README: new coverage row + knob, with the mock/sandbox-only caveat.
- Changeset: minor for `@open-rgs/adapter-test-kit`.

`bun run typecheck` + `bun test` (repo root): 358 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)