### PR TITLE
docs: name the slot libraries that the last release added

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,13 +37,25 @@ open-rgs/
 |   +-- adapter-test-kit/      @open-rgs/adapter-test-kit  - conformance suite
 |   +-- client/                @open-rgs/client  - tiny WS client
 |   +-- simulator/             @open-rgs/simulator  - RTP simulator + reports
+|   |
+|   |   the slot libraries, one package per mechanic:
+|   +-- grid/ weights/ selectors/          substrate
+|   +-- fill/ markov/ recipes/ strips/     making a board
+|   +-- paytable/ pay-lines/ pay-ways/     what a board is worth
+|   +-- pay-anywhere/ pay-cluster/
+|   +-- multiways/ big-symbols/ scatters/  reels, blocks, spawns
+|   +-- symbols/                           mystery, transforms, walking wilds
+|   +-- cascade/ holdwin/ freespins/       features
+|   +-- picks/ gamble/ meters/
 +-- apps/
     +-- site/                  Astro docs site -> open-rgs.dev
 ```
 
 ## What's shipped
 
-- All published `@open-rgs/*` packages (adapter-artube is private, see below)
+- All published `@open-rgs/*` packages: the engine (contract, core, log,
+  platform-mock, adapter-kit, adapter-test-kit, client, simulator) plus 19
+  slot libraries. adapter-artube is private, see below
 - `apps/site`: public docs site (Astro static SSG)
 - Specs `00-10` + `12` + ADRs
 - `deploy/`: reference Docker + k8s templates

--- a/README.md
+++ b/README.md
@@ -149,7 +149,12 @@ enforces each guarantee, what it prevents, and how an integrator must not break 
 | `@open-rgs/adapter-test-kit` | conformance suite for any PlatformAdapter implementation |
 | `@open-rgs/client` | tiny TS WebSocket client (Bun / Node / browser) |
 | `@open-rgs/simulator` | per-mode RTP / hit-rate / mark simulator + reports; fast WASM & native-Zig batch tiers |
-| `@open-rgs/grid`, `weights`, `pay-lines`, `pay-ways`, `cascade`, `holdwin`, ... | the slot libraries: one small package per mechanic ([full set](https://open-rgs.dev/extension)) |
+| **slot libraries** | one small package per mechanic, each an ordinary import ([all of them](https://open-rgs.dev/extension)) |
+| `grid` `weights` `selectors` | the substrate: shape, weighted draws, cell selection |
+| `fill` `markov` `recipes` `strips` | making a board: per-cell draws, clumping, declared mixtures, classic reels |
+| `paytable` `pay-lines` `pay-ways` `pay-anywhere` `pay-cluster` | what a board is worth |
+| `multiways` `big-symbols` `scatters` `symbols` | reel heights, blocks, spawned scatters, symbol mechanics |
+| `cascade` `holdwin` `freespins` `picks` `gamble` `meters` | features: tumbles, respins, free spins, pick bonuses, gambles, collection meters |
 
 ## Build a game
 
@@ -171,7 +176,7 @@ Plug points (each is one interface):
 - **Transport** -> implement `ClientTransport`. Two ship: `binaryTransport` (binary-msgpack over WebSocket, the default) and `restTransport` (plain HTTP and JSON, for tooling and clients that cannot hold a socket open)
 - **Deferred close** -> wrap a simple math with `withDeferredClose` so the client finishes the round explicitly, and an abandoned round can be replayed and closed later
 - **Math** -> `loadTsMath` (default) or `loadWasmMath`; both return the same `MathModule`
-- **Slot libraries** -> `@open-rgs/grid`, `pay-lines`, `cascade`, `holdwin` and friends, imported like any package
+- **Slot libraries** -> 19 packages from `@open-rgs/grid` to `@open-rgs/freespins`, imported like any package
 - **Compiled math** -> ship a WASM kernel (`loadWasmMath`) authored in Zig/Rust; run it fail-closed under a worker pool (`createMathPool`)
 - **Metrics / logs** -> bring your own registry / formatter
 - **Idempotency** -> configurable per RPC

--- a/specs/00-overview.md
+++ b/specs/00-overview.md
@@ -127,6 +127,9 @@ open-rgs/
 |   +-- core/                  @open-rgs/core  - runtime
 |   +-- platform-mock/           @open-rgs/platform-mock  - dev/test wallet
 |   +-- simulator/             @open-rgs/simulator  - RTP simulator + `open-rgs-sim` CLI
+|   +-- <slot libraries>/       one package per mechanic (grid, weights, pay-*,
+|                               cascade, holdwin, freespins, picks, gamble,
+|                               symbols, meters, strips, ...)
 +-- examples/
 |   +-- hello-spin/            example: the smallest working server
 |   +-- gamble-slot/           example: complex round with a gamble


### PR DESCRIPTION
Six packages shipped in #62 without appearing in any of the three places a reader looks for the set:

- the README's package table said "and friends"
- CLAUDE.md's repo layout listed the nine engine packages as though that were all of them
- spec 00's tree did the same

All three now name them, grouped by purpose rather than alphabetically: substrate, making a board, what a board is worth, reels and symbols, features.

Docs only, no source changes.