### PR TITLE
Mid-round money: a step can take a stake or pay an award

### DIFF
--- a/.changeset/mid-round-money.md
+++ b/.changeset/mid-round-money.md
@@ -1,0 +1,14 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+"@open-rgs/platform-mock": minor
+"@open-rgs/adapter-test-kit": minor
+---
+
+Mid-round money: a step can now take a stake or pay an award without closing the round.
+
+A round has never really been one debit and one credit. Buying a respin takes money while the round continues; a free-spin feature that pays per spin gives money back before the round is over. Until now both had to be smuggled into the opening bet or held back until close, which makes an operator's ledger a work of fiction.
+
+`StepOutcome` gains optional `stake` and `award` multipliers, and `PlatformAdapter` gains optional `stakeComplex` and `awardComplex`. Both are optional on purpose: a wallet that models a round the old way stays conformant, and a game that asks such a wallet for a mid-round movement fails the step with a clear error rather than playing on with money nobody agreed to move.
+
+The orchestrator takes before it gives, raises the round's cost by a mid-round stake so the max-win cap scales with what the player actually paid, and deducts mid-round awards from that cap so a round cannot pay its ceiling once per step and again at close. Keys are deterministic per step, so a resent step is the same movement.

--- a/packages/adapter-test-kit/src/runner.ts
+++ b/packages/adapter-test-kit/src/runner.ts
@@ -4,7 +4,8 @@
 // Coverage:
 //   - lifecycle: connect, isHealthy, diagnostics shape, disconnect
 //   - simple-round: openSession returns SessionInfo, settleSimple debits+credits
-//   - complex-round (if attempted): openComplex -> updateComplex(optional) -> closeComplex
+//   - complex-round (if attempted): openComplex -> updateComplex(optional) ->
+//     stakeComplex/awardComplex (optional, mid-round money) -> closeComplex
 //   - events: onEvent registered, balanceChanged fires when expected
 //   - idempotency: a REPEATED key moves money once and returns the same
 //     receipt  - the property the contract relies on (was advertised but
@@ -247,6 +248,69 @@ export async function runConformance(
       });
     } else {
       skip("complex.updateComplex", "complex-round", "updateComplex (optional)  - not implemented", "adapter does not implement updateComplex");
+    }
+
+    // Mid-round money is optional: a wallet that models a round as one debit
+    // and one credit is conformant. A wallet that DOES implement it must move
+    // the money without closing the round, and must dedupe a repeated key the
+    // same way every other movement does.
+    if (typeof adapter.stakeComplex === "function") {
+      await run("complex.stakeComplex", "complex-round", "stakeComplex debits mid-round without closing", async () => {
+        if (!openReceipt) throw new Error("openReceipt missing");
+        const first = await adapter.stakeComplex!({
+          sessionId: fixture.sessionId,
+          roundId: openReceipt.roundId,
+          stake: fixture.bet,
+          multiplier: 1,
+          state: "mid-state-v1",
+          idempotencyKey: "conf-stake-1",
+        });
+        if (typeof first.balance !== "number") throw new Error("stakeComplex returned no balance");
+        const repeat = await adapter.stakeComplex!({
+          sessionId: fixture.sessionId,
+          roundId: openReceipt.roundId,
+          stake: fixture.bet,
+          multiplier: 1,
+          state: "mid-state-v1",
+          idempotencyKey: "conf-stake-1",
+        });
+        if (repeat.balance !== first.balance) {
+          throw new Error("a repeated stakeComplex key debited twice  - it MUST dedupe");
+        }
+        // The round must still be open: closing it later is what proves it.
+      });
+    } else {
+      skip("complex.stakeComplex", "complex-round", "stakeComplex (optional)  - not implemented", "adapter does not implement stakeComplex");
+    }
+
+    if (typeof adapter.awardComplex === "function") {
+      await run("complex.awardComplex", "complex-round", "awardComplex credits mid-round without closing", async () => {
+        if (!openReceipt) throw new Error("openReceipt missing");
+        const first = await adapter.awardComplex!({
+          sessionId: fixture.sessionId,
+          roundId: openReceipt.roundId,
+          win: fixture.bet,
+          multiplier: 1,
+          type: "award",
+          state: "mid-state-v1",
+          idempotencyKey: "conf-award-1",
+        });
+        if (typeof first.balance !== "number") throw new Error("awardComplex returned no balance");
+        const repeat = await adapter.awardComplex!({
+          sessionId: fixture.sessionId,
+          roundId: openReceipt.roundId,
+          win: fixture.bet,
+          multiplier: 1,
+          type: "award",
+          state: "mid-state-v1",
+          idempotencyKey: "conf-award-1",
+        });
+        if (repeat.balance !== first.balance) {
+          throw new Error("a repeated awardComplex key credited twice  - it MUST dedupe");
+        }
+      });
+    } else {
+      skip("complex.awardComplex", "complex-round", "awardComplex (optional)  - not implemented", "adapter does not implement awardComplex");
     }
     // Bad round id is rejected  - and must leave the real open round intact,
     // so we run it before the valid close.

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -84,6 +84,28 @@ export interface StepOutcome {
   state: RoundState;
   ops: Op[];
   awaiting?: AwaitingHint;     // null = ready to close
+
+  /**
+   * Take more money from the player *now*, without closing the round: a paid
+   * respin, a doubled ante, buying one more pick. Expressed as a multiple of
+   * the round's cost so math stays currency-blind, exactly like `multiplier`.
+   *
+   * Requires an adapter that implements `stakeComplex`. A game that asks for
+   * money the wallet cannot take fails the step rather than continuing on
+   * credit.
+   */
+  stake?: number;
+
+  /**
+   * Pay the player *now*, without closing the round: one free spin's win,
+   * a collected prize, a partial cash-out. A multiple of the round's cost.
+   *
+   * Requires an adapter that implements `awardComplex`.
+   */
+  award?: number;
+
+  /** Tag for a mid-round award, as `type` is for a close. Default "award". */
+  awardType?: string;
 }
 
 /** What a complex-round math returns from close(). */
@@ -477,6 +499,51 @@ export interface UpdateComplex {
   state: RoundState;
 }
 
+/**
+ * Money out of the player, mid-round. The round stays open.
+ *
+ * This exists because a round is not always one bet and one win: buying a
+ * feature, paying for a respin, or doubling an ante all move money while the
+ * round continues. Without it a game has to pretend the extra cost was part of
+ * the opening bet, which makes the operator's ledger a work of fiction.
+ */
+export interface StakeComplex {
+  sessionId: string;
+  roundId: string;
+  /** Amount to debit, integer minor units. */
+  stake: number;
+  /** The multiple of the round's cost this represents, for reporting. */
+  multiplier: number;
+  /** Game-defined reason, e.g. "respin", "ante", "buy". */
+  reason?: string;
+  /** Math state at the moment of the debit. */
+  state: RoundState;
+  mathVersion?: string;
+  /** Deterministic per-step key; a repeat must not debit twice. */
+  idempotencyKey?: string;
+}
+
+/**
+ * Money to the player, mid-round. The round stays open.
+ *
+ * A free-spin round that pays per spin has a win per spin, and a player who
+ * watched three spins pay out should not have to wait for a fourth to see the
+ * money. The wallet books each one as its own movement.
+ */
+export interface AwardComplex {
+  sessionId: string;
+  roundId: string;
+  /** Amount to credit, integer minor units. */
+  win: number;
+  /** The multiple of the round's cost this represents. */
+  multiplier: number;
+  /** Game-defined tag, e.g. "free-spin-win". */
+  type: string;
+  state: RoundState;
+  mathVersion?: string;
+  idempotencyKey?: string;
+}
+
 export interface CloseComplex {
   sessionId: string;
   roundId: string;
@@ -592,6 +659,18 @@ export interface PlatformAdapter {
   openComplex(req: OpenComplex): Promise<RoundReceipt>;
   /** Audit-only state update (no money moves). Optional. */
   updateComplex?(req: UpdateComplex): Promise<void>;
+
+  /**
+   * OPTIONAL. Move money mid-round, in either direction, without closing.
+   *
+   * Both are optional because most wallets model a round as one debit and one
+   * credit, and those wallets stay conformant. A game whose math asks for a
+   * mid-round movement against an adapter that does not implement the matching
+   * method fails the step with a clear error - the orchestrator never invents
+   * money the wallet has not agreed to move.
+   */
+  stakeComplex?(req: StakeComplex): Promise<RoundReceipt>;
+  awardComplex?(req: AwardComplex): Promise<RoundReceipt>;
   /** Close a complex round (credit win). */
   closeComplex(req: CloseComplex): Promise<RoundReceipt>;
 
@@ -742,6 +821,12 @@ export interface ClientResponseOpenRound {
 export interface ClientResponseStepRound {
   ops: Op[];
   awaiting?: AwaitingHint;
+  /** Present when the step moved money: the balance after it did. */
+  balance?: number;
+  /** Money taken by this step, minor units. */
+  stake?: number;
+  /** Money paid by this step, minor units. */
+  win?: number;
 }
 
 export interface ClientResponseCloseRound {

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -28,12 +28,14 @@ import {
   type SimpleMath,
   type ComplexMath,
   type GameMode,
+  type StepOutcome,
   type SpinContext,
   type CheatHint,
   type RoundOutcome,
   type CloseOutcome,
 } from "@open-rgs/contract";
 import * as sessions from "./session.js";
+import type { LocalSession, OpenRound } from "./session.js";
 import * as promo from "./promo.js";
 import { settleAmount } from "./money.js";
 import { deriveIdempotencyKey } from "./idempotency.js";
@@ -709,12 +711,23 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     open.actionLog.push(req.action);
     open.opsLog.push(...stepResult.ops);
 
-    // Record the player action into the tamper-evident game-cycle log (no
-    // money moves on a step, so win/multiplier are 0).
+    // Record the player action into the tamper-evident game-cycle log. Money
+    // moved by this step, if any, is recorded separately below so that each
+    // movement is its own line rather than a footnote on the action.
     recordAudit(mode, {
       sessionId: s.sessionId, roundId: open.roundId, kind: "step",
       type: String(req.action.type), bet: 0, win: 0, multiplier: 0, reason: "",
     });
+
+    // --- mid-round money ----------------------------------------------------
+    //
+    // A round is not always one debit and one credit. Buying a respin takes
+    // money while the round continues; a free spin that pays per spin gives it
+    // back before the round is over. Both are optional on the adapter, so a
+    // wallet that models a round the old way stays conformant - and a game
+    // that asks such a wallet for a mid-round movement fails here rather than
+    // playing on with money nobody agreed to move.
+    const stepMoney = await applyStepMoney(s, open, mode, stepResult);
 
     // Wallet-side action-log checkpoint, if the provider supports it.
     if (typeof platform.updateComplex === "function") {
@@ -737,7 +750,127 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     return {
       ops: stepResult.ops,
       ...(stepResult.awaiting ? { awaiting: stepResult.awaiting } : {}),
+      ...(stepMoney.balance !== undefined ? { balance: stepMoney.balance } : {}),
+      ...(stepMoney.stake !== undefined ? { stake: stepMoney.stake } : {}),
+      ...(stepMoney.win !== undefined ? { win: stepMoney.win } : {}),
     };
+  }
+
+  /** The round's remaining max-win allowance, mid-round awards deducted. */
+  function remainingCap(open: OpenRound, mode: GameMode): number | undefined {
+    return remainingCapFor(
+      open.paidOut ?? 0,
+      open.effectiveCost,
+      mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
+    );
+  }
+
+  /** A mid-round award may not spend more than the round has left. */
+  function capMidRoundAward(
+    open: OpenRound,
+    mode: GameMode,
+    multiplier: number,
+  ): number {
+    const allowance = remainingCap(open, mode);
+    return allowance === undefined ? multiplier : Math.min(multiplier, allowance);
+  }
+
+  /**
+   * Apply whatever money a step asked to move, in the only safe order: take
+   * before you give.
+   *
+   * A mid-round stake raises what the round has cost, so the max-win cap
+   * scales with what the player actually paid. A mid-round award spends part
+   * of that cap, so the close cannot pay the ceiling a second time.
+   */
+  async function applyStepMoney(
+    s: LocalSession,
+    open: OpenRound,
+    mode: GameMode,
+    stepResult: StepOutcome,
+  ): Promise<{ balance?: number; stake?: number; win?: number }> {
+    const wantsStake = typeof stepResult.stake === "number" && stepResult.stake > 0;
+    const wantsAward = typeof stepResult.award === "number" && stepResult.award > 0;
+    if (!wantsStake && !wantsAward) return {};
+
+    // The step index makes each movement's key deterministic, so a client that
+    // resends a step it never saw the answer to gets the same movement rather
+    // than a second one.
+    const stepIndex = open.actionLog.length;
+    const result: { balance?: number; stake?: number; win?: number } = {};
+
+    if (wantsStake) {
+      if (typeof platform.stakeComplex !== "function") {
+        throw new RGSError(
+          "STEP_FAILED",
+          "math asked for a mid-round stake but this wallet adapter does not implement stakeComplex",
+        );
+      }
+      const amount = settleAmount(stepResult.stake!, open.effectiveCost);
+      if (amount > s.balance) {
+        throw new RGSError("INSUFFICIENT_BALANCE", `mid-round stake ${amount} > balance ${s.balance}`);
+      }
+      let receipt;
+      try {
+        receipt = await timedPlatformCall(metrics, "stakeComplex", () => platform.stakeComplex!({
+          sessionId: s.sessionId,
+          roundId: open.roundId,
+          stake: amount,
+          multiplier: stepResult.stake!,
+          state: open.state,
+          ...(mode.math.version ? { mathVersion: mode.math.version } : {}),
+          idempotencyKey: deriveIdempotencyKey(s.sessionId, open.roundId, "stake", stepIndex),
+        }));
+      } catch (e) {
+        throw translate(e, "STEP_FAILED");
+      }
+      open.extraStake = (open.extraStake ?? 0) + amount;
+      open.effectiveCost += amount;
+      sessions.setBalance(s.sessionId, receipt.balance);
+      result.balance = receipt.balance;
+      result.stake = amount;
+      recordAudit(mode, {
+        sessionId: s.sessionId, roundId: open.roundId, kind: "step",
+        type: "stake", bet: amount, win: 0, multiplier: stepResult.stake!, reason: "",
+      });
+    }
+
+    if (wantsAward) {
+      if (typeof platform.awardComplex !== "function") {
+        throw new RGSError(
+          "STEP_FAILED",
+          "math asked for a mid-round award but this wallet adapter does not implement awardComplex",
+        );
+      }
+      assertFundedWin(open.effectiveCost, stepResult.award!);
+      const capped = capMidRoundAward(open, mode, stepResult.award!);
+      const amount = settleAmount(capped, open.effectiveCost);
+      let receipt;
+      try {
+        receipt = await timedPlatformCall(metrics, "awardComplex", () => platform.awardComplex!({
+          sessionId: s.sessionId,
+          roundId: open.roundId,
+          win: amount,
+          multiplier: capped,
+          type: stepResult.awardType ?? "award",
+          state: open.state,
+          ...(mode.math.version ? { mathVersion: mode.math.version } : {}),
+          idempotencyKey: deriveIdempotencyKey(s.sessionId, open.roundId, "award", stepIndex),
+        }));
+      } catch (e) {
+        throw translate(e, "STEP_FAILED");
+      }
+      open.paidOut = (open.paidOut ?? 0) + amount;
+      sessions.setBalance(s.sessionId, receipt.balance);
+      result.balance = receipt.balance;
+      result.win = amount;
+      recordAudit(mode, {
+        sessionId: s.sessionId, roundId: open.roundId, kind: "step",
+        type: stepResult.awardType ?? "award", bet: 0, win: amount, multiplier: capped, reason: "",
+      });
+    }
+
+    return result;
   }
 
   // --- COMPLEX CLOSE ------------------------------------------------------
@@ -767,7 +900,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     const cappedClose = applyMaxWinCapClose(
       closeResult,
       open.effectiveCost,
-      mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
+      remainingCap(open, mode),
     );
     const win = settleAmount(cappedClose.multiplier, open.effectiveCost);
     assertFundedWin(open.effectiveCost, cappedClose.multiplier);
@@ -919,7 +1052,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     const cappedClose = applyMaxWinCapClose(
       closeResult,
       open.effectiveCost,
-      mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
+      remainingCap(open, mode),
     );
     const win = settleAmount(cappedClose.multiplier, open.effectiveCost);
     assertFundedWin(open.effectiveCost, cappedClose.multiplier);
@@ -1114,6 +1247,23 @@ export function applyMaxWinCap(
 }
 
 /** Same sanitize-then-cap applied to a complex-round close outcome. */
+/**
+ * What is left of a round's max-win allowance after any mid-round awards.
+ *
+ * Without this a round that pays its ceiling on a step could pay it again on
+ * close, and the cap would only ever have limited a single movement rather
+ * than the round.
+ */
+function remainingCapFor(
+  paidOut: number,
+  effectiveCost: number,
+  maxMultiplier: number | undefined,
+): number | undefined {
+  if (maxMultiplier == null) return undefined;
+  if (paidOut <= 0 || effectiveCost <= 0) return maxMultiplier;
+  return Math.max(0, maxMultiplier - paidOut / effectiveCost);
+}
+
 export function applyMaxWinCapClose(
   outcome: CloseOutcome,
   _bet: number,

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -45,6 +45,18 @@ export interface OpenRound {
   opsLog: Op[];
   /** Wall-clock ms epoch when the round opened. */
   openedAt: number;
+  /**
+   * Money taken mid-round by `StepOutcome.stake`, in minor units. It is added
+   * to what the round has cost, so the max-win cap scales with what the player
+   * actually paid rather than with the opening bet alone.
+   */
+  extraStake?: number;
+  /**
+   * Money already paid out mid-round by `StepOutcome.award`, in minor units.
+   * The close's cap allowance is reduced by it, so a round cannot pay its
+   * ceiling once per step.
+   */
+  paidOut?: number;
 }
 
 export interface LocalSession {

--- a/packages/core/test/mid-round-money.test.ts
+++ b/packages/core/test/mid-round-money.test.ts
@@ -1,0 +1,269 @@
+// Mid-round money: a step that takes a stake or pays an award without closing
+// the round.
+//
+// The cases that matter are the refusals. A game whose math asks for money the
+// adapter cannot move must fail the step, not carry on; a mid-round stake must
+// raise what the round has cost so the max-win cap scales with it; and a
+// mid-round award must spend the cap it uses, so a round cannot pay its
+// ceiling once per step and again at close.
+
+import { describe, expect, test } from "bun:test";
+import { createOrchestrator } from "../src/index.js";
+import {
+  defineGame,
+  type AwardComplex,
+  type ComplexMath,
+  type ConnectionMeta,
+  type CloseComplex,
+  type OpenComplex,
+  type PlatformAdapter,
+  type PlatformEvent,
+  type RoundReceipt,
+  type SessionInfo,
+  type StakeComplex,
+  type StepOutcome,
+} from "@open-rgs/contract";
+
+interface Recorded {
+  stakes: StakeComplex[];
+  awards: AwardComplex[];
+  closes: CloseComplex[];
+}
+
+class Wallet implements PlatformAdapter {
+  isHealthy = true;
+  diagnostics = {};
+  balance = 10_000;
+  readonly recorded: Recorded = { stakes: [], awards: [], closes: [] };
+  private readonly seen = new Map<string, RoundReceipt>();
+
+  constructor(private readonly supports: { stake: boolean; award: boolean } = { stake: true, award: true }) {
+    if (!supports.stake) delete (this as Partial<PlatformAdapter>).stakeComplex;
+    if (!supports.award) delete (this as Partial<PlatformAdapter>).awardComplex;
+  }
+
+  async connect() {}
+  disconnect() {}
+  async openSession(sessionId: string): Promise<SessionInfo> {
+    return {
+      sessionId,
+      currency: "USD",
+      currencyDecimals: 2,
+      balance: this.balance,
+      allowedBets: [100],
+      defaultBetIndex: 0,
+    };
+  }
+  async settleSimple(): Promise<RoundReceipt> {
+    return { roundId: "s1", balance: this.balance };
+  }
+  async openComplex(req: OpenComplex): Promise<RoundReceipt> {
+    this.balance -= req.bet * (req.priceMultiplier ?? 1);
+    return { roundId: "r1", balance: this.balance };
+  }
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+    this.recorded.closes.push(req);
+    this.balance += req.win;
+    return { roundId: req.roundId, balance: this.balance };
+  }
+  stakeComplex = async (req: StakeComplex): Promise<RoundReceipt> => {
+    const replay = req.idempotencyKey ? this.seen.get(req.idempotencyKey) : undefined;
+    if (replay) return replay;
+    this.recorded.stakes.push(req);
+    if (req.stake > this.balance) throw new Error("InsufficientFunds");
+    this.balance -= req.stake;
+    const receipt = { roundId: req.roundId, balance: this.balance };
+    if (req.idempotencyKey) this.seen.set(req.idempotencyKey, receipt);
+    return receipt;
+  };
+  awardComplex = async (req: AwardComplex): Promise<RoundReceipt> => {
+    const replay = req.idempotencyKey ? this.seen.get(req.idempotencyKey) : undefined;
+    if (replay) return replay;
+    this.recorded.awards.push(req);
+    this.balance += req.win;
+    const receipt = { roundId: req.roundId, balance: this.balance };
+    if (req.idempotencyKey) this.seen.set(req.idempotencyKey, receipt);
+    return receipt;
+  };
+  onEvent(_handler: (event: PlatformEvent) => void) {}
+}
+
+/** A round whose steps do whatever the test asks, then closes for `closeWin`. */
+function mathThatSteps(steps: StepOutcome[], closeMultiplier = 0): ComplexMath {
+  let index = 0;
+  return {
+    kind: "complex",
+    name: "stepper",
+    version: "1",
+    rtp: 1,
+    open: () => ({ state: "{}", ops: [], awaiting: { type: "go" } }),
+    step: () => {
+      const outcome = steps[Math.min(index++, steps.length - 1)]!;
+      return outcome;
+    },
+    isTerminal: () => index >= steps.length,
+    close: () => ({ multiplier: closeMultiplier, ops: [], type: "win" }),
+  };
+}
+
+async function setup(
+  steps: StepOutcome[],
+  options: { closeMultiplier?: number; maxWin?: number; supports?: { stake: boolean; award: boolean } } = {},
+) {
+  const platform = new Wallet(options.supports ?? { stake: true, award: true });
+  const manifest = defineGame({
+    id: "g",
+    declaredRtp: 1,
+    defaultMode: "base",
+    ...(options.maxWin !== undefined ? { maxWinMultiplier: options.maxWin } : {}),
+    modes: { base: { math: mathThatSteps(steps, options.closeMultiplier ?? 0), stakeMultiplier: 1 } },
+  });
+  const orch = createOrchestrator({ manifest, platform });
+  const conn: ConnectionMeta = { connectionId: "c1", sessionId: null, demo: false };
+  await orch.init({ sid: `s-${Math.random()}` }, conn);
+  return { orch, conn, platform };
+}
+
+describe("a step that takes more money", () => {
+  test("debits it, keeps the round open, and says so in the response", async () => {
+    const { orch, conn, platform } = await setup([
+      { state: "{}", ops: [], awaiting: { type: "go" }, stake: 2 },
+    ]);
+    await orch.openRound({ betIndex: 0 }, conn);
+    expect(platform.balance).toBe(9_900);
+
+    const step = await orch.stepRound({ action: { type: "go" } }, conn);
+
+    expect(platform.recorded.stakes).toHaveLength(1);
+    expect(platform.recorded.stakes[0]).toMatchObject({ stake: 200, multiplier: 2 });
+    expect(step.stake).toBe(200);
+    expect(step.balance).toBe(9_700);
+    expect(platform.balance).toBe(9_700);
+  });
+
+  test("refuses when the player cannot afford it, and takes nothing", async () => {
+    const { orch, conn, platform } = await setup([
+      { state: "{}", ops: [], awaiting: { type: "go" }, stake: 1_000 },
+    ]);
+    await orch.openRound({ betIndex: 0 }, conn);
+    const before = platform.balance;
+
+    await expect(orch.stepRound({ action: { type: "go" } }, conn)).rejects.toMatchObject({
+      code: "INSUFFICIENT_BALANCE",
+    });
+    expect(platform.recorded.stakes).toHaveLength(0);
+    expect(platform.balance).toBe(before);
+  });
+
+  test("fails the step when the wallet does not implement stakeComplex", async () => {
+    const { orch, conn } = await setup([{ state: "{}", ops: [], awaiting: { type: "go" }, stake: 1 }], {
+      supports: { stake: false, award: true },
+    });
+    await orch.openRound({ betIndex: 0 }, conn);
+
+    const error = await orch.stepRound({ action: { type: "go" } }, conn).catch((e: unknown) => e);
+    expect(error).toMatchObject({ code: "STEP_FAILED" });
+    expect(String(error)).toContain("stakeComplex");
+  });
+
+  test("raises what the round has cost, so the close pays on the larger stake", async () => {
+    const { orch, conn, platform } = await setup(
+      [{ state: "{}", ops: [], awaiting: undefined, stake: 1 }],
+      { closeMultiplier: 3 },
+    );
+    await orch.openRound({ betIndex: 0 }, conn);
+    await orch.stepRound({ action: { type: "go" } }, conn);
+    await orch.closeRound({}, conn);
+
+    // 100 opening + 100 mid-round = 200 of cost; a 3x close is 600, not 300.
+    expect(platform.recorded.closes[0]?.win).toBe(600);
+  });
+});
+
+describe("a step that pays out", () => {
+  test("credits it without closing the round", async () => {
+    const { orch, conn, platform } = await setup([
+      { state: "{}", ops: [], awaiting: { type: "go" }, award: 5, awardType: "free-spin-win" },
+    ]);
+    await orch.openRound({ betIndex: 0 }, conn);
+    const step = await orch.stepRound({ action: { type: "go" } }, conn);
+
+    expect(platform.recorded.awards[0]).toMatchObject({ win: 500, multiplier: 5, type: "free-spin-win" });
+    expect(step.win).toBe(500);
+    expect(platform.balance).toBe(10_400);
+    expect(platform.recorded.closes).toHaveLength(0);
+  });
+
+  test("fails the step when the wallet does not implement awardComplex", async () => {
+    const { orch, conn } = await setup([{ state: "{}", ops: [], awaiting: { type: "go" }, award: 1 }], {
+      supports: { stake: true, award: false },
+    });
+    await orch.openRound({ betIndex: 0 }, conn);
+
+    const error = await orch.stepRound({ action: { type: "go" } }, conn).catch((e: unknown) => e);
+    expect(error).toMatchObject({ code: "STEP_FAILED" });
+    expect(String(error)).toContain("awardComplex");
+  });
+
+  test("spends the round's max-win allowance rather than resetting it", async () => {
+    const { orch, conn, platform } = await setup(
+      [{ state: "{}", ops: [], awaiting: undefined, award: 8 }],
+      { closeMultiplier: 8, maxWin: 10 },
+    );
+    await orch.openRound({ betIndex: 0 }, conn);
+    await orch.stepRound({ action: { type: "go" } }, conn);
+    await orch.closeRound({}, conn);
+
+    // 8x paid mid-round leaves 2x of a 10x cap, so the 8x close is capped.
+    expect(platform.recorded.awards[0]?.win).toBe(800);
+    expect(platform.recorded.closes[0]?.win).toBe(200);
+    expect(platform.recorded.closes[0]?.type).toBe("max_win_reached");
+  });
+
+  test("caps a single mid-round award at the round's ceiling", async () => {
+    const { orch, conn, platform } = await setup(
+      [{ state: "{}", ops: [], awaiting: { type: "go" }, award: 50 }],
+      { maxWin: 10 },
+    );
+    await orch.openRound({ betIndex: 0 }, conn);
+    await orch.stepRound({ action: { type: "go" } }, conn);
+
+    expect(platform.recorded.awards[0]?.win).toBe(1_000);
+  });
+});
+
+describe("both in one step", () => {
+  test("takes before it gives", async () => {
+    const { orch, conn, platform } = await setup([
+      { state: "{}", ops: [], awaiting: { type: "go" }, stake: 1, award: 4 },
+    ]);
+    await orch.openRound({ betIndex: 0 }, conn);
+    const step = await orch.stepRound({ action: { type: "go" } }, conn);
+
+    expect(platform.recorded.stakes).toHaveLength(1);
+    expect(platform.recorded.awards).toHaveLength(1);
+    // The award is a multiple of the round's cost *after* the extra stake:
+    // 100 + 100 = 200, so 4x is 800.
+    expect(platform.recorded.awards[0]?.win).toBe(800);
+    expect(step.stake).toBe(100);
+    expect(step.win).toBe(800);
+  });
+});
+
+describe("keys", () => {
+  test("each step's movements carry a deterministic key", async () => {
+    const { orch, conn, platform } = await setup([
+      { state: "{}", ops: [], awaiting: { type: "go" }, award: 1 },
+      { state: "{}", ops: [], awaiting: { type: "go" }, award: 1 },
+    ]);
+    await orch.openRound({ betIndex: 0 }, conn);
+    await orch.stepRound({ action: { type: "go" } }, conn);
+    await orch.stepRound({ action: { type: "go" } }, conn);
+
+    const keys = platform.recorded.awards.map((award) => award.idempotencyKey);
+    expect(new Set(keys).size).toBe(2);
+    expect(keys[0]).toContain("award");
+    // The step index is in the key, so a resent step is the same movement.
+    expect(keys[0]).not.toBe(keys[1]);
+  });
+});

--- a/packages/platform-mock/src/index.ts
+++ b/packages/platform-mock/src/index.ts
@@ -21,6 +21,8 @@ import type {
   OpenComplex,
   UpdateComplex,
   CloseComplex,
+  StakeComplex,
+  AwardComplex,
   RoundReceipt,
   ReverseRound,
   ReverseReceipt,
@@ -224,6 +226,42 @@ export class MockPlatform implements PlatformAdapter {
 
   async updateComplex(_req: UpdateComplex): Promise<void> {
     /* audit-only no-op for the mock */
+  }
+
+  // --- mid-round money --------------------------------------------------
+  //
+  // Optional on the contract, implemented here so the conformance suite has
+  // something to hold a real adapter against. Both movements belong to the
+  // round that is already open: they change the balance, they do not close it,
+  // and they are covered by the reversal snapshot taken at open.
+
+  async stakeComplex(req: StakeComplex): Promise<RoundReceipt> {
+    const dup = this.replay(req.idempotencyKey);
+    if (dup) return dup;
+
+    const s = this.must(req.sessionId);
+    assertAmount(req.stake, "stake");
+    if (!s.openRound || s.openRound.roundId !== req.roundId) {
+      throw new Error("InvalidRoundOperation: roundId mismatch");
+    }
+    if (req.stake > s.balance) throw new Error("InsufficientFunds");
+    s.balance -= req.stake;
+    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: s.balance, reason: "stake" });
+    return this.remember(req.idempotencyKey, { roundId: req.roundId, balance: s.balance });
+  }
+
+  async awardComplex(req: AwardComplex): Promise<RoundReceipt> {
+    const dup = this.replay(req.idempotencyKey);
+    if (dup) return dup;
+
+    const s = this.must(req.sessionId);
+    assertAmount(req.win, "win");
+    if (!s.openRound || s.openRound.roundId !== req.roundId) {
+      throw new Error("InvalidRoundOperation: roundId mismatch");
+    }
+    s.balance += req.win;
+    this.emit({ type: "balanceChanged", sessionId: req.sessionId, balance: s.balance, reason: "award" });
+    return this.remember(req.idempotencyKey, { roundId: req.roundId, balance: s.balance });
   }
 
   async closeComplex(req: CloseComplex): Promise<RoundReceipt> {

--- a/specs/05-platform-protocol.md
+++ b/specs/05-platform-protocol.md
@@ -21,6 +21,8 @@ interface PlatformAdapter {
 
   openComplex(req: OpenComplex): Promise<RoundReceipt>;
   updateComplex?(req: UpdateComplex): Promise<void>;
+  stakeComplex?(req: StakeComplex): Promise<RoundReceipt>;
+  awardComplex?(req: AwardComplex): Promise<RoundReceipt>;
   closeComplex(req: CloseComplex): Promise<RoundReceipt>;
 
   onEvent(handler: (e: PlatformEvent) => void): void;
@@ -52,6 +54,8 @@ rounding modes.
 | `settleSimple` | Atomically debit `bet` and credit `win`. Single transaction. |
 | `openComplex` | Debit `bet`. Returns `roundId` referenceable by close/update. |
 | `updateComplex` | NO money movement. Pure audit/state-persistence. Idempotent. |
+| `stakeComplex` | OPTIONAL. Debit mid-round. The round stays open. |
+| `awardComplex` | OPTIONAL. Credit mid-round. The round stays open. |
 | `closeComplex` | Credit `win` against the open round. Final transaction. |
 | `reverseRound` | OPTIONAL. Undo a settled round  - money AND carry  - latest-first. |
 
@@ -90,6 +94,43 @@ The wallet guarantees:
   the admin endpoint.
 - `BalanceChangedEvent` is emitted whenever the balance changes for any
   reason (round settle, deposit, withdrawal, manual adjustment).
+
+### Mid-round money (optional)
+
+A round is not always one debit and one credit. Buying a respin takes money
+while the round continues; a free-spin feature that pays per spin gives money
+back before the round is over. `stakeComplex` and `awardComplex` are how a
+wallet accepts those movements without pretending they were part of the
+opening bet.
+
+Both are **optional**, and a wallet that models a round the old way stays
+conformant. The orchestrator never invents money a wallet has not agreed to
+move: a game whose math returns `StepOutcome.stake` or `StepOutcome.award`
+against an adapter that does not implement the matching method fails that step
+with `STEP_FAILED`, naming the missing method.
+
+Math stays currency-blind: `stake` and `award` on a `StepOutcome` are
+multiples of the round's cost, exactly like `multiplier` on a close.
+
+The orchestrator guarantees:
+
+- Within one step, `stakeComplex` runs before `awardComplex`  - take before
+  you give, so a player cannot be paid out of money they have not yet staked.
+- A mid-round stake **raises the round's cost**, so the max-win cap scales with
+  what the player actually paid rather than with the opening bet alone.
+- A mid-round award **spends** the round's max-win allowance. A round that
+  pays its ceiling on a step cannot pay it again at close.
+- Keys are deterministic per step: `"<sessionId>:<roundId>:stake:<stepIndex>"`
+  and the matching `award` form, so a resent step is the same movement rather
+  than a second one.
+
+The wallet guarantees:
+
+- Both are idempotent on `idempotencyKey`, like every other movement.
+- Neither closes the round. A `closeComplex` must still arrive, and the
+  autoclose backstop still applies.
+- A reversal of the round undoes mid-round movements along with the rest of it
+  (Guarantee 2: the round is one record).
 
 ### Reversal (optional)  - Guarantee 2, "One Round, One Record"
 


### PR DESCRIPTION
## Why

A round has never really been one debit and one credit. Buying a respin takes money while the round continues; a free-spin feature that pays per spin gives money back before the round is over. Today both have to be smuggled into the opening bet or held back until close, which makes an operator's ledger a work of fiction and makes "what did this round cost" unanswerable.

## What

- `StepOutcome` gains optional `stake` and `award` — multiples of the round's cost, so math stays currency-blind — plus `awardType`.
- `PlatformAdapter` gains optional `stakeComplex(req)` and `awardComplex(req)`.
- `ClientResponseStepRound` gains `balance`, `stake` and `win` when a step moved money.

Optional is the point. A wallet that models a round as one debit and one credit stays conformant, and a game that asks such a wallet for a mid-round movement fails that step with `STEP_FAILED` naming the missing method — the orchestrator never invents money the wallet has not agreed to move.

## The rules it enforces

- **Take before you give.** Within a step, `stakeComplex` runs before `awardComplex`, so a player cannot be paid out of a stake they have not yet paid.
- **A mid-round stake raises the round's cost**, so the max-win cap scales with what the player actually paid rather than with the opening bet alone.
- **A mid-round award spends the cap it uses.** A round that pays its ceiling on a step cannot pay it again at close — without this, the cap would only ever have limited a single movement rather than the round.
- **Keys are deterministic per step** (`<sessionId>:<roundId>:stake:<stepIndex>`), so a resent step is the same movement rather than a second one.

## Also in here

- `@open-rgs/platform-mock` implements both, so adapter authors have a reference.
- `@open-rgs/adapter-test-kit` checks them when present (including dedupe on a repeated key) and skips them when absent.
- `specs/05-platform-protocol.md` documents what each side guarantees.

## Testing

10 new tests in `packages/core/test/mid-round-money.test.ts` covering both directions, both refusals when the adapter lacks the method, insufficient balance mid-round, cost and cap arithmetic, ordering, and key derivation. Full suite green at 357.

🤖 Generated with [Claude Code](https://claude.com/claude-code)