### PR TITLE
fix(adapter-test-kit): overspend probe must trip amount-blind wires - drive priceMultiplier, not bet

### DIFF
--- a/.changeset/test-kit-overspend-amount-blind.md
+++ b/.changeset/test-kit-overspend-amount-blind.md
@@ -1,0 +1,10 @@
+---
+"@open-rgs/adapter-test-kit": patch
+---
+
+The overspend conformance probe now drives the cost through
+`priceMultiplier` (with a consistent oversized `bet`) instead of a doctored
+`bet` alone. Amount-blind wallet wires - platforms that recompute the debit
+from their own bet ladder and ignore wire amounts - never saw the old
+probe's giant `bet`, so the check could not trip them. Every wallet shape
+sees `ladder/bet x priceMultiplier` exceed the conformance balance.

--- a/packages/adapter-test-kit/src/runner.ts
+++ b/packages/adapter-test-kit/src/runner.ts
@@ -210,14 +210,20 @@ export async function runConformance(
 
   // --- error paths ------------------------------------------------
   await run("errors.insufficient-funds", "errors", "a bet exceeding balance is rejected", async () => {
+    // Overspend is driven through priceMultiplier, NOT a giant `bet`:
+    // amount-blind wires (the platform recomputes cost from its own bet
+    // ladder and ignores the wire amount) never see a doctored `bet`, but
+    // EVERY wallet shape sees cost = ladder/bet x priceMultiplier explode
+    // past the balance. 1e6 x any conformance ladder entry is far above
+    // any conformance balance.
     await expectReject(() => adapter.settleSimple({
       sessionId: fixture.sessionId,
-      bet: 10_000_000_000,           // far above any conformance balance
+      bet: fixture.bet * 1_000_000,
       betIndex: fixture.betIndex,
-      priceMultiplier: fixture.priceMultiplier,
+      priceMultiplier: 1_000_000,
       win: 0, multiplier: 0, type: "loss", roundState: "",
       idempotencyKey: "conf-overspend-1",
-    }), "settle with bet > balance was accepted  - a wallet MUST reject overspend");
+    }), "settle with cost > balance was accepted  - a wallet MUST reject overspend");
   });
 
   await run("errors.unknown-session", "errors", "a settle on an unopened session is rejected", async () => {


### PR DESCRIPTION
Found by pointing the kit at the first amount-blind adapter wire (a
platform that recomputes the debit from its own bet ladder and ignores
wire amounts): the old probe's bet=10_000_000_000 never reached the
wallet's cost computation, so the overspend check could not trip. Driving
priceMultiplier (with a consistent oversized bet) makes the cost explode
past the balance for EVERY wallet shape - amount-carrying and
ladder-computing alike.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
