### PR TITLE
fix(site): theme-aware code colours and figures, and a page for carry

### DIFF
--- a/apps/site/src/components/Anim.astro
+++ b/apps/site/src/components/Anim.astro
@@ -474,6 +474,20 @@ const n = (k: number) => Array.from({ length: k });
   .num { font-family: var(--mono, monospace); color: var(--fg, #ccc); font-size: 0.85rem; }
   .num.big2 { font-size: 1.1rem; color: #0E6B62; }
 
+  /* Figure fills. A cell painted with white at 5% is invisible on the light
+     theme's cream page, so the two states a board has - holding something, or
+     empty - are palette entries with a value per theme. */
+  .anim {
+    --fig-coin: rgba(14, 107, 98, .22);
+    --fig-coin-fg: #0a4a44;
+    --fig-empty: rgba(0, 0, 0, .07);
+  }
+  :root[data-theme="dark"] .anim {
+    --fig-coin: rgba(14, 107, 98, .3);
+    --fig-coin-fg: #7fd8cb;
+    --fig-empty: rgba(255, 255, 255, .07);
+  }
+
   .a { background: #0E6B62; border-color: #0E6B62; }
   .b { background: #8A5A15; border-color: #8A5A15; }
   .c { background: #4A6570; border-color: #4A6570; }
@@ -685,8 +699,8 @@ const n = (k: number) => Array.from({ length: k });
   /* --- strips: a fixed reel, a window that slides over it ------------------ */
   .strip { position: relative; display: flex; flex-direction: column; gap: 2px; }
   .strip i {
-    width: 26px; height: 15px; border-radius: 2px; background: rgba(255,255,255,.06);
-    color: #9a9a9a; font-family: var(--mono, monospace); font-size: .62rem; font-style: normal;
+    width: 26px; height: 15px; border-radius: 2px; background: var(--fig-empty);
+    color: var(--fg-mute, #888); font-family: var(--mono, monospace); font-size: .62rem; font-style: normal;
     display: flex; align-items: center; justify-content: center;
   }
   .strip .win {
@@ -730,11 +744,11 @@ const n = (k: number) => Array.from({ length: k });
 
   /* the spun cells change, the held ones do not */
   @keyframes reSpin { 0%,45%{opacity:1} 50%{opacity:.15} 55%,100%{opacity:1} }
-  .hwc.spun { background: rgba(255,255,255,.06); color: #9a9a9a; animation: reSpin 3s infinite; }
+  .hwc.spun { background: var(--fig-empty); color: var(--fg-mute, #888); animation: reSpin 3s infinite; }
   .hwc.spun.s2 { animation-delay: .06s } .hwc.spun.s3 { animation-delay: .12s }
 
   /* --- picks: boxes open one at a time, a wheel lands on one segment ------- */
-  .hwc.box { background: rgba(255,255,255,.08); color: #b9b9b9; }
+  .hwc.box { background: var(--fig-empty); color: var(--fg-mute, #888); }
   @keyframes boxOpen { 0%,20%{opacity:1} 30%,100%{opacity:.16} }
   .b2{animation:boxOpen 5s infinite .6s}.b5{animation:boxOpen 5s infinite 1.4s}
   .b3{animation:boxOpen 5s infinite 2.2s}
@@ -750,12 +764,12 @@ const n = (k: number) => Array.from({ length: k });
     display: flex; align-items: center; justify-content: center;
     font-family: var(--mono, monospace); font-size: .78rem;
   }
-  .hwc.coin { background: rgba(14,107,98,.22); color: #7fd8cb; }
-  .hwc.hole { background: rgba(255,255,255,.05); }
+  .hwc.coin { background: var(--fig-coin); color: var(--fig-coin-fg); }
+  .hwc.hole { background: var(--fig-empty); }
 
   /* landing: three cells take a coin, one after another */
   @keyframes landIn { 0%,20%{opacity:0;transform:translateY(-8px)} 30%,100%{opacity:1;transform:none} }
-  .hwc.land { background: rgba(14,107,98,.22); color: #7fd8cb; opacity: 0; }
+  .hwc.land { background: var(--fig-coin); color: var(--fig-coin-fg); opacity: 0; }
   .l1{animation:landIn 5s infinite}.l2{animation:landIn 5s infinite 1.2s}.l3{animation:landIn 5s infinite 2.4s}
 
   /* collector: the others empty out, its total climbs */
@@ -772,16 +786,16 @@ const n = (k: number) => Array.from({ length: k });
   }
 
   /* mystery: hidden cells flip together to one value */
-  .hwc.q { background: rgba(255,255,255,.09); color: #b9b9b9; }
+  .hwc.q { background: var(--fig-empty); color: var(--fg-mute, #888); }
   .hwc.q .flip {
     position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
-    background: rgba(14,107,98,.22); color: #7fd8cb; border-radius: 3px;
+    background: var(--fig-coin); color: var(--fig-coin-fg); border-radius: 3px;
     opacity: 0; animation: show 4.5s infinite;
   }
   .hwc.q .flip.f1 { animation-delay: .07s } .hwc.q .flip.f2 { animation-delay: .14s }
 
   /* a factor printed on the cell, then a second one stacking onto it */
-  .hwc.xcell { background: rgba(14,107,98,.22); color: #7fd8cb; outline: 1px solid rgba(14,107,98,.55); outline-offset: 1px; }
+  .hwc.xcell { background: var(--fig-coin); color: var(--fig-coin-fg); outline: 1px solid #0E6B62; outline-offset: 1px; }
   .hwc .badge {
     position: absolute; right: -6px; top: -7px; padding: 0 3px; border-radius: 2px;
     background: #0E6B62; color: #041614; font-size: .6rem; font-weight: 700;
@@ -799,8 +813,8 @@ const n = (k: number) => Array.from({ length: k });
   @keyframes show { 0%,55%{opacity:0} 65%,100%{opacity:1} }
 
   /* Empty cells that keep trying, and the one that takes. */
-  @keyframes tryLand { 0%,100%{opacity:.14} 46%{opacity:.14} 52%{opacity:1;background:#0E6B62} }
-  .empty { opacity: .14; }
+  @keyframes tryLand { 0%,100%{opacity:.34} 46%{opacity:.34} 52%{opacity:1;background:#0E6B62} }
+  .empty { opacity: .34; }
   .e0{animation:tryLand 4s infinite .0s}.e1{animation:tryLand 4s infinite 1.1s}
   .e2{animation:tryLand 4s infinite 2.2s}.e3{animation:tryLand 4s infinite 3.0s}
   .e4{animation:tryLand 4s infinite .6s}

--- a/apps/site/src/components/Code.astro
+++ b/apps/site/src/components/Code.astro
@@ -57,8 +57,13 @@ function highlight(src: string): string {
     border-radius: 0;
     margin: 0 0 1rem;
   }
-  .hl :global(.c-str) { color: #c7a96b; }
-  .hl :global(.c-key) { color: #6fc3b5; }
-  .hl :global(.c-num) { color: #d99a7a; }
-  .hl :global(.c-fn)  { color: #8fb8d8; }
+  /* Token colours come in two sets. The originals were picked against a dark
+     panel and hardcoded, so on the light theme - which is the default, since
+     the site follows the OS - they sat pale-on-pale and the highlighting read
+     as plain text. Each token now has a light value and a dark one, and the
+     dark set is the original. */
+  .hl :global(.c-str) { color: var(--code-str); }
+  .hl :global(.c-key) { color: var(--code-key); }
+  .hl :global(.c-num) { color: var(--code-num); }
+  .hl :global(.c-fn)  { color: var(--code-fn); }
 </style>

--- a/apps/site/src/layouts/BaseLayout.astro
+++ b/apps/site/src/layouts/BaseLayout.astro
@@ -269,6 +269,11 @@ const jsonLd = isLanding
         --bg:        #fbf9f3;
         --bg-soft:   #f3f0e6;
         --bg-code:   #f1ede0;
+        /* code tokens, dark enough to read on the light panel */
+        --code-str:  #7d6218;
+        --code-key:  #0f6b62;
+        --code-num:  #a04f22;
+        --code-fn:   #2f5f8a;
         --fg:        #1a1a1a;
         --fg-mute:   #5a5650;
         --fg-faint:  #8a857c;
@@ -283,6 +288,11 @@ const jsonLd = isLanding
         --bg:        #16140f;
         --bg-soft:   #1d1b16;
         --bg-code:   #1f1d17;
+        /* the original set, picked against the dark panel */
+        --code-str:  #c7a96b;
+        --code-key:  #6fc3b5;
+        --code-num:  #d99a7a;
+        --code-fn:   #8fb8d8;
         --fg:        #e6e0d0;
         --fg-mute:   #a09a8a;
         --fg-faint:  #706a5e;

--- a/apps/site/src/pages/carry.astro
+++ b/apps/site/src/pages/carry.astro
@@ -1,0 +1,79 @@
+---
+import BaseLayout from "../layouts/BaseLayout.astro";
+import Code from "../components/Code.astro";
+---
+
+<BaseLayout
+  title="Carry, state that outlives a round"
+  description="How cross-round math state is threaded, who stores it, what happens on reconnect, and why it is discarded when the math version changes."
+>
+  <main>
+    <h1>Carry</h1>
+
+    <p class="lede">The one thing a round leaves behind.</p>
+
+    <p>A round is a pure function of its state and its randomness. Carry is how the <em>next</em> round gets the state: an opaque string the math returns at the end of a round and receives at the start of the following one. Progress meters, a bonus counter, a gamble pot, "the next spin is a free one" all live in it, and nothing else in the engine looks inside.</p>
+
+    <h2 data-section="&sect; 1">The loop</h2>
+
+    <p>The math writes it, the engine passes it to the wallet with the money, the wallet stores it, and the engine reads it back when the session next opens.</p>
+
+    <Code code={`// the math returns it with the outcome
+play(prev, ctx) {
+  const meter = prev ? JSON.parse(prev).meter : 0;
+  return {
+    multiplier: 0,
+    ops: [],
+    type: "loss",
+    carry: JSON.stringify({ meter: meter + 1 }),
+  };
+}
+
+// the engine hands the previous one back on the next round
+play(prev, ctx)   // prev === '{"meter":1}'`} />
+
+    <p>Two rules make that work. The math never stores anything itself, because a math instance is shared by every player on the server: state kept in a module variable belongs to whichever session touched it last. And the format is the math's own business, since the engine treats it as an opaque string.</p>
+
+    <h2 data-section="&sect; 2">The wallet stores it, not the engine</h2>
+
+    <p>The orchestrator keeps carry in memory for a live session, but that copy is a cache. The durable one goes to the wallet inside the same call that moves the money, and comes back on <code>openSession</code>.</p>
+
+    <Code code={`// simple round: roundState IS the carry, since it opens and closes at once
+settleSimple({ sessionId, bet, win, roundState, mathVersion });
+
+// complex round: carry is separate from the round's own final state
+closeComplex({ sessionId, roundId, finalState, carry, mathVersion });
+
+// and it comes back next time the session opens
+openSession(sid) -> { balance, carry, mathVersion, ... }`} />
+
+    <p>That is <a href="https://github.com/open-rgs/open-rgs/blob/main/specs/adr/004-adapter-owns-state.md">ADR-004</a>, and it is what makes the RGS stateless: any pod can serve the next round, because the state arrives with the session rather than living on the machine that dealt the last one. It also means carry rides the same write as the balance, so a round that never paid never leaves progress behind. That is <a href="/overview">Guarantee 1</a>, and it is why "just cache it" is not an alternative.</p>
+
+    <p>An adapter that drops carry produces a game that works perfectly until a player reconnects, and then quietly restarts their progress. The conformance suite checks the round trip for exactly that reason.</p>
+
+    <h2 data-section="&sect; 3">Reconnects</h2>
+
+    <p>A player who drops mid-session and comes back gets their carry from the wallet on the fresh INIT. A player who drops mid-<em>round</em> is a different case: the round is still open, so the engine resumes it from the round's own state and the carry is untouched until that round closes.</p>
+
+    <h2 data-section="&sect; 4">A new math version discards it</h2>
+
+    <p>Carry is written by one version of a math and read by another only if you let it. The engine stores <code>mathVersion</code> beside the carry, and on INIT it compares that against the loaded math:</p>
+
+    <Code code={`// SessionInfo comes back with carry + mathVersion
+// if mathVersion !== the loaded math's version, the carry is dropped
+// and the session starts fresh, with a warn-level log line`} />
+
+    <p>Dropping it is the conservative choice, and the alternative is worse than it sounds: a meter written as <code>{"{ level: 3 }"}</code> by yesterday's math and read as <code>{"{ level, multiplier }"}</code> by today's is not a crash, it is a game paying the wrong thing to one player in a way nothing else will notice. Bump <code>math.version</code> whenever the carry's shape changes, and the engine handles the rest.</p>
+
+    <h2 data-section="&sect; 5">Keep it small, and keep it yours</h2>
+
+    <ul>
+      <li><strong>Small.</strong> It crosses the wire on every settle and is stored per session. A JSON blob of a few fields is right; a board snapshot is not.</li>
+      <li><strong>Yours.</strong> The engine never parses it. Version it inside if you want migrations rather than discards.</li>
+      <li><strong>Not a ledger.</strong> Money lives in the wallet. Carry is what the math needs to keep playing, not a record of what it paid.</li>
+      <li><strong>Not a session.</strong> A promo pool, a balance and an open round are engine concepts with their own fields.</li>
+    </ul>
+
+    <p>A simple round has no separate carry field on the wire: <code>roundState</code> doubles as it, because a simple round opens and closes in the same call, so this round's final state <em>is</em> what the next one starts from. A complex round has both, and they are different things: <code>finalState</code> is what this round ended as, <code>carry</code> is what the next one begins with.</p>
+  </main>
+</BaseLayout>

--- a/apps/site/src/pages/index.astro
+++ b/apps/site/src/pages/index.astro
@@ -48,6 +48,7 @@ await createServer({
       <li><a href="/extension">Extensions</a>: <span class="dim">grid, reels, pays, cascade, hold &amp; win. One small package per concern</span></li>
       <li><a href="/math">Math . simple</a>: <span class="dim">single-call rounds: slots, instant-win, dice, plinko</span></li>
       <li><a href="/complex">Math . complex</a>: <span class="dim">open / step / close: Mines, Chicken-Road, gamble, crash</span></li>
+      <li><a href="/carry">Carry</a>: <span class="dim">state that outlives a round: who stores it, and when it is discarded</span></li>
       <li><a href="/adapter">Platform adapter</a>: <span class="dim">wallet, sessions, money flow</span></li>
       <li><a href="/admin">Admin &amp; probes</a>: <span class="dim">/livez, /readyz, /healthz, /admin/*, metrics</span></li>
       <li><a href="/errors">Errors</a>: <span class="dim">canonical error vocabulary</span></li>


### PR DESCRIPTION
Three things, two of which turned out to be the same bug.

## Syntax highlighting

Not broken so much as invisible. The deployed HTML carries the `c-key` / `c-str` / `c-num` / `c-fn` spans and the scoped rule that colours them, but the four colours were picked against a dark panel and written as literals. On the light theme's cream panel they sit at **1.8:1** contrast, which reads as plain text.

Each token now has a value per theme. The dark set is unchanged; the light set is measured against the panel it is actually drawn on:

| token | before (light) | after (light) | dark |
|---|---|---|---|
| keyword | 1.77:1 | **5.43:1** | 8.14:1 |
| string | 1.92:1 | **4.94:1** | 7.47:1 |
| number | 2.03:1 | **4.93:1** | 7.10:1 |
| call | 1.79:1 | **5.74:1** | 8.04:1 |

## The animated figures

Same mistake, hidden better. Cells were painted with white at 5-9% opacity, which is invisible on a cream page, so the boards in the newer explainers (hold & win, strips, picks, free spins) rendered as empty outlines. "Holding something" and "empty" are palette entries now, with a value per theme.

Both were reproducible in a local `astro build`, so this was never a deploy problem.

## Carry

It had no page. It is the one piece of state that outlives a round, and the thing an adapter is most likely to drop, and it was documented only across ADR-004, spec 02 and spec 05.

[`/carry`](https://open-rgs.dev/carry) covers the loop (math writes it, wallet stores it, engine threads it back), why the wallet owns it rather than the engine, what happens on a reconnect mid-session versus mid-round, why a math-version change discards it, and what does not belong in it.

Docs and styles only. 38 pages build; every internal link on the new page resolves.