### PR TITLE
feat(meters): bounds, spending, and carry with named migration strategies

### DIFF
--- a/.changeset/meter-bounds-carry.md
+++ b/.changeset/meter-bounds-carry.md
@@ -1,0 +1,29 @@
+---
+"@open-rgs/meters": minor
+---
+
+Bounds, spending, and living in carry.
+
+**A floor and a ceiling.** A counter needs neither; a multiplier that starts at
+1x and tops out at 10x needs both. Collecting past the ceiling clamps rather
+than throwing, because a spin that collects more than the meter can hold is a
+good spin. `fillLevel` reports how full the meter is between those bounds,
+which is a different question from `progress`, and drawn on a different bar.
+
+**Spending it down.** `spend` takes from the count and stops at the floor. A
+threshold already earned stays earned, so a player who spends a meter and
+refills it is not paid for the same rung twice - `reawardAfterSpend` says
+otherwise for games where that is the point.
+
+**Carry.** A meter that outlasts a spin has to live in the math's carry, since
+the engine keeps no per-player state of its own. `toCarry` writes a short
+versioned form; `fromCarry` reads it back, clamping into whatever the bounds
+are NOW, since they may have tightened since it was written.
+
+That makes the meter's serialised shape part of the game's persisted state, so
+`fromCarry` takes a migration strategy for carry it cannot read: `"reset"`
+(the engine's own answer to a math-version change: nothing paid twice, nothing
+parsed wrongly), `"keep-count"` (keep the progress and let the passed rungs pay
+again, which is generous in some games and double-paying in others), or a
+function that reads the old shape and returns the meter it should become - the
+only option that keeps both progress and awards.

--- a/apps/site/src/pages/carry.astro
+++ b/apps/site/src/pages/carry.astro
@@ -74,6 +74,8 @@ openSession(sid) -> { balance, carry, mathVersion, ... }`} />
       <li><strong>Not a session.</strong> A promo pool, a balance and an open round are engine concepts with their own fields.</li>
     </ul>
 
+    <p><a href="/extension/meters">@open-rgs/meters</a> is a worked example of all of this: a counter that lives in carry, with <code>toCarry</code> / <code>fromCarry</code> and three named strategies for what happens to a player mid-meter when its shape changes.</p>
+
     <p>A simple round has no separate carry field on the wire: <code>roundState</code> doubles as it, because a simple round opens and closes in the same call, so this round's final state <em>is</em> what the next one starts from. A complex round has both, and they are different things: <code>finalState</code> is what this round ended as, <code>carry</code> is what the next one begins with.</p>
   </main>
 </BaseLayout>

--- a/apps/site/src/pages/extension/meters.astro
+++ b/apps/site/src/pages/extension/meters.astro
@@ -51,7 +51,43 @@ toNext(m, CFG);      // symbols to the next threshold
 progress(m, CFG);    // 0..1 between the last threshold and the next, for the bar
 isFull(m, CFG);      // every threshold awarded`} />
 
-    <h2 data-section="&sect; 4">The cadence is arithmetic</h2>
+    <h2 data-section="&sect; 4">A floor, a ceiling, and spending it down</h2>
+
+    <p>A counter with no ceiling is fine. A multiplier that tops out at 10x is not, and neither is one that starts at 1x rather than at nothing. Bounds make both say so, and collecting past the ceiling clamps rather than throwing, because a spin that collects more than the meter can hold is a good spin.</p>
+
+    <Code code={`const MULT = { thresholds: [...], min: 1, max: 10 };
+
+meter(MULT).count;              // 1, not 0
+fillLevel(m, MULT);             // 0..1 between the floor and the ceiling
+isAtMax(m, MULT);               // time to award something else instead
+
+spend(m, 3, MULT);              // for a meter that is spent as well as filled`} />
+
+    <p><code>fillLevel</code> is not <code>progress</code>: one measures how full the meter is, the other how close the next prize is. A bar drawn toward the top of the meter wants the first; a bar drawn toward the next threshold wants the second.</p>
+
+    <p>Spending down does <strong>not</strong> un-earn a threshold. A player who spends a meter and refills it has collected the symbols twice but is not paid for the same rung twice, unless the game asks for that with <code>reawardAfterSpend</code>. That default is the difference between a meter and a repeatable prize.</p>
+
+    <h2 data-section="&sect; 5">Living in carry, and surviving a change</h2>
+
+    <p>A meter that outlasts a spin has to live in the math's <a href="/carry">carry</a>, because the engine keeps no per-player state of its own. That makes the meter's serialised shape part of the game's persisted state, so a change to that shape meets carry written by the version before it.</p>
+
+    <Code code={`import { toCarry, fromCarry } from "@open-rgs/meters";
+
+// at the end of a spin
+return { multiplier, ops, type, carry: toCarry(m) };
+
+// at the start of the next one
+let m = fromCarry(prev, CFG);                    // "reset" on anything unreadable
+let m = fromCarry(prev, CFG, "keep-count");      // keep progress, forget the rungs
+let m = fromCarry(prev, CFG, (raw) => ({         // or read the old shape yourself
+  count: raw.total, awarded: raw.paid, laps: 0,
+}));`} />
+
+    <p>The engine already has one rule here: a carry whose stored math version differs from the loaded math is discarded, and the session starts fresh. <code>fromCarry</code> covers what that rule does not, which is a meter whose own shape changed while the math version stayed put, and games that would rather migrate than discard.</p>
+
+    <p>The three strategies are a real choice rather than a formality. <strong>Reset</strong> pays nobody twice and reads nothing with the wrong parser. <strong>Keep-count</strong> preserves what the player collected and lets the rungs they already passed pay <em>again</em>, which is generous in some games and paying twice for one collection in others. <strong>A function</strong> is the only one that keeps both progress and awards, and the only one that needs the old shape written down somewhere.</p>
+
+    <h2 data-section="&sect; 6">The cadence is arithmetic</h2>
 
     <p>A meter at 10 that collects 0.4 per spin on average fills in 25 spins, so a ten-spin feature fills it about four times in ten. That is worth knowing before a simulation, because it is the number you are actually choosing when you set the threshold.</p>
 

--- a/packages/meters/src/index.ts
+++ b/packages/meters/src/index.ts
@@ -26,6 +26,19 @@ export interface MeterConfig<A> {
   /** Start again from zero after the highest threshold, so the meter can be
    *  filled more than once in a feature. Default false: it stops at the top. */
   readonly repeat?: boolean;
+  /** Lowest the count may go, for a meter that is spent as well as filled.
+   *  Default 0. */
+  readonly min?: number;
+  /** Highest the count may reach. Collecting past it CLAMPS rather than
+   *  throwing: a spin that collects more than the meter can hold is a good
+   *  spin, not an error. Without it a meter counts without limit, which is
+   *  fine for a counter and wrong for a multiplier that tops out. */
+  readonly max?: number;
+  /** Whether a threshold can be earned again after the count falls back below
+   *  it (see `spend`). Default false, because the usual answer is no: a player
+   *  who spends a meter down and refills it has collected the symbols twice
+   *  but should not be paid for the same rung twice. */
+  readonly reawardAfterSpend?: boolean;
 }
 
 export interface Meter<A> {
@@ -37,9 +50,17 @@ export interface Meter<A> {
   readonly laps: number;
 }
 
-/** An empty meter. */
-export function meter<A>(): Meter<A> {
-  return { count: 0, awarded: [], laps: 0 };
+/** An empty meter. Starts at `cfg.min` when one is set, since a meter with a
+ *  floor of 1 (a multiplier, say) starts at 1 rather than at nothing. */
+export function meter<A>(cfg?: MeterConfig<A>): Meter<A> {
+  return { count: cfg?.min ?? 0, awarded: [], laps: 0 };
+}
+
+/** Clamp a count into the configured bounds. */
+function clamp<A>(n: number, cfg: MeterConfig<A>): number {
+  const lo = cfg.min ?? 0;
+  const hi = cfg.max ?? Infinity;
+  return Math.min(hi, Math.max(lo, n));
 }
 
 /**
@@ -62,7 +83,7 @@ export function collect<A>(
 
   const sorted = [...cfg.thresholds].sort((a, b) => a.at - b.at);
   const top = sorted[sorted.length - 1];
-  let count = m.count + amount;
+  let count = clamp(m.count + amount, cfg);
   let awarded = [...m.awarded];
   let laps = m.laps;
   const awards: A[] = [];
@@ -82,7 +103,7 @@ export function collect<A>(
     // awards it immediately, rather than waiting for a spin that adds nothing:
     // the player collected those symbols.
     if (cfg.repeat && top && count >= top.at && awarded.length === sorted.length) {
-      count -= top.at;
+      count = clamp(count - top.at, cfg);
       awarded = [];
       laps += 1;
       if (count < (sorted[0]?.at ?? Infinity)) break;
@@ -93,6 +114,46 @@ export function collect<A>(
   }
 
   return { meter: { count, awarded, laps }, awards };
+}
+
+/**
+ * Take from the meter, for one that is spent as well as filled.
+ *
+ * Clamps at `min`. Thresholds already earned stay earned: a player who spends
+ * a meter down and fills it again has collected the symbols twice but is not
+ * paid for the same rung twice, unless the game says so with
+ * `reawardAfterSpend`. That default is the conservative one, and it is the
+ * difference between a meter and a repeatable prize.
+ */
+export function spend<A>(m: Meter<A>, amount: number, cfg: MeterConfig<A>): Meter<A> {
+  if (!Number.isFinite(amount) || amount < 0) {
+    throw new Error(`spend: amount must be a non-negative number, got ${amount}`);
+  }
+  if (amount === 0) return m;
+  const count = clamp(m.count - amount, cfg);
+  const awarded = cfg.reawardAfterSpend ? m.awarded.filter((at) => count >= at) : m.awarded;
+  return { ...m, count, awarded };
+}
+
+/**
+ * How full the meter is between its floor and its ceiling, in [0, 1].
+ *
+ * Different from {@link progress}, which measures the gap between the last
+ * threshold and the next one. A bar that fills toward the top of the meter
+ * wants this; a bar that fills toward the next prize wants that. Returns 0
+ * when no `max` is configured, because an unbounded meter has no fill level.
+ */
+export function fillLevel<A>(m: Meter<A>, cfg: MeterConfig<A>): number {
+  const lo = cfg.min ?? 0;
+  const hi = cfg.max;
+  if (hi === undefined || hi <= lo) return 0;
+  return Math.min(1, Math.max(0, (m.count - lo) / (hi - lo)));
+}
+
+/** Is the meter at its ceiling? A capped meter that keeps collecting is
+ *  usually a signal to award something else instead. */
+export function isAtMax<A>(m: Meter<A>, cfg: MeterConfig<A>): boolean {
+  return cfg.max !== undefined && m.count >= cfg.max;
 }
 
 /** How far to the next threshold, or 0 when the meter is full. The number a
@@ -122,6 +183,101 @@ export function isFull<A>(m: Meter<A>, cfg: MeterConfig<A>): boolean {
  *  meter was filled. */
 export function reset<A>(m: Meter<A>): Meter<A> {
   return { count: 0, awarded: [], laps: m.laps };
+}
+
+// --- carry -------------------------------------------------------------------
+//
+// A meter that survives a spin has to live in the math's `carry`, because the
+// engine keeps no per-player state of its own: carry is written with the money
+// and read back when the session next opens (see open-rgs.dev/carry). That
+// makes the meter's serialised shape part of the game's persisted state, and
+// it means a change to that shape meets carry written by the previous version.
+//
+// The engine already has one rule for that: when the loaded math's version
+// differs from the version stored beside the carry, the carry is discarded and
+// the session starts fresh. `fromCarry` exists for the case that rule does not
+// cover, which is a meter whose own shape changed WITHOUT the math version
+// moving, and for games that would rather migrate than discard.
+
+/** Bumped when the serialised shape below changes. */
+export const METER_CARRY_VERSION = 1;
+
+interface CarriedMeter {
+  readonly v: number;
+  readonly c: number;
+  readonly a: readonly number[];
+  readonly l: number;
+}
+
+/** Serialise a meter for the math's carry. Short keys, because carry crosses
+ *  the wire on every settle and is stored per session. */
+export function toCarry<A>(m: Meter<A>): string {
+  const out: CarriedMeter = { v: METER_CARRY_VERSION, c: m.count, a: m.awarded, l: m.laps };
+  return JSON.stringify(out);
+}
+
+/**
+ * What to do with carry this version cannot read.
+ *
+ * - `"reset"` (default): start fresh. The same answer the engine gives a carry
+ *   whose math version moved, and the safe one: nothing is paid twice and
+ *   nothing is read with the wrong parser.
+ * - `"keep-count"`: keep the progress, forget which thresholds were earned.
+ *   The player keeps what they collected, and the thresholds they already
+ *   passed can pay AGAIN as the count crosses them. Sometimes that is
+ *   generous-but-fine, and sometimes it is paying twice for one collection:
+ *   decide per game rather than per convenience.
+ * - a function: read the old shape yourself and return the meter it should
+ *   become. The only option that can preserve both progress and awards, and
+ *   the only one that needs the old shape to be documented somewhere.
+ */
+export type CarryMigration<A> = "reset" | "keep-count" | ((raw: unknown, cfg: MeterConfig<A>) => Meter<A>);
+
+/**
+ * Read a meter back out of carry.
+ *
+ * Absent or empty carry is a fresh meter, which is the first spin of a
+ * session. Anything unreadable goes through `migration`, so a game states what
+ * happens to a player mid-meter when its shape changes, rather than finding
+ * out on the day.
+ */
+export function fromCarry<A>(
+  carry: string | undefined,
+  cfg: MeterConfig<A>,
+  migration: CarryMigration<A> = "reset",
+): Meter<A> {
+  if (carry === undefined || carry === "") return meter(cfg);
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(carry);
+  } catch {
+    return migrate(undefined, cfg, migration);
+  }
+
+  const r = raw as Partial<CarriedMeter>;
+  const readable =
+    r !== null && typeof r === "object" &&
+    r.v === METER_CARRY_VERSION &&
+    typeof r.c === "number" && Array.isArray(r.a) && typeof r.l === "number";
+  if (!readable) return migrate(raw, cfg, migration);
+
+  return {
+    // Clamp on the way in: the bounds may have tightened since this was
+    // written, and a count outside them would make progress read past 1.
+    count: clamp(r.c!, cfg),
+    awarded: [...r.a!].filter((at) => typeof at === "number"),
+    laps: r.l!,
+  };
+}
+
+function migrate<A>(raw: unknown, cfg: MeterConfig<A>, migration: CarryMigration<A>): Meter<A> {
+  if (typeof migration === "function") return migration(raw, cfg);
+  if (migration === "keep-count") {
+    const c = (raw as { c?: unknown } | undefined)?.c;
+    return { count: typeof c === "number" ? clamp(c, cfg) : (cfg.min ?? 0), awarded: [], laps: 0 };
+  }
+  return meter(cfg);
 }
 
 /**

--- a/packages/meters/test/meters.test.ts
+++ b/packages/meters/test/meters.test.ts
@@ -2,7 +2,10 @@
 // that crossed two thresholds, losing the remainder when it fills.
 
 import { describe, expect, test } from "bun:test";
-import { collect, isFull, meter, progress, reset, spinsToFill, toNext, type MeterConfig } from "../src/index.js";
+import {
+  METER_CARRY_VERSION, collect, fillLevel, fromCarry, isAtMax, isFull, meter, progress,
+  reset, spend, spinsToFill, toCarry, toNext, type MeterConfig,
+} from "../src/index.js";
 
 const CFG: MeterConfig<string> = {
   thresholds: [{ at: 3, award: "MINI" }, { at: 6, award: "MINOR" }, { at: 10, award: "MAJOR" }],
@@ -141,3 +144,107 @@ function mulberry32(seed: number): () => number {
     return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
   };
 }
+
+describe("bounds", () => {
+  const CAPPED: MeterConfig<string> = { thresholds: [{ at: 2, award: "X" }], max: 5 };
+
+  test("collecting past the ceiling clamps rather than throwing", () => {
+    // A spin that collects more than the meter can hold is a good spin.
+    const out = collect(meter<string>(CAPPED), 99, CAPPED);
+    expect(out.meter.count).toBe(5);
+    expect(out.awards).toEqual(["X"]);
+    expect(isAtMax(out.meter, CAPPED)).toBe(true);
+  });
+
+  test("a meter with a floor starts at it", () => {
+    const MULT: MeterConfig<string> = { thresholds: [{ at: 5, award: "X" }], min: 1, max: 10 };
+    expect(meter(MULT).count).toBe(1);
+    expect(fillLevel(meter(MULT), MULT)).toBe(0);
+  });
+
+  test("fill level runs between the floor and the ceiling", () => {
+    const MULT: MeterConfig<string> = { thresholds: [], min: 1, max: 11 };
+    const m = collect(meter<string>(MULT), 4, MULT).meter;   // 1 -> 5
+    expect(fillLevel(m, MULT)).toBeCloseTo(0.4, 10);
+  });
+
+  test("an unbounded meter has no fill level, which is different from being empty", () => {
+    expect(fillLevel(meter<string>(), { thresholds: [] })).toBe(0);
+    expect(isAtMax(meter<string>(), { thresholds: [] })).toBe(false);
+  });
+});
+
+describe("spending a meter down", () => {
+  const CFG2: MeterConfig<string> = { thresholds: [{ at: 3, award: "MINI" }], min: 0, max: 10 };
+
+  test("takes from the count and stops at the floor", () => {
+    const m = collect(meter<string>(CFG2), 5, CFG2).meter;
+    expect(spend(m, 2, CFG2).count).toBe(3);
+    expect(spend(m, 99, CFG2).count).toBe(0);
+    expect(spend(m, 0, CFG2)).toBe(m);
+    expect(() => spend(m, -1, CFG2)).toThrow(/non-negative/);
+  });
+
+  test("a rung already earned stays earned, so refilling does not pay twice", () => {
+    let m = collect(meter<string>(CFG2), 3, CFG2).meter;      // MINI awarded
+    m = spend(m, 3, CFG2);                                     // back to zero
+    expect(collect(m, 3, CFG2).awards).toEqual([]);            // and no second MINI
+  });
+
+  test("unless the game says otherwise", () => {
+    const REARM: MeterConfig<string> = { ...CFG2, reawardAfterSpend: true };
+    let m = collect(meter<string>(REARM), 3, REARM).meter;
+    m = spend(m, 3, REARM);
+    expect(collect(m, 3, REARM).awards).toEqual(["MINI"]);
+  });
+});
+
+describe("carry", () => {
+  const CFG3: MeterConfig<string> = { thresholds: [{ at: 3, award: "MINI" }, { at: 6, award: "MINOR" }], max: 20 };
+
+  test("a meter survives a round trip through carry", () => {
+    const m = collect(meter<string>(CFG3), 7, CFG3).meter;
+    const back = fromCarry(toCarry(m), CFG3);
+    expect(back).toEqual(m);
+  });
+
+  test("no carry is the first spin of a session", () => {
+    expect(fromCarry(undefined, CFG3)).toEqual(meter(CFG3));
+    expect(fromCarry("", CFG3)).toEqual(meter(CFG3));
+  });
+
+  test("carry this version cannot read resets by default", () => {
+    expect(fromCarry('{"v":0,"count":9}', CFG3)).toEqual(meter(CFG3));
+    expect(fromCarry("not json at all", CFG3)).toEqual(meter(CFG3));
+    expect(fromCarry('{"v":1}', CFG3)).toEqual(meter(CFG3));      // right version, wrong shape
+  });
+
+  test("'keep-count' keeps progress and lets the rungs pay again, which is the trade", () => {
+    const back = fromCarry('{"v":0,"c":7}', CFG3, "keep-count");
+    expect(back.count).toBe(7);
+    expect(back.awarded).toEqual([]);
+    // the thresholds it already passed will pay a second time on the next collect
+    expect(collect(back, 0.0001, CFG3).awards).toEqual(["MINI", "MINOR"]);
+  });
+
+  test("a function migration can preserve both progress and awards", () => {
+    const old = '{"version":0,"total":7,"paid":[3]}';
+    const back = fromCarry(old, CFG3, (raw) => {
+      const r = raw as { total?: number; paid?: number[] };
+      return { count: r.total ?? 0, awarded: r.paid ?? [], laps: 0 };
+    });
+    expect(back).toEqual({ count: 7, awarded: [3], laps: 0 });
+    expect(collect(back, 0.0001, CFG3).awards).toEqual(["MINOR"]);   // MINI stays paid
+  });
+
+  test("a count outside the bounds is clamped on the way back in", () => {
+    // The ceiling may have been lowered since this carry was written.
+    expect(fromCarry('{"v":1,"c":500,"a":[],"l":0}', CFG3).count).toBe(20);
+  });
+
+  test("the serialised form is small, since it rides every settle", () => {
+    const m = collect(meter<string>(CFG3), 7, CFG3).meter;
+    expect(toCarry(m).length).toBeLessThan(60);
+    expect(JSON.parse(toCarry(m)).v).toBe(METER_CARRY_VERSION);
+  });
+});


### PR DESCRIPTION
Follow-up to #65. The meters package shipped with thresholds and a progress bar and nothing else; these are the parts that only show up once a real game keeps a meter across spins.

**Stacks on [#65](https://github.com/open-rgs/open-rgs/pull/65)** — it edits `/carry`, which that PR adds. Merge #65 first.

## Bounds

A counter needs neither floor nor ceiling. A multiplier that starts at 1x and tops out at 10x needs both. Collecting past the ceiling clamps rather than throwing, because a spin that collects more than the meter can hold is a good spin.

`fillLevel` is how full the meter is between its bounds. `progress` is how close the next prize is. Different bars, different questions, and conflating them is why a capped meter's bar reads wrong at the top.

## Spending

`spend` takes from the count and stops at the floor. A threshold already earned stays earned, so spending a meter down and refilling it does not pay for the same rung twice. `reawardAfterSpend` opts into the other behaviour for games where that is the mechanic.

## Carry, and what happens when the shape changes

A meter that outlasts a spin lives in the math's [carry](https://open-rgs.dev/carry), since the engine keeps no per-player state. `toCarry` writes a short versioned form; `fromCarry` reads it back and clamps into whatever the bounds are *now*, since they may have tightened since it was written.

That makes the serialised shape part of the game's persisted state, so `fromCarry` takes a migration strategy for carry it cannot read:

| strategy | keeps progress | keeps awards | risk |
|---|---|---|---|
| `"reset"` (default) | no | no | none: the engine's own answer to a math-version change |
| `"keep-count"` | yes | no | passed rungs can pay **again** |
| a function | yes | yes | needs the old shape documented |

The engine already discards carry when the loaded math's version differs from the stored one. This covers what that rule does not: a meter whose own shape changed while the math version stayed put.

Three new rules, each mutation-checked — re-arming on spend, skipping the clamp on read, and ignoring the ceiling each fail a test. 1,015 tests pass, site builds.