### PR TITLE
Artube complex rounds, and four fixes the round lifecycle was hiding

### DIFF
--- a/.changeset/artube-complex-rounds.md
+++ b/.changeset/artube-complex-rounds.md
@@ -1,0 +1,32 @@
+---
+"@open-rgs/adapter-artube": minor
+---
+
+Artube adapter: complex rounds, platform autoclose, and major-unit amounts.
+
+`openComplex` / `updateComplex` / `closeComplex` threw — the adapter served
+simple-round games only. They are now `OpenRoundRequest` /
+`UpdateRoundStateRequest` / `CloseRoundRequest`, with the platform's
+`round_version` tracked per round (it is computed wallet-side, and a stale one
+is refused with `InvalidRoundOperation`).
+
+An `AutocloseRequestEvent` surfaces as `PlatformEvent{type:"autocloseRequested"}`,
+and the close the orchestrator answers it with goes back out as
+`AutocloseRoundRequest` rather than a plain close.
+
+Two fixes that were latent before complex rounds made them urgent:
+
+- **Amounts.** Artube states money in major units (`150.75`); open-rgs counts
+  integer minor units and refuses a fractional bet. An unconverted
+  `allowed_bets: [0.10, 0.25]` failed every round with `INVALID_BET`. Inbound
+  amounts are now scaled by `game_settings.currency_minimal_unit` (or
+  `currencyDecimals`). `amountScaling: "verbatim"` opts out.
+- **Events.** `BalanceChangedEvent` and friends were only matched without the
+  `Event` suffix; both spellings appear in Artube's docs and the suffixed ones
+  were being dropped as unknown types.
+
+Also: a close carries both the round's final state and the next round's carry
+into one wallet slot via a marked envelope (unmarked strings still read back
+verbatim); features are read from a `$features` key in the math's own state and
+sent as the open ∪ close union; and `schemaVersion: 2` opts into the
+per-contract Hello declaration.

--- a/.changeset/artube-complex-rounds.md
+++ b/.changeset/artube-complex-rounds.md
@@ -25,6 +25,11 @@ Two fixes that were latent before complex rounds made them urgent:
   `Event` suffix; both spellings appear in Artube's docs and the suffixed ones
   were being dropped as unknown types.
 
+A carry is read only from a round that finished. `last_round` is whatever the
+session touched last; while a round is open that is the open round, and its
+`round_state` is the math's in-flight state. Handing it back as the carry
+resets the meters of any player whose pod restarted mid-round.
+
 `previous_round_id` is not sent. It chains a round to the one it continues and
 the platform validates the link, so guessing it from the last round the adapter
 closed fails every open that follows a simple settle - found against the

--- a/.changeset/artube-complex-rounds.md
+++ b/.changeset/artube-complex-rounds.md
@@ -25,6 +25,12 @@ Two fixes that were latent before complex rounds made them urgent:
   `Event` suffix; both spellings appear in Artube's docs and the suffixed ones
   were being dropped as unknown types.
 
+`disconnect()` marks the adapter unhealthy synchronously. It was cleared in
+the socket's close handler, so between the call and the event landing
+`isHealthy` still read `true` - and whoever asks is deciding whether to route
+a round at it. Local machines fire close in the same tick and hide it; CI
+does not.
+
 A carry is read only from a round that finished. `last_round` is whatever the
 session touched last; while a round is open that is the open round, and its
 `round_state` is the math's in-flight state. Handing it back as the carry

--- a/.changeset/artube-complex-rounds.md
+++ b/.changeset/artube-complex-rounds.md
@@ -25,6 +25,11 @@ Two fixes that were latent before complex rounds made them urgent:
   `Event` suffix; both spellings appear in Artube's docs and the suffixed ones
   were being dropped as unknown types.
 
+`previous_round_id` is not sent. It chains a round to the one it continues and
+the platform validates the link, so guessing it from the last round the adapter
+closed fails every open that follows a simple settle - found against the
+sandbox, and the fake server now models the refusal.
+
 Also: a close carries both the round's final state and the next round's carry
 into one wallet slot via a marked envelope (unmarked strings still read back
 verbatim); features are read from a `$features` key in the math's own state and

--- a/.changeset/bet-coordinates-in-spin-context.md
+++ b/.changeset/bet-coordinates-in-spin-context.md
@@ -1,0 +1,26 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+---
+
+`SpinContext` now carries the round's `betIndex` and `priceMultiplier`.
+
+Math was currency-blind and also stake-blind: it could not tell a 0.10 round
+from a 10.00 one. That rules out a whole class of ordinary mechanics — a meter
+that fills in proportion to the stake, a ladder whose rungs differ per tier —
+unless the client sends its bet level in `params`, where a client that lies
+about it desyncs the mechanic from the money.
+
+Both fields come from `computeBet`, so they are the same numbers the wallet is
+charged against: the client's choice, the session default, or the bet a promo
+locked the round to. Currency-blindness is untouched — an index is not an
+amount, and the win is still `multiplier × bet` with `bet` owned by the
+orchestrator.
+
+Additive and optional: every existing math keeps compiling and behaving
+identically.
+
+`openComplex` now also stamps `mathVersion`, which `settleSimple` and
+`closeComplex` already did. Without it the adapter had no version to write at
+open and a round reported two different state-format versions across its own
+lifetime.

--- a/.changeset/complex-round-dev-fixes.md
+++ b/.changeset/complex-round-dev-fixes.md
@@ -1,0 +1,17 @@
+---
+"@open-rgs/core": patch
+---
+
+Two fixes on the complex-round path, both found by driving it end to end.
+
+**Forced outcomes never reached a complex round.** `openRound` passed
+`undefined` where `spin` passes `params.cheat`, so the dev-only cheat gate
+silently did nothing on the one round shape where a deterministic opening draw
+matters most - everything after the open is a branch off it. Same plumbing as
+`spin` now; the production gate is untouched (cheats still require an explicit
+opt-in and a non-production build).
+
+**`binaryTransport` reported the configured port, not the bound one.**
+`port: 0` means "bind anywhere", and the 0 was handed straight back to the
+caller and written to the listen log. Report `server.port`, which is the only
+case where the answer was not already known.

--- a/.changeset/legible-init-failure.md
+++ b/.changeset/legible-init-failure.md
@@ -1,0 +1,16 @@
+---
+"@open-rgs/core": patch
+---
+
+An INIT that the wallet refuses now says why.
+
+`platform.openSession` was the one platform call `init` did not run through
+`translate()`, so an upstream refusal arrived as a bare `Error`, became
+`INTERNAL_ERROR` at the transport, and reached the client as
+`internal error (ref: …)`. A session the wallet does not recognise is the
+single most common integration failure and it was also the least legible one -
+the actual reason was visible only in the pod's logs.
+
+It maps like every other platform call now: a wallet saying `SessionInvalid`
+produces `SESSION_INVALID` with the reason intact, and anything unrecognised
+still fails closed as `INIT_FAILED`.

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -33,8 +33,71 @@ await createServer({
   waiting for a TCP timeout that may never come.
 - **RPC deadlines.** Every request has one, so a wallet that goes quiet fails
   the round rather than hanging it.
+- **Simple rounds.** `settleSimple` is one `PlayRoundRequest`.
+- **Complex rounds.** `openComplex` / `updateComplex` / `closeComplex` are
+  `OpenRoundRequest` / `UpdateRoundStateRequest` / `CloseRoundRequest`.
+- **Autoclose.** An `AutocloseRequestEvent` from the platform surfaces as
+  `PlatformEvent{type:"autocloseRequested"}`, and the close it provokes goes
+  back out as `AutocloseRoundRequest`.
 - **Events.** `BalanceChanged` and `SessionClosed` are surfaced as
-  `PlatformEvent`s.
+  `PlatformEvent`s, with or without the `Event` suffix the docs use in
+  places.
+
+## Complex rounds
+
+`OpenRound` debits the stake and names the round; `UpdateRoundState` leaves
+the player's action log on the wallet; `CloseRound` credits the win. Three
+things in that flow are this wire's own and worth knowing before you meet
+them at integration time.
+
+**`round_version` is the platform's counter, not yours.** Open returns it,
+every update returns the next one, and each request must echo the newest one
+the wallet handed back. Send a stale number and the round is refused with
+`InvalidRoundOperation`. open-rgs has no concept of it, so the adapter tracks
+it per round. Two consequences: a close for a round this adapter never opened
+is refused locally rather than sent with a guessed version, and a close that
+fails leaves the round's bookkeeping in place so a retry (or an autoclose) can
+still use it.
+
+**One `round_state` slot, two pieces of state.** A close carries the round's
+final state *and* the carry the next round starts from; the wallet stores one
+opaque string. The adapter packs both:
+
+```json
+{ "$rgs": 1, "state": { "step": 9 }, "carry": { "meterPoints": 42 } }
+```
+
+`openSession` unpacks `carry` out of it again. A string that was never packed
+(a simple round's state, or anything written before this existed) is returned
+verbatim, so no meter resets on the first read after an upgrade. Because the
+wallet only persists the state of a round that moved money, this envelope is
+also the only cross-round storage a game gets here - there is no player-level
+bucket to put a meter in.
+
+**Features come from the math's own state.** `CloseComplex` has no features
+field, and putting an Artube concept in the neutral contract would be the
+wrong fix. Instead the math names them in its state under a reserved key:
+
+```ts
+{ "$features": ["PlayedGamble"], "step": 4 }
+```
+
+The adapter reads `$features` from the open, each update and the close, and
+sends the union on close - which is what the platform's merge rule asks for.
+`"$status": "cancelled"` in the final state closes the round as cancelled;
+anything else, a zero-win round included, is `completed`.
+
+## Amounts are converted, on purpose
+
+Artube states money in major units (`"balance": 150.75`). open-rgs counts
+integer minor units and refuses a fractional bet outright, so an unconverted
+`allowed_bets: [0.10, 0.25]` fails every round with `INVALID_BET`.
+
+Everything inbound - balance, the bet ladder, promo bet, `BalanceChanged` - is
+multiplied by the scale in `game_settings.currency_minimal_unit`, or by
+`10^currencyDecimals` when the wallet does not send one. Nothing outbound needs
+converting: this wire is amount-blind. `amountScaling: "verbatim"` turns it off
+for a wallet already configured in minor units.
 
 ## Amount-blindness is deliberate
 
@@ -60,14 +123,6 @@ The practical consequences:
 
 ## Known limitations
 
-Two, both properties of the Artube Games API rather than gaps in this code.
-They are listed because finding them at integration time is far worse than
-reading them now.
-
-**Complex rounds are not supported.** The API is one-shot, so `openComplex`,
-`updateComplex` and `closeComplex` throw rather than silently no-oping. This
-adapter serves simple-round games only.
-
 **`idempotencyKey` is dropped.** `PlayRoundRequest` has no idempotency field,
 so the key open-rgs generates never reaches the wallet. A retried settle after
 a timeout or a reconnect is **not deduplicated wallet-side**. If the socket
@@ -79,9 +134,12 @@ grows a field for it. This is the adapter's most significant gap.
 ## Conformance results
 
 `test/conformance.test.ts` runs `@open-rgs/adapter-test-kit` against a fake
-Artube server speaking the real wire protocol. Everything passes except two
-checks that the wire cannot express, and those are allowlisted with their
-reason rather than faked green:
+Artube server speaking the real wire protocol (`test/fake-artube.ts`, which
+refuses unknown sessions, stale `round_version`s and closed rounds the way the
+platform does). `test/complex.test.ts` asserts the frames themselves: which
+message type went out, which version rode on it, what landed in the state
+slot. Everything passes except two checks that the wire cannot express, and
+those are allowlisted with their reason rather than faked green:
 
 | Check | Why it cannot pass |
 |-------|--------------------|
@@ -99,6 +157,10 @@ kit changes, the allowlist goes red instead of quietly over-permitting.
 | `gameId` | Sent as the `X-Game-ID` header. |
 | `authToken` | Sent as the `X-Api-Key` header. Required in production. |
 | `rpcTimeoutMs` | Per-request deadline. Default 30000. |
+| `currencyDecimals` | Fallback precision when the wallet sends no `currency_minimal_unit`. Default 2. |
+| `amountScaling` | `"minor-units"` (default) converts inbound amounts; `"verbatim"` passes them through. |
+| `defaultRoundStateVersion` | `round_state_version` when the RGS has no math version to stamp. Default `"1"`. |
+| `schemaVersion` | Hello schema, 1 (default) or 2. Schema 2 declares all 16 contract types; a type left undeclared is never delivered on that connection. |
 | `handshakeTimeoutMs` | Hello to Welcome. Default 10000. |
 | `heartbeatIntervalMs` | Ping cadence. |
 | `heartbeatTimeoutMs` | How long a silent socket lives before it is terminated. |

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -50,6 +50,16 @@ the player's action log on the wallet; `CloseRound` credits the win. Three
 things in that flow are this wire's own and worth knowing before you meet
 them at integration time.
 
+**A round is not chained to whatever came before it.** `previous_round_id`
+links a round to the one it continues - a bonus to the base round that
+triggered it - and the platform validates the link: an id that is not this
+session's actual previous round is refused with `InvalidRoundOperation`
+("Invalid rounds sequence") and the open fails. The adapter does not send it.
+Guessing from the last round it happened to close is a different claim and is
+wrong the moment a simple settle, another pod or a restart comes between; and
+the contract has no field for a deliberate chain to forward. When it grows
+one, it belongs in `OpenComplex` rather than inferred here.
+
 **`round_version` is the platform's counter, not yours.** Open returns it,
 every update returns the next one, and each request must echo the newest one
 the wallet handed back. Send a stale number and the round is refused with

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -77,7 +77,12 @@ opaque string. The adapter packs both:
 { "$rgs": 1, "state": { "step": 9 }, "carry": { "meterPoints": 42 } }
 ```
 
-`openSession` unpacks `carry` out of it again. A string that was never packed
+`openSession` unpacks `carry` out of it again - but only from a round that
+*finished*. `last_round` is whatever the session touched last, and while a
+round is open that is the open round, whose `round_state` is the math's
+in-flight state rather than anything to carry forward. Handing that back is
+how a pod restart mid-round silently resets a player's meters, so an
+unfinished round yields no carry at all: unknown, not empty. A string that was never packed
 (a simple round's state, or anything written before this existed) is returned
 verbatim, so no meter resets on the first read after an upgrade. Because the
 wallet only persists the state of a round that moved money, this envelope is

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -14,21 +14,45 @@
 //   - Channels       rpc | events | control
 //   - RPCs           SessionInfoRequest, answered by SessionInfoResponse
 //                    PlayRoundRequest, answered by PlayRoundResponse
+//                    OpenRoundRequest / UpdateRoundStateRequest /
+//                    CloseRoundRequest / AutocloseRoundRequest, the
+//                    complex-round (interactive) trio plus the
+//                    platform-initiated close.
 //                    Errors arrive as type:"Error" with corr_id matching
 //                    the request; payload {code, message, details?}
-//   - Events         BalanceChanged, SessionClosed, NewConnection
+//   - Events         BalanceChanged, SessionClosed, NewConnection,
+//                    AutocloseRequest (with or without an `Event` suffix,
+//                    both spellings appear in Artube's docs).
 //   - GoAway         control/GoAway closes the WS; if retry_after_ms is
 //                    set we wait that long before reconnecting.
 //
 // Mapping to @open-rgs/contract:
-//   PlatformAdapter.openSession  is SessionInfoRequest
-//   PlatformAdapter.settleSimple is PlayRoundRequest
-//   PlatformAdapter.{openComplex,updateComplex,closeComplex}
-//                                are not supported (one-shot protocol).
-//                                   Throws E_NOT_SUPPORTED rather than
-//                                   silently no-oping.
-//   BalanceChanged event         becomes PlatformEvent{type:"balanceChanged"}
-//   SessionClosed  event         becomes PlatformEvent{type:"sessionClosed"}
+//   PlatformAdapter.openSession    is SessionInfoRequest
+//   PlatformAdapter.settleSimple   is PlayRoundRequest
+//   PlatformAdapter.openComplex    is OpenRoundRequest
+//   PlatformAdapter.updateComplex  is UpdateRoundStateRequest
+//   PlatformAdapter.closeComplex   is CloseRoundRequest, or
+//                                  AutocloseRoundRequest when the close
+//                                  carries a `reason` (platform-initiated).
+//   BalanceChanged event           becomes PlatformEvent{type:"balanceChanged"}
+//   SessionClosed  event           becomes PlatformEvent{type:"sessionClosed"}
+//   AutocloseRequest event         becomes PlatformEvent{type:"autocloseRequested"}
+//
+// Two things the wire forces on this adapter, both handled here rather
+// than pushed onto every game:
+//
+//   Amounts are major units. Artube speaks `150.75`; open-rgs money is
+//   integer minor units. Everything inbound (balance, allowed_bets,
+//   BalanceChanged) is scaled by 10^currencyDecimals, taken from
+//   `game_settings.currency_minimal_unit` when the wallet sends it.
+//   Nothing outbound needs scaling: this wire is amount-blind.
+//
+//   One round_state slot, two pieces of state. A complex close carries
+//   BOTH this round's final state and the cross-round carry, and the
+//   wallet stores exactly one opaque string. We pack them into one
+//   marked envelope (see packRoundState) and unpack on openSession, so
+//   the audit record keeps the real final state instead of losing it to
+//   the carry.
 //
 // NOT PUBLISHED. This package lives in the monorepo for the workspace, the
 // typecheck and the conformance run, and is marked `private` so `changeset
@@ -59,7 +83,8 @@ type Channel = "rpc" | "events" | "control";
 
 interface Envelope<T = unknown> {
   proto: 1;
-  schema: 1;
+  /** Negotiated at Hello. 1 unless the adapter was configured for 2. */
+  schema: number;
   chan: Channel;
   type: string;
   id: string;
@@ -69,7 +94,32 @@ interface Envelope<T = unknown> {
   payload: T;
 }
 
-interface HelloPayload   { supports: { max_schema: number } }
+interface HelloPayload {
+  supports: {
+    max_schema: number;
+    /** Schema 2 only: the contract types this backend can handle, and the
+     *  version range for each. Artube filters the connection down to this
+     *  list, so anything left out is never delivered. */
+    contracts?: Record<string, { min: number; max: number }>;
+    features?: string[];
+  };
+}
+
+/** Every contract type this adapter understands, for the schema-2 Hello.
+ *  Leaving one out would silently switch off that message for the whole
+ *  connection, so the list is exhaustive by construction rather than by
+ *  whatever happened to be needed when it was written. */
+const DECLARED_CONTRACTS = [
+  "SessionInfoRequest", "SessionInfoResponse",
+  "PlayRoundRequest", "PlayRoundResponse",
+  "OpenRoundRequest", "OpenRoundResponse",
+  "UpdateRoundStateRequest", "UpdateRoundStateResponse",
+  "CloseRoundRequest", "CloseRoundResponse",
+  "AutocloseRoundRequest",
+  "Error",
+  "BalanceChangedEvent", "SessionClosedEvent",
+  "AutocloseRequestEvent", "NewConnectionEvent",
+] as const;
 interface WelcomePayload { use:      { max_schema: number } }
 interface GoAwayPayload  { reason: string; retry_after_ms?: number }
 
@@ -90,6 +140,10 @@ interface ArtubeFreeRoundCampaign {
 interface ArtubeGameSettings {
   default_bet_index: number;
   allowed_bets: number[];
+  /** Smallest representable amount in the session currency (0.01 for a
+   *  2-decimal currency, 1 for a 0-decimal one). Optional on the wire;
+   *  when absent we fall back to the adapter's `currencyDecimals`. */
+  currency_minimal_unit?: number;
   available_auto_spin_counts: number[];
   rtp_options: Array<{ rtp: number; game_mode: string; volatility?: string }>;
   locales: string[];
@@ -102,7 +156,8 @@ interface ArtubeLastRound {
   win: number;
   free_round_campaign_id?: string;
   started_at: string;
-  finished_at: string;
+  /** Absent while the round is still open. */
+  finished_at?: string;
   round_version: number;
   round_state_version: string;
   round_state: string;
@@ -137,6 +192,76 @@ interface PlayRoundResponsePayload {
     is_complete: boolean;
   };
   is_platform_max_win_reached: boolean;
+}
+
+// -- Complex round: OpenRound -> UpdateRoundState* -> CloseRound --------
+//
+// `round_version` is the wallet's own per-round operation counter. It is
+// computed strictly on the Artube side: open returns it, every update
+// returns the next one, and each request must echo the latest one the
+// wallet handed back. Send a stale number and the round is refused with
+// InvalidRoundOperation, so the adapter tracks it per round rather than
+// asking the RGS (which has no concept of it) to carry it.
+
+interface ArtubeFeature { type: string }
+
+interface OpenRoundRequestPayload {
+  session_id: string;
+  price_multiplier: number;
+  bet_index: number;
+  free_round_campaign_id?: string;
+  previous_round_id?: string;
+  features?: ArtubeFeature[];
+  round_state_version: string;
+  round_state: string;
+}
+interface OpenRoundResponsePayload {
+  round_version: number;
+  round_id: string;
+  balance: number;
+}
+
+interface UpdateRoundStateRequestPayload {
+  session_id: string;
+  round_id: string;
+  round_version: number;
+  round_state_version: string;
+  round_state: string;
+}
+interface UpdateRoundStateResponsePayload {
+  round_version: number;
+}
+
+interface CloseRoundRequestPayload {
+  session_id: string;
+  round_id: string;
+  win_multiplier: number;
+  status: "completed" | "cancelled";
+  features?: ArtubeFeature[];
+  round_version: number;
+  round_state_version: string;
+  round_state: string;
+}
+interface CloseRoundResponsePayload {
+  balance: number;
+  win?: number;
+  free_round_campaign?: {
+    rounds_left: number;
+    total_win: number;
+    is_complete: boolean;
+  };
+  is_platform_max_win_reached?: boolean;
+}
+
+/** The platform asking us to finish a round it considers abandoned. It
+ *  carries the authoritative `round_version` to answer with, which is why
+ *  we stash it before handing the trigger up to the orchestrator. */
+interface AutocloseRequestEventPayload {
+  session_id: string;
+  round_id: string;
+  round_version: number;
+  round_state_version: string;
+  round_state: string;
 }
 
 interface ErrorPayload {
@@ -178,6 +303,28 @@ export interface ArtubeAdapterOptions {
    *  here to get artube lines into the same sink/format as everything
    *  else. */
   logger?: Logger;
+  /** Fractional digits of the session currency, used to convert Artube's
+   *  major-unit amounts (150.75) into the integer minor units open-rgs
+   *  counts money in (15075). Only a fallback: when the wallet sends
+   *  `game_settings.currency_minimal_unit` that value wins, because it is
+   *  per-session and this is not. Default 2. */
+  currencyDecimals?: number;
+  /** "minor-units" (default) scales every inbound amount as described
+   *  above. "verbatim" passes Artube's numbers through untouched - only
+   *  correct if your wallet is already configured in minor units, and it
+   *  will make `bet` non-integer on a 2-decimal ladder, which the
+   *  orchestrator refuses. Escape hatch, not a tuning knob. */
+  amountScaling?: "minor-units" | "verbatim";
+  /** `round_state_version` sent when the RGS has no math version to stamp
+   *  (the orchestrator omits it on a complex open). Default "1". */
+  defaultRoundStateVersion?: string;
+  /** Hello schema to negotiate. 1 (default) is the flat handshake. 2 adds
+   *  the per-contract version declaration - and with it Artube's filter:
+   *  a contract type you do not declare is never delivered on that
+   *  connection. We declare all 16, so 2 is safe; it is opt-in only
+   *  because a wallet that does not speak it closes the socket with
+   *  PolicyViolation rather than downgrading. */
+  schemaVersion?: 1 | 2;
 }
 
 // ── Adapter ──────────────────────────────────────────────────────────
@@ -187,6 +334,24 @@ interface PendingRpc {
   sentAt: number;
   resolve: (env: Envelope) => void;
   reject:  (err: Error) => void;
+}
+
+/** What the adapter remembers about a round the wallet has open. */
+interface OpenRoundBook {
+  sessionId: string;
+  /** Latest round_version the wallet handed back. */
+  version: number;
+  /** round_state_version stamped at open; reused when a later request has
+   *  no math version of its own, so one round reports one format version. */
+  stateVersion: string;
+  /** Union of every feature declared so far on this round. */
+  features: Set<string>;
+  /** Serialises the wallet calls for this round. `updateComplex` is
+   *  fire-and-forget in best-effort mode, so two updates can be in flight
+   *  at once; each would read the same `version` and the second would be
+   *  refused with InvalidRoundOperation. Chaining keeps version reads and
+   *  writes in order without a lock the rest of the adapter doesn't need. */
+  chain: Promise<unknown>;
 }
 
 export class ArtubeAdapter implements PlatformAdapter {
@@ -228,6 +393,25 @@ export class ArtubeAdapter implements PlatformAdapter {
   // Envelope op_seq counter (resets on each new connection)
   private opSeqCounter = 0;
 
+  // ── Complex-round bookkeeping ────────────────────────────────────────
+  // One entry per round that is open on the wallet. `version` is the
+  // wallet's round_version, the number every subsequent request on that
+  // round must echo; `features` accumulates so the close can send the
+  // open-union-close set the docs ask for. The entry dies with the close.
+  private readonly rounds = new Map<string, OpenRoundBook>();
+  // Last round we closed on a session, sent as `previous_round_id` on the
+  // next open so the wallet can chain them. Purely informational upstream.
+  private readonly lastClosedRound = new Map<string, string>();
+  // Per-session minor-unit scale, learned from SessionInfo. Events carry a
+  // balance but no currency metadata, so without this an out-of-band
+  // BalanceChanged would arrive in different units than every other amount.
+  private readonly sessionScale = new Map<string, number>();
+
+  private readonly currencyDecimals: number;
+  private readonly scaleAmounts: boolean;
+  private readonly defaultRoundStateVersion: string;
+  private readonly schemaVersion: 1 | 2;
+
   private readonly gameId: string;
   private readonly apiKey: string | undefined;
   private readonly wsUrl: string;
@@ -250,6 +434,10 @@ export class ArtubeAdapter implements PlatformAdapter {
     this.maxReconnectAttempts = opts.maxReconnectAttempts ?? 20;
     this.heartbeatIntervalMs  = opts.heartbeatIntervalMs  ?? 20_000;
     this.heartbeatTimeoutMs   = opts.heartbeatTimeoutMs   ?? 60_000;
+    this.currencyDecimals     = opts.currencyDecimals     ?? 2;
+    this.scaleAmounts         = (opts.amountScaling ?? "minor-units") === "minor-units";
+    this.defaultRoundStateVersion = opts.defaultRoundStateVersion ?? "1";
+    this.schemaVersion        = opts.schemaVersion        ?? 1;
 
     // Caller can hand us a server-core logger so everything flows
     // through one sink/format. Default keeps the adapter usable on
@@ -280,6 +468,9 @@ export class ArtubeAdapter implements PlatformAdapter {
       "artube.handshake_timeout_ms":  this.handshakeTimeoutMs,
       "artube.reconnect_base_ms":     this.reconnectBaseMs,
       "artube.max_reconnect_attempts": this.maxReconnectAttempts,
+      "artube.schema_version":         this.schemaVersion,
+      "artube.amount_scaling":         this.scaleAmounts ? "minor-units" : "verbatim",
+      "artube.currency_decimals":      this.currencyDecimals,
     });
   }
 
@@ -328,6 +519,9 @@ export class ArtubeAdapter implements PlatformAdapter {
       heartbeat_interval_ms:  this.heartbeatIntervalMs,
       heartbeat_timeout_ms:   this.heartbeatTimeoutMs,
       heartbeat_silent_ms:    this.lastPongAt ? Date.now() - this.lastPongAt : null,
+      open_complex_rounds:    this.rounds.size,
+      schema_version:         this.schemaVersion,
+      amount_scaling:         this.scaleAmounts ? "minor-units" : "verbatim",
     };
   }
 
@@ -343,7 +537,9 @@ export class ArtubeAdapter implements PlatformAdapter {
         player_connection_info: { player_connection_id: connectionId },
       },
     );
-    return artubeSessionToContract(sessionId, env.payload);
+    const scale = this.scaleFor(env.payload.game_settings);
+    this.sessionScale.set(sessionId, scale);
+    return artubeSessionToContract(sessionId, env.payload, scale, this.currencyDecimals);
   }
 
   async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
@@ -365,19 +561,168 @@ export class ArtubeAdapter implements PlatformAdapter {
       "PlayRoundRequest",
       payload,
     );
-    return artubePlayRoundToReceipt(env.payload);
+    const receipt: RoundReceipt = {
+      roundId: env.payload.round_id,
+      balance: this.toMinor(env.payload.balance, req.sessionId),
+    };
+    if (env.payload.free_round_campaign) {
+      receipt.promo = { remaining: env.payload.free_round_campaign.rounds_left };
+    }
+    return receipt;
   }
 
-  // Artube Games-API is a one-shot PlayRound. There is no debit-only
-  // open + step + credit-only close shape. Fail loudly instead of pretending.
-  async openComplex(_: OpenComplex): Promise<RoundReceipt> {
-    throw new Error("ArtubeAdapter: complex rounds are not supported by Artube Games-API (one-shot PlayRound only)");
+  // ── Complex rounds ──────────────────────────────────────────────────
+  //
+  // OpenRound debits the stake and returns the round id the rest of the
+  // round is addressed by. Nothing else moves money until CloseRound.
+
+  async openComplex(req: OpenComplex): Promise<RoundReceipt> {
+    const stateVersion = req.mathVersion ?? this.defaultRoundStateVersion;
+    const features = extractFeatures(req.initialState);
+    const previous = this.lastClosedRound.get(req.sessionId);
+
+    const payload: OpenRoundRequestPayload = {
+      session_id:          req.sessionId,
+      price_multiplier:    req.priceMultiplier,
+      bet_index:           req.betIndex,
+      ...(req.promoId  ? { free_round_campaign_id: req.promoId } : {}),
+      ...(previous     ? { previous_round_id: previous } : {}),
+      ...(features.length > 0 ? { features: features.map((type) => ({ type })) } : {}),
+      round_state_version: stateVersion,
+      round_state:         packRoundState(req.initialState),
+    };
+
+    const env = await this.rpc<OpenRoundRequestPayload, OpenRoundResponsePayload>(
+      "OpenRoundRequest",
+      payload,
+    );
+
+    this.rounds.set(env.payload.round_id, {
+      sessionId:    req.sessionId,
+      version:      env.payload.round_version,
+      stateVersion,
+      features:     new Set(features),
+      chain:        Promise.resolve(),
+    });
+
+    this.log.info("Artube complex round opened", {
+      "event.category": "artube",
+      "event.action":   "round_open",
+      "artube.round_id":      env.payload.round_id,
+      "artube.round_version": env.payload.round_version,
+      "artube.bet_index":     req.betIndex,
+      "artube.price_multiplier": req.priceMultiplier,
+    });
+
+    return {
+      roundId: env.payload.round_id,
+      balance: this.toMinor(env.payload.balance, req.sessionId),
+    };
   }
-  async updateComplex(_: UpdateComplex): Promise<void> {
-    throw new Error("ArtubeAdapter: complex rounds are not supported by Artube Games-API");
+
+  /** Audit checkpoint. Moves no money; its only job is to leave the
+   *  player's action log on the wallet side, which is what a regulator
+   *  reconstructs a disputed round from. */
+  async updateComplex(req: UpdateComplex): Promise<void> {
+    const book = this.rounds.get(req.roundId);
+    if (!book) {
+      throw new Error(`ArtubeAdapter: no open round ${req.roundId} to update`);
+    }
+    await this.onRound(book, async () => {
+      const env = await this.rpc<UpdateRoundStateRequestPayload, UpdateRoundStateResponsePayload>(
+        "UpdateRoundStateRequest",
+        {
+          session_id:          req.sessionId,
+          round_id:            req.roundId,
+          round_version:       book.version,
+          round_state_version: book.stateVersion,
+          round_state:         packRoundState(req.state),
+        },
+      );
+      for (const f of extractFeatures(req.state)) book.features.add(f);
+      book.version = env.payload.round_version;
+    });
   }
-  async closeComplex(_: CloseComplex): Promise<RoundReceipt> {
-    throw new Error("ArtubeAdapter: complex rounds are not supported by Artube Games-API");
+
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+    const book = this.rounds.get(req.roundId);
+    if (!book) {
+      // An unknown round is not something to paper over: the money for it
+      // was taken by an open this adapter never saw (another pod, a restart),
+      // and guessing a round_version would either be refused or - worse -
+      // land on a version that means something else.
+      throw new Error(`ArtubeAdapter: no open round ${req.roundId} to close`);
+    }
+
+    // `reason` is set only when the close was triggered from outside the
+    // player's own flow, which on this wire is exactly the platform's
+    // autoclose. Same payload, different type, and the platform matches it
+    // against the AutocloseRequestEvent it sent us.
+    const isAutoclose = req.reason !== undefined;
+    const type = isAutoclose ? "AutocloseRoundRequest" : "CloseRoundRequest";
+
+    for (const f of extractFeatures(req.finalState)) book.features.add(f);
+    const features = [...book.features];
+
+    const payload: CloseRoundRequestPayload = {
+      session_id:          req.sessionId,
+      round_id:            req.roundId,
+      win_multiplier:      req.multiplier,
+      status:              closeStatus(req.finalState),
+      ...(features.length > 0 ? { features: features.map((t) => ({ type: t })) } : {}),
+      round_version:       book.version,
+      round_state_version: req.mathVersion ?? book.stateVersion,
+      round_state:         packRoundState(req.finalState, req.carry),
+    };
+
+    let env: Envelope<CloseRoundResponsePayload>;
+    try {
+      env = await this.onRound(book, () =>
+        this.rpc<CloseRoundRequestPayload, CloseRoundResponsePayload>(type, payload));
+    } catch (e) {
+      // Leave the book entry in place. The round is still open wallet-side,
+      // and the orchestrator keeps its own open round for a retry or an
+      // autoclose; dropping our version here would make that retry fail for
+      // a second, unrelated reason.
+      this.log.error("Artube complex round close failed", {
+        "event.category": "artube",
+        "event.action":   "round_close_failed",
+        "artube.round_id":   req.roundId,
+        "artube.autoclose":  isAutoclose,
+        "error.message":     e instanceof Error ? e.message : String(e),
+      });
+      throw e;
+    }
+
+    this.rounds.delete(req.roundId);
+    this.lastClosedRound.set(req.sessionId, req.roundId);
+
+    this.log.info("Artube complex round closed", {
+      "event.category": "artube",
+      "event.action":   "round_close",
+      "artube.round_id":       req.roundId,
+      "artube.autoclose":      isAutoclose,
+      "artube.win_multiplier": req.multiplier,
+      "artube.features":       features.join(",") || undefined,
+      "artube.reason":         req.reason,
+    });
+
+    const receipt: RoundReceipt = {
+      roundId: req.roundId,
+      balance: this.toMinor(env.payload.balance, req.sessionId),
+    };
+    if (env.payload.free_round_campaign) {
+      receipt.promo = { remaining: env.payload.free_round_campaign.rounds_left };
+    }
+    return receipt;
+  }
+
+  /** Run `fn` after everything already queued on this round, and keep the
+   *  queue alive whatever `fn` does. */
+  private onRound<T>(book: OpenRoundBook, fn: () => Promise<T>): Promise<T> {
+    const next = book.chain.then(fn, fn);
+    book.chain = next.catch(() => undefined);
+    return next;
   }
 
   // ── Connection lifecycle ────────────────────────────────────────────
@@ -431,9 +776,8 @@ export class ArtubeAdapter implements PlatformAdapter {
       });
       this.reconnectAttempts = 0;
       this.startHeartbeat();
-      const hello = this.makeEnvelope<HelloPayload>("control", "Hello", {
-        supports: { max_schema: 1 },
-      });
+      const hello = this.makeEnvelope<HelloPayload>("control", "Hello", this.helloPayload());
+      hello.schema = this.schemaVersion;
       this.send(hello);
     });
 
@@ -747,15 +1091,57 @@ export class ArtubeAdapter implements PlatformAdapter {
 
   private dispatchEvent(msg: Envelope): void {
     let translated: PlatformEvent | null = null;
-    switch (msg.type) {
+    // Artube's docs use both `BalanceChanged` and `BalanceChangedEvent` for
+    // the same message. Match on the stem so a wallet that picks either
+    // spelling is understood, instead of falling into the unknown-type
+    // branch and dropping a balance update on the floor.
+    switch (msg.type.replace(/Event$/, "")) {
       case "BalanceChanged": {
         const p = msg.payload as BalanceChangedPayload;
-        translated = { type: "balanceChanged", sessionId: p.session_id, balance: p.balance, reason: p.reason };
+        translated = {
+          type: "balanceChanged",
+          sessionId: p.session_id,
+          balance: this.toMinor(p.balance, p.session_id),
+          reason: p.reason,
+        };
         break;
       }
       case "SessionClosed": {
         const p = msg.payload as SessionClosedPayload;
         translated = { type: "sessionClosed", sessionId: p.session_id, reason: p.reason };
+        break;
+      }
+      case "AutocloseRequest": {
+        // The platform decided this round has been open long enough. Its
+        // round_version is the one the AutocloseRoundRequest must carry, and
+        // it is newer than ours whenever the platform wrote state itself, so
+        // take it over what we last recorded.
+        const p = msg.payload as AutocloseRequestEventPayload;
+        const book = this.rounds.get(p.round_id);
+        if (book) {
+          book.version = p.round_version;
+          if (p.round_state_version) book.stateVersion = p.round_state_version;
+        } else {
+          this.log.warn("Artube autoclose for a round this adapter has no book for", {
+            "event.category": "artube",
+            "event.action":   "autoclose_unknown_round",
+            "artube.round_id":   p.round_id,
+            "artube.session_id": p.session_id,
+          });
+        }
+        this.log.info("Artube autoclose requested", {
+          "event.category": "artube",
+          "event.action":   "autoclose_requested",
+          "artube.round_id":      p.round_id,
+          "artube.session_id":    p.session_id,
+          "artube.round_version": p.round_version,
+        });
+        translated = {
+          type: "autocloseRequested",
+          sessionId: p.session_id,
+          roundId: p.round_id,
+          reason: "platform-autoclose",
+        };
         break;
       }
       case "NewConnection": {
@@ -859,6 +1245,40 @@ export class ArtubeAdapter implements PlatformAdapter {
     this.ws.send(json);
   }
 
+  private helloPayload(): HelloPayload {
+    if (this.schemaVersion < 2) return { supports: { max_schema: 1 } };
+    const contracts: Record<string, { min: number; max: number }> = {};
+    for (const c of DECLARED_CONTRACTS) contracts[c] = { min: 1, max: 1 };
+    return { supports: { max_schema: 2, contracts, features: [] } };
+  }
+
+  /** Minor units per major unit for a session. `currency_minimal_unit` is
+   *  the wallet's own statement of its precision, so it beats the adapter's
+   *  configured default whenever it is present. */
+  private scaleFor(gs: ArtubeGameSettings): number {
+    if (!this.scaleAmounts) return 1;
+    const unit = gs.currency_minimal_unit;
+    if (typeof unit === "number" && unit > 0) {
+      const scale = Math.round(1 / unit);
+      // Guard against a malformed unit turning every amount into nonsense:
+      // only accept it if it round-trips to a clean power of ten.
+      if (scale >= 1 && Math.abs(1 / scale - unit) < 1e-9) return scale;
+      this.log.warn("Artube currency_minimal_unit is not a clean power of ten, using configured decimals", {
+        "event.category": "artube",
+        "event.action":   "currency_unit_rejected",
+        "artube.currency_minimal_unit": unit,
+      });
+    }
+    return 10 ** this.currencyDecimals;
+  }
+
+  /** Artube amount -> open-rgs integer minor units. */
+  private toMinor(amount: number, sessionId: string): number {
+    if (!this.scaleAmounts) return amount;
+    const scale = this.sessionScale.get(sessionId) ?? 10 ** this.currencyDecimals;
+    return scale === 1 ? amount : Math.round(amount * scale);
+  }
+
   private makeEnvelope<T>(chan: Channel, type: string, payload: T): Envelope<T> {
     return {
       proto: 1, schema: 1, chan, type,
@@ -888,24 +1308,31 @@ export class ArtubeAdapter implements PlatformAdapter {
 function artubeSessionToContract(
   sessionId: string,
   p: SessionInfoResponsePayload,
+  scale: number,
+  fallbackDecimals: number,
 ): SessionInfo {
+  // Artube states amounts in major units (150.75); open-rgs counts integer
+  // minor units (15075) and refuses a fractional bet outright. `scale` is
+  // the per-session conversion, derived from the wallet's own
+  // currency_minimal_unit when it sends one.
+  const decimals = scale > 1 ? Math.round(Math.log10(scale)) : fallbackDecimals;
+  // scale === 1 is the verbatim escape hatch: pass the wallet's own numbers
+  // through untouched. Rounding them "by 1" would floor a 0.25 ladder rung
+  // to 0, which is a worse answer than the one the hatch exists to give.
+  const conv = (n: number) => (scale === 1 ? n : Math.round(n * scale));
   const info: SessionInfo = {
     sessionId,
     currency:        p.currency,
-    // Artube wire amounts are minor units of a 2-decimal currency
-    // (EUR/USD/RUB-class). The wire schema does not carry a
-    // precision field, if Artube ever supports JPY (0) or BTC (8),
-    // this needs to become per-currency lookup or per-session metadata.
-    currencyDecimals: 2,
-    balance:         p.balance,
-    allowedBets:     p.game_settings.allowed_bets,
+    currencyDecimals: decimals,
+    balance:         conv(p.balance),
+    allowedBets:     p.game_settings.allowed_bets.map(conv),
     defaultBetIndex: p.game_settings.default_bet_index,
   };
   if (p.free_round_campaign && !p.free_round_campaign.is_complete) {
-    info.promo = artubeCampaignToPromo(p.free_round_campaign);
+    info.promo = artubeCampaignToPromo(p.free_round_campaign, scale);
   }
   if (p.last_round) {
-    info.carry = p.last_round.round_state;
+    info.carry = unpackCarry(p.last_round.round_state);
     // `round_state_version` is the field the settle WRITES mathVersion into
     // (see settleSimple), so it is the field to read it back from.
     // `round_version` is the wallet's own round counter, an unrelated number:
@@ -922,23 +1349,91 @@ function artubeSessionToContract(
  *  neutral PromoFreeRounds. The Artube-specific tracking fields
  *  (total_win, is_complete, valid_from) stay inside this adapter, 
  *  the platform's bonus engine owns those numbers, not the RGS. */
-function artubeCampaignToPromo(c: ArtubeFreeRoundCampaign): PromoFreeRounds {
+function artubeCampaignToPromo(c: ArtubeFreeRoundCampaign, scale: number): PromoFreeRounds {
   return {
     id:        c.campaign_id,
-    bet:       c.bet,
+    bet:       scale === 1 ? c.bet : Math.round(c.bet * scale),
     remaining: c.rounds_left,
     total:     c.rounds_total,
     validTo:   c.valid_to,
   };
 }
 
-function artubePlayRoundToReceipt(p: PlayRoundResponsePayload): RoundReceipt {
-  const receipt: RoundReceipt = {
-    roundId: p.round_id,
-    balance: p.balance,
+// ── round_state packing ──────────────────────────────────────────────
+//
+// Artube gives a round ONE opaque state slot. A complex close has two
+// things to keep: the round's own final state (what an auditor replays)
+// and the carry the next round starts from. Packing both under a marker
+// keeps the audit record honest and still lets openSession hand the RGS
+// back a carry it can use.
+//
+// A simple round has only one (its state IS its carry), so it is written
+// unpacked - and an unmarked string read back is returned verbatim, which
+// is what keeps rounds written by older builds readable.
+
+const RGS_ENVELOPE_MARK = "$rgs";
+
+interface RoundStateEnvelope {
+  [RGS_ENVELOPE_MARK]: 1;
+  state: unknown;
+  carry?: unknown;
+}
+
+/** Parse if it is JSON, otherwise hand back the raw string. Stored parsed
+ *  so the wallet's back office shows a round state, not an escaped blob. */
+function asJsonOrString(s: string): unknown {
+  if (s === "") return "";
+  try { return JSON.parse(s) as unknown; } catch { return s; }
+}
+
+function fromJsonOrString(v: unknown): string {
+  return typeof v === "string" ? v : JSON.stringify(v);
+}
+
+/** `state` alone when there is no carry to keep; both under the marker
+ *  when there is. */
+function packRoundState(state: string, carry?: string): string {
+  if (carry === undefined) return state;
+  const env: RoundStateEnvelope = {
+    [RGS_ENVELOPE_MARK]: 1,
+    state: asJsonOrString(state),
+    carry: asJsonOrString(carry),
   };
-  if (p.free_round_campaign) {
-    receipt.promo = { remaining: p.free_round_campaign.rounds_left };
+  return JSON.stringify(env);
+}
+
+/** What the next round should start from: the carry out of a packed
+ *  envelope, or the whole string when it was never packed. */
+function unpackCarry(roundState: string): string {
+  const parsed = asJsonOrString(roundState);
+  if (parsed !== null && typeof parsed === "object" && (parsed as Record<string, unknown>)[RGS_ENVELOPE_MARK] === 1) {
+    const env = parsed as unknown as RoundStateEnvelope;
+    return env.carry === undefined ? "" : fromJsonOrString(env.carry);
   }
-  return receipt;
+  return roundState;
+}
+
+/** Features the math declared, read from a reserved key in its own state.
+ *  The contract has no field for them and inventing one would put an
+ *  Artube concept in the neutral surface, so the math says it where it
+ *  already says everything else. */
+function extractFeatures(state: string): string[] {
+  const parsed = asJsonOrString(state);
+  if (parsed === null || typeof parsed !== "object") return [];
+  const raw = (parsed as Record<string, unknown>)["$features"];
+  if (!Array.isArray(raw)) return [];
+  const out = new Set<string>();
+  for (const f of raw) if (typeof f === "string" && f !== "") out.add(f);
+  return [...out];
+}
+
+/** "cancelled" only when the math asks for it by name. Everything else,
+ *  a zero-win round included, is a round that completed. */
+function closeStatus(state: string): "completed" | "cancelled" {
+  const parsed = asJsonOrString(state);
+  if (parsed !== null && typeof parsed === "object"
+      && (parsed as Record<string, unknown>)["$status"] === "cancelled") {
+    return "cancelled";
+  }
+  return "completed";
 }

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -480,6 +480,12 @@ export class ArtubeAdapter implements PlatformAdapter {
 
   disconnect(): void {
     this.shouldReconnect = false;
+    // Synchronously, before the socket has finished closing. `ready` was
+    // cleared in the close handler, so between calling disconnect() and the
+    // event landing the adapter still answered isHealthy: true - and a caller
+    // that asks is deciding whether to route a round at it. A machine fast
+    // enough to fire close inside the same tick hides this; CI is not.
+    this.ready = false;
     this.stopHeartbeat();
     if (this.reconnectTimer) {
       clearTimeout(this.reconnectTimer);

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -399,9 +399,6 @@ export class ArtubeAdapter implements PlatformAdapter {
   // round must echo; `features` accumulates so the close can send the
   // open-union-close set the docs ask for. The entry dies with the close.
   private readonly rounds = new Map<string, OpenRoundBook>();
-  // Last round we closed on a session, sent as `previous_round_id` on the
-  // next open so the wallet can chain them. Purely informational upstream.
-  private readonly lastClosedRound = new Map<string, string>();
   // Per-session minor-unit scale, learned from SessionInfo. Events carry a
   // balance but no currency metadata, so without this an out-of-band
   // BalanceChanged would arrive in different units than every other amount.
@@ -579,14 +576,22 @@ export class ArtubeAdapter implements PlatformAdapter {
   async openComplex(req: OpenComplex): Promise<RoundReceipt> {
     const stateVersion = req.mathVersion ?? this.defaultRoundStateVersion;
     const features = extractFeatures(req.initialState);
-    const previous = this.lastClosedRound.get(req.sessionId);
 
+    // No `previous_round_id`. It chains one round to another - a bonus
+    // continuing the base round that triggered it - and the platform
+    // validates the chain: a round id that is not actually this session's
+    // previous round is refused with InvalidRoundOperation ("Invalid rounds
+    // sequence"), which fails the open and strands nothing but the player's
+    // patience. Sending the last round this adapter happened to close is not
+    // the same claim: simple settles do not update it, another pod may have
+    // served the round in between, and either way the RGS has no concept of
+    // a deliberate chain to tell us about. When open-rgs grows one, it
+    // belongs in OpenComplex as an explicit field rather than inferred here.
     const payload: OpenRoundRequestPayload = {
       session_id:          req.sessionId,
       price_multiplier:    req.priceMultiplier,
       bet_index:           req.betIndex,
       ...(req.promoId  ? { free_round_campaign_id: req.promoId } : {}),
-      ...(previous     ? { previous_round_id: previous } : {}),
       ...(features.length > 0 ? { features: features.map((type) => ({ type })) } : {}),
       round_state_version: stateVersion,
       round_state:         packRoundState(req.initialState),
@@ -695,7 +700,6 @@ export class ArtubeAdapter implements PlatformAdapter {
     }
 
     this.rounds.delete(req.roundId);
-    this.lastClosedRound.set(req.sessionId, req.roundId);
 
     this.log.info("Artube complex round closed", {
       "event.category": "artube",

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -1335,7 +1335,18 @@ function artubeSessionToContract(
   if (p.free_round_campaign && !p.free_round_campaign.is_complete) {
     info.promo = artubeCampaignToPromo(p.free_round_campaign, scale);
   }
-  if (p.last_round) {
+  // Only a FINISHED round carries anything forward. `last_round` is whatever
+  // round the session touched last, and while one is open that is the open
+  // round: its `round_state` is the math's in-flight state, not a carry. The
+  // RGS was being handed it anyway, so a game whose carry parser tolerates
+  // the shape read a round's innards as a carry, and one that does not read
+  // it as a brand-new player - silently resetting the meters of anyone whose
+  // pod restarted mid-round.
+  //
+  // No carry is the honest answer here: it is unknown, not empty. The
+  // orchestrator resumes from its own memory when it still has the session,
+  // and this path is what runs when it does not.
+  if (p.last_round && p.last_round.finished_at) {
     info.carry = unpackCarry(p.last_round.round_state);
     // `round_state_version` is the field the settle WRITES mathVersion into
     // (see settleSimple), so it is the field to read it back from.

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -183,6 +183,29 @@ describe("complex rounds", () => {
     expect((bal as { balance: number }).balance).toBe(fake.balanceMinor("s6"));
   });
 
+  test("an unfinished round is not read back as a carry", async () => {
+    // last_round is whatever the session touched last, and while a round is
+    // open that is the open round - whose round_state is the math's in-flight
+    // state. Handing it back as the carry resets the meters of anyone whose
+    // pod restarted mid-round.
+    const { adapter } = await connect();
+    await adapter.openSession("open-carry", "c1");
+    await adapter.settleSimple({
+      sessionId: "open-carry", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss",
+      roundState: JSON.stringify({ meterPoints: 11 }),
+    });
+    expect(JSON.parse((await adapter.openSession("open-carry", "c2")).carry!)).toEqual({ meterPoints: 11 });
+
+    await adapter.openComplex({
+      sessionId: "open-carry", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ phase: "decide", pending: 2 }),
+    });
+    // Unknown, not empty, and above all not the open round's own state.
+    const during = await adapter.openSession("open-carry", "c3");
+    expect(during.carry).toBeUndefined();
+  });
+
   test("an open does not chain itself to whatever round came before", async () => {
     // previous_round_id links a round to the one it continues - a bonus to
     // the base round that triggered it. Sending the last round this adapter

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -183,6 +183,41 @@ describe("complex rounds", () => {
     expect((bal as { balance: number }).balance).toBe(fake.balanceMinor("s6"));
   });
 
+  test("an open does not chain itself to whatever round came before", async () => {
+    // previous_round_id links a round to the one it continues - a bonus to
+    // the base round that triggered it. Sending the last round this adapter
+    // happened to close is a different claim, and the platform refuses it
+    // with "Invalid rounds sequence" whenever the guess is wrong: after a
+    // simple settle, after another pod served a round, after a restart.
+    const { fake, adapter } = await connect();
+    await adapter.openSession("chain", "c1");
+    await adapter.settleSimple({
+      sessionId: "chain", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+    });
+    const first = await adapter.openComplex({
+      sessionId: "chain", bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}",
+    });
+    await adapter.closeComplex({
+      sessionId: "chain", roundId: first.roundId,
+      finalState: "{}", win: 0, multiplier: 0, type: "loss",
+    });
+    // The one that used to fail: a complex open straight after a complex
+    // close, with a simple round's settle in between having moved the
+    // wallet's idea of "previous" on.
+    await adapter.settleSimple({
+      sessionId: "chain", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+    });
+    const second = await adapter.openComplex({
+      sessionId: "chain", bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}",
+    });
+    expect(second.roundId).toBeTruthy();
+    for (const frame of fake.sent("OpenRoundRequest")) {
+      expect(frame.payload["previous_round_id"]).toBeUndefined();
+    }
+  });
+
   test("closing a round this adapter never opened is refused locally", async () => {
     // Not forwarded as a guessed round_version: the money for such a round
     // was moved by an open we never saw, and a wrong version is either

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -1,0 +1,266 @@
+// The complex-round half of the wire, checked frame by frame.
+//
+// These assertions are about the things a passing balance cannot prove:
+// which message type went out, what round_version rode on it, what ended up
+// in the wallet's one round_state slot, and whether an autoclose the
+// platform asked for came back as the autoclose message it expects.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { PlatformEvent } from "@open-rgs/contract";
+import { ArtubeAdapter } from "../src/index.js";
+import { fakeArtube, type FakeArtube, type FakeArtubeOptions } from "./fake-artube.js";
+
+let open: { fake: FakeArtube; adapter: ArtubeAdapter } | null = null;
+
+async function connect(opts: FakeArtubeOptions = {}, adapterOpts: Record<string, unknown> = {}) {
+  const fake = fakeArtube(opts);
+  const events: PlatformEvent[] = [];
+  const adapter = new ArtubeAdapter({
+    wsUrl: fake.url,
+    gameId: "complex-test",
+    authToken: "test-key",
+    handshakeTimeoutMs: 5_000,
+    rpcTimeoutMs: 5_000,
+    ...adapterOpts,
+  });
+  adapter.onEvent((e) => events.push(e));
+  await adapter.connect();
+  open = { fake, adapter };
+  return { fake, adapter, events };
+}
+
+afterEach(() => {
+  open?.adapter.disconnect();
+  open?.fake.stop();
+  open = null;
+});
+
+/** Wait for `pred` to hold, or fail loudly. Events arrive on the socket, so
+ *  a bare assertion right after a send is a race. */
+async function until(pred: () => boolean, what: string, ms = 2_000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await Bun.sleep(5);
+  }
+}
+
+describe("complex rounds", () => {
+  test("open -> update -> close threads the wallet's round_version", async () => {
+    const { fake, adapter } = await connect();
+    await adapter.openSession("s1", "c1");
+
+    const opened = await adapter.openComplex({
+      sessionId: "s1", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ step: 1 }),
+      mathVersion: "3.2.1",
+    });
+    expect(opened.roundId).toBeTruthy();
+    expect(opened.balance).toBe(1_000_000 - 100);
+
+    await adapter.updateComplex!({ sessionId: "s1", roundId: opened.roundId, state: JSON.stringify({ step: 2 }) });
+    await adapter.updateComplex!({ sessionId: "s1", roundId: opened.roundId, state: JSON.stringify({ step: 3 }) });
+
+    const closed = await adapter.closeComplex({
+      sessionId: "s1", roundId: opened.roundId,
+      finalState: JSON.stringify({ step: 4 }),
+      win: 400, multiplier: 4, type: "win",
+    });
+    expect(closed.balance).toBe(1_000_000 - 100 + 400);
+
+    // 0 from the open, then each update answers with the next one. A stale
+    // number here is InvalidRoundOperation on the real platform, which is
+    // why this is asserted on the frames and not just on the balance.
+    expect(fake.sent("UpdateRoundStateRequest").map((f) => f.payload["round_version"])).toEqual([0, 1]);
+    expect(fake.sent("CloseRoundRequest")[0]!.payload["round_version"]).toBe(2);
+    expect(fake.sent("OpenRoundRequest")[0]!.payload["round_state_version"]).toBe("3.2.1");
+  });
+
+  test("the close packs final state AND carry into the one state slot", async () => {
+    const { fake, adapter } = await connect();
+    await adapter.openSession("s2", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "s2", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ step: 1 }),
+    });
+    await adapter.closeComplex({
+      sessionId: "s2", roundId: opened.roundId,
+      finalState: JSON.stringify({ step: 9, pending: 0 }),
+      carry: JSON.stringify({ meterPoints: 42 }),
+      win: 0, multiplier: 0, type: "loss",
+      mathVersion: "1.0.0",
+    });
+
+    const stored = fake.lastRoundState("s2")!;
+    const parsed = JSON.parse(stored) as Record<string, unknown>;
+    // The audit record keeps the round's own final state...
+    expect(parsed["state"]).toEqual({ step: 9, pending: 0 });
+    // ...and the carry rides alongside it rather than overwriting it.
+    expect(parsed["carry"]).toEqual({ meterPoints: 42 });
+
+    // And it comes back out as the carry for the next round.
+    const info = await adapter.openSession("s2", "c2");
+    expect(JSON.parse(info.carry!)).toEqual({ meterPoints: 42 });
+    expect(info.mathVersion).toBe("1.0.0");
+  });
+
+  test("a round_state written without an envelope still reads back as carry", async () => {
+    // Simple rounds write their state unpacked, and so did every round
+    // written before the envelope existed. Reading one must not return an
+    // empty carry and silently reset a player's meters.
+    const { adapter } = await connect();
+    await adapter.openSession("s3", "c1");
+    await adapter.settleSimple({
+      sessionId: "s3", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss",
+      roundState: JSON.stringify({ meterPoints: 7 }),
+      mathVersion: "1.0.0",
+    });
+    const info = await adapter.openSession("s3", "c2");
+    expect(JSON.parse(info.carry!)).toEqual({ meterPoints: 7 });
+  });
+
+  test("features declared by the math are sent, and open ∪ close is what closes", async () => {
+    const { fake, adapter } = await connect();
+    await adapter.openSession("s4", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "s4", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ $features: ["BonusGame"] }),
+    });
+    await adapter.closeComplex({
+      sessionId: "s4", roundId: opened.roundId,
+      finalState: JSON.stringify({ $features: ["PlayedGamble"] }),
+      win: 200, multiplier: 2, type: "win",
+    });
+    expect(fake.sent("OpenRoundRequest")[0]!.payload["features"]).toEqual([{ type: "BonusGame" }]);
+    const closeFeatures = fake.sent("CloseRoundRequest")[0]!.payload["features"] as { type: string }[];
+    expect(new Set(closeFeatures.map((f) => f.type))).toEqual(new Set(["BonusGame", "PlayedGamble"]));
+  });
+
+  test("a platform autoclose comes back as AutocloseRoundRequest, not CloseRound", async () => {
+    const { fake, adapter, events } = await connect();
+    await adapter.openSession("s5", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "s5", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ step: 1 }),
+    });
+    await adapter.updateComplex!({ sessionId: "s5", roundId: opened.roundId, state: JSON.stringify({ step: 2 }) });
+
+    fake.requestAutoclose(opened.roundId);
+    await until(() => events.some((e) => e.type === "autocloseRequested"), "autocloseRequested event");
+
+    const asked = events.find((e) => e.type === "autocloseRequested")!;
+    expect(asked).toMatchObject({ type: "autocloseRequested", sessionId: "s5", roundId: opened.roundId });
+
+    // This is what the orchestrator does with that event: close the round,
+    // stamping the reason. The reason is the only thing that tells the
+    // adapter to use the autoclose message.
+    await adapter.closeComplex({
+      sessionId: "s5", roundId: opened.roundId,
+      finalState: JSON.stringify({ step: 3 }),
+      win: 150, multiplier: 1.5, type: "autoclose-settled",
+      reason: "platform-autoclose",
+    });
+
+    expect(fake.sent("AutocloseRoundRequest").length).toBe(1);
+    expect(fake.sent("CloseRoundRequest").length).toBe(0);
+    expect(fake.sent("AutocloseRoundRequest")[0]!.payload["round_version"]).toBe(1);
+    expect(fake.balanceMinor("s5")).toBe(1_000_000 - 100 + 150);
+  });
+
+  test("events are understood with or without the Event suffix", async () => {
+    const { fake, adapter, events } = await connect({ eventSuffix: false });
+    await adapter.openSession("s6", "c1");
+    await adapter.settleSimple({
+      sessionId: "s6", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+    });
+    await until(() => events.some((e) => e.type === "balanceChanged"), "balanceChanged event");
+    const bal = events.find((e) => e.type === "balanceChanged")!;
+    // ...and the balance on it is scaled like every other amount, not left
+    // in the wallet's major units.
+    expect(bal).toMatchObject({ type: "balanceChanged", sessionId: "s6" });
+    expect((bal as { balance: number }).balance).toBe(fake.balanceMinor("s6"));
+  });
+
+  test("closing a round this adapter never opened is refused locally", async () => {
+    // Not forwarded as a guessed round_version: the money for such a round
+    // was moved by an open we never saw, and a wrong version is either
+    // refused or lands on something else entirely.
+    const { fake, adapter } = await connect();
+    await adapter.openSession("s7", "c1");
+    await expect(adapter.closeComplex({
+      sessionId: "s7", roundId: "no-such-round",
+      finalState: "{}", win: 0, multiplier: 0, type: "loss",
+    })).rejects.toThrow(/no open round/);
+    expect(fake.sent("CloseRoundRequest").length).toBe(0);
+  });
+
+  test("a failed close keeps the round open for a retry", async () => {
+    const { fake, adapter } = await connect();
+    await adapter.openSession("s8", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "s8", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: "{}",
+    });
+    // Desync the adapter's round_version the way a dropped UpdateRoundState
+    // response would, so the wallet refuses the close.
+    await adapter.updateComplex!({ sessionId: "s8", roundId: opened.roundId, state: "{}" });
+    (adapter as unknown as { rounds: Map<string, { version: number }> }).rounds.get(opened.roundId)!.version = 0;
+
+    await expect(adapter.closeComplex({
+      sessionId: "s8", roundId: opened.roundId,
+      finalState: "{}", win: 0, multiplier: 0, type: "loss",
+    })).rejects.toThrow(/InvalidRoundOperation/);
+
+    // Still ours to retry: the book entry survived, and so did the wallet's
+    // open round.
+    expect(fake.openRoundIds()).toContain(opened.roundId);
+    (adapter as unknown as { rounds: Map<string, { version: number }> }).rounds.get(opened.roundId)!.version = 1;
+    const closed = await adapter.closeComplex({
+      sessionId: "s8", roundId: opened.roundId,
+      finalState: "{}", win: 100, multiplier: 1, type: "win",
+    });
+    expect(closed.balance).toBe(1_000_000);
+  });
+
+  test("without currency_minimal_unit the configured decimals are used", async () => {
+    const { adapter } = await connect({ sendMinimalUnit: false }, { currencyDecimals: 2 });
+    const info = await adapter.openSession("s9", "c1");
+    expect(info.balance).toBe(1_000_000);
+    expect(info.allowedBets).toEqual([25, 50, 100, 200, 500, 1000]);
+  });
+
+  test("verbatim scaling passes the wallet's own numbers through", async () => {
+    // The escape hatch, for a wallet already configured in minor units.
+    const { adapter } = await connect({}, { amountScaling: "verbatim" });
+    const info = await adapter.openSession("s10", "c1");
+    expect(info.balance).toBe(10_000);
+    expect(info.allowedBets).toEqual([0.25, 0.5, 1, 2, 5, 10]);
+  });
+
+  test("schema 2 declares every contract type it can receive", async () => {
+    // Artube filters the connection to what Hello declared: a type left out
+    // is never delivered. Assert the declaration is complete rather than
+    // whatever was needed the day it was written.
+    const { fake } = await connect({ welcomeSchema: 2 }, { schemaVersion: 2 });
+    // The fake answers Welcome on open, so connect() can resolve before it
+    // has processed the Hello that crossed the other way.
+    await until(() => fake.sent("Hello").length > 0, "Hello frame");
+    const hello = fake.sent("Hello")[0]!;
+    expect(hello.schema).toBe(2);
+    const supports = hello.payload["supports"] as { contracts: Record<string, unknown> };
+    expect(Object.keys(supports.contracts).sort()).toEqual([
+      "AutocloseRequestEvent", "AutocloseRoundRequest",
+      "BalanceChangedEvent",
+      "CloseRoundRequest", "CloseRoundResponse",
+      "Error",
+      "NewConnectionEvent",
+      "OpenRoundRequest", "OpenRoundResponse",
+      "PlayRoundRequest", "PlayRoundResponse",
+      "SessionClosedEvent",
+      "SessionInfoRequest", "SessionInfoResponse",
+      "UpdateRoundStateRequest", "UpdateRoundStateResponse",
+    ]);
+  });
+});

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -183,6 +183,17 @@ describe("complex rounds", () => {
     expect((bal as { balance: number }).balance).toBe(fake.balanceMinor("s6"));
   });
 
+  test("disconnect() takes effect before the socket finishes closing", async () => {
+    // Whoever asks isHealthy is deciding whether to route a round at this
+    // adapter. "I told it to disconnect and it says it is fine" is wrong at
+    // any speed; it only LOOKS fine on a machine where close fires in the
+    // same tick.
+    const { adapter } = await connect();
+    expect(adapter.isHealthy).toBe(true);
+    adapter.disconnect();
+    expect(adapter.isHealthy).toBe(false);
+  });
+
   test("an unfinished round is not read back as a carry", async () => {
     // last_round is whatever the session touched last, and while a round is
     // open that is the open round - whose round_state is the math's in-flight

--- a/packages/adapter-artube/test/conformance.test.ts
+++ b/packages/adapter-artube/test/conformance.test.ts
@@ -1,142 +1,20 @@
 // Run the conformance suite against the adapter.
 //
-// This suite was a declared devDependency of this package for its whole life
-// and was never once run. That is the worst state for a test kit to be in: it
-// looks covered from the outside and proves nothing.
-//
 // It cannot point at a real wallet - the suite moves money, opens derived
 // sessions and asserts balances, so it only ever belongs against a mock or a
 // sandbox. What it CAN do here is run the adapter against a fake Artube server
-// speaking the real wire protocol, which is what the fixture below is.
+// speaking the real wire protocol, which is what ./fake-artube.ts is.
 //
-// Complex-round checks are skipped on purpose rather than silently passing:
-// the Artube Games API is one-shot, so `openComplex` and friends throw. Skipping
-// records that as a known limitation instead of pretending it works.
+// Complex-round checks used to be skipped here because the adapter threw on
+// them. They run now: the Games API has OpenRound / UpdateRoundState /
+// CloseRound and the adapter speaks all three.
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { runConformance } from "@open-rgs/adapter-test-kit";
 import { ArtubeAdapter } from "../src/index.js";
+import { fakeArtube, type FakeArtube } from "./fake-artube.js";
 
-/** Minimal Artube server: handshake, SessionInfo, PlayRound, nothing else.
- *  Balances are per session so the suite's derived sessions stay independent. */
-function fakeArtube() {
-  const balances = new Map<string, number>();
-  const known = new Set<string>();
-  const lastRounds = new Map<string, Record<string, unknown>>();
-  // Index 2 is 100 on purpose: the conformance fixture uses betIndex 2 with
-  // bet 100, and this wire is amount-blind - the wallet derives the stake from
-  // its own ladder, so the ladder has to agree with the fixture or every
-  // balance assertion is off by the difference.
-  const LADDER = [25, 50, 100, 200, 500, 1000];
-  const START = 1_000_000;
-  let roundSeq = 0;
-
-  const server = Bun.serve({
-    port: 0,
-    fetch(req, srv) {
-      return srv.upgrade(req) ? undefined : new Response("expected websocket", { status: 426 });
-    },
-    websocket: {
-      open(ws) {
-        ws.send(JSON.stringify({
-          proto: 1, schema: 1, chan: "control", type: "Welcome",
-          id: "w1", op_seq: 0, timestamp: Date.now(),
-          payload: { use: { max_schema: 1 } },
-        }));
-      },
-      message(ws, raw): void {
-        const msg = JSON.parse(String(raw)) as {
-          type: string; id: string; payload?: Record<string, unknown>;
-        };
-        const reply = (type: string, payload: unknown) =>
-          ws.send(JSON.stringify({
-            proto: 1, schema: 1, chan: "rpc", type,
-            id: `r-${msg.id}`, corr_id: msg.id, op_seq: 0,
-            timestamp: Date.now(), payload,
-          }));
-
-        if (msg.type === "Hello") return;
-
-        if (msg.type === "SessionInfoRequest") {
-          const sid = String(msg.payload?.["session_id"] ?? "s");
-          // A session only exists once opened. The conformance suite checks
-          // that an unknown session is refused, so this must not auto-create.
-          if (!balances.has(sid)) balances.set(sid, START);
-          known.add(sid);
-          // A real wallet returns the player's last round, and the adapter maps
-          // its round_state / round_version onto the contract's carry and
-          // mathVersion. The fake used to omit it, so the cross-round state the
-          // RGS depends on was never exercised against this wire at all.
-          const last = lastRounds.get(sid);
-          reply("SessionInfoResponse", {
-            security_hash: "hash",
-            currency: "USD",
-            balance: balances.get(sid),
-            ...(last ? { last_round: last } : {}),
-            game_settings: {
-              default_bet_index: 0,
-              allowed_bets: [100, 200, 500, 1000],
-              available_auto_spin_counts: [10, 25, 50],
-              rtp_options: [{ rtp: 0.96, game_mode: "default" }],
-              locales: ["en"],
-            },
-          });
-          return;
-        }
-
-        if (msg.type === "PlayRoundRequest") {
-          const p = msg.payload ?? {};
-          const sid = String(p["session_id"] ?? "s");
-          const err = (code: string, message: string) => ws.send(JSON.stringify({
-            proto: 1, schema: 1, chan: "rpc", type: "Error",
-            id: `e-${msg.id}`, corr_id: msg.id, op_seq: 0, timestamp: Date.now(),
-            payload: { code, message },
-          }));
-          // A real wallet refuses a session it never opened.
-          if (!known.has(sid)) { err("E_SESSION_NOT_FOUND", "unknown session"); return; }
-
-          const betIndex = Number(p["bet_index"] ?? 0);
-          const priceMul = Number(p["price_multiplier"] ?? 1);
-          const winMul   = Number(p["win_multiplier"] ?? 0);
-          const bet = LADDER[betIndex] !== undefined ? LADDER[betIndex]! * priceMul : Number.MAX_SAFE_INTEGER;
-          const win = Math.round(bet * winMul);
-          const have = balances.get(sid) ?? START;
-          if (bet > have) {
-            err("E_INSUFFICIENT_FUNDS", "not enough balance");
-            return;
-          }
-          const next = have - bet + win;
-          balances.set(sid, next);
-          const roundId = `round-${++roundSeq}`;
-          // Store the round the way the wallet does, so the next
-          // SessionInfoResponse can hand its state back.
-          lastRounds.set(sid, {
-            round_id: roundId,
-            price_multiplier: priceMul,
-            bet_index: betIndex,
-            win_multiplier: winMul,
-            win,
-            started_at: new Date().toISOString(),
-            finished_at: new Date().toISOString(),
-            round_version: Number(p["round_version"] ?? 1),
-            round_state_version: String(p["round_state_version"] ?? "1"),
-            round_state: String(p["round_state"] ?? ""),
-            is_platform_max_win_reached: false,
-          });
-          reply("PlayRoundResponse", {
-            round_id: roundId,
-            balance: next,
-            win,
-          });
-        }
-      },
-    },
-  });
-
-  return { url: `ws://localhost:${server.port}`, stop: () => server.stop(true) };
-}
-
-let fake: ReturnType<typeof fakeArtube>;
+let fake: FakeArtube;
 let adapter: ArtubeAdapter;
 
 beforeAll(async () => {
@@ -161,17 +39,22 @@ describe("conformance", () => {
     expect(adapter.isHealthy).toBe(true);
   });
 
-  test("opens a session with a usable bet ladder", async () => {
+  test("opens a session with a usable bet ladder, converted to minor units", async () => {
     const info = await adapter.openSession("conf-session", "conn-1");
+    // The wallet said 10000.00; open-rgs counts minor units.
     expect(info.balance).toBe(1_000_000);
     expect(info.currency).toBe("USD");
-    expect(info.allowedBets.length).toBeGreaterThan(0);
+    expect(info.currencyDecimals).toBe(2);
+    // Ladder crosses the same way: 0.25 -> 25. Integers, because the
+    // orchestrator refuses a fractional bet outright.
+    expect(info.allowedBets).toEqual([25, 50, 100, 200, 500, 1000]);
+    for (const b of info.allowedBets) expect(Number.isInteger(b)).toBe(true);
     expect(info.allowedBets[info.defaultBetIndex]).toBeDefined();
   });
 
   test("a settle moves the balance by exactly win minus bet", async () => {
     await adapter.openSession("conf-money", "conn-2");
-    // Index 2 is 100 on this wallet's ladder, and the win is derived wallet-side
+    // Index 2 is 1.00 on this wallet's ladder, and the win is derived wallet-side
     // from win_multiplier - the adapter's `win` field never crosses the wire.
     const receipt = await adapter.settleSimple({
       sessionId: "conf-money",
@@ -193,23 +76,16 @@ describe("conformance", () => {
     })).rejects.toThrow();
   });
 
-  test("complex rounds throw rather than silently no-oping", async () => {
-    // A one-shot wallet that quietly accepted an open would strand a debit.
-    await expect(adapter.openComplex({
-      sessionId: "conf-session", roundId: "r", bet: 100,
-      betIndex: 0, priceMultiplier: 1,
-    } as never)).rejects.toThrow(/not supported/i);
-  });
-
   // Two checks the Artube wire cannot satisfy, allowlisted with the reason
   // rather than papered over in the fake server. Faking a pass here would hide
   // a real integration limitation behind a green suite.
   const WIRE_CANNOT = new Set([
-    // PlayRoundRequest carries bet_index and price_multiplier, never an
-    // amount. The wallet computes the stake from its own ladder, so the
-    // adapter cannot declare an oversized bet and this probe cannot trip it.
-    // adapter-test-kit fixes the probe to drive priceMultiplier instead; that
-    // fix is on an unmerged branch, so it still fails here.
+    // The probe declares an oversized `bet`, but PlayRoundRequest carries
+    // bet_index and price_multiplier, never an amount. The wallet computes
+    // the stake from its own ladder, so the adapter cannot declare an
+    // oversized bet and this probe cannot trip it. (The adapter IS refused
+    // on a real overspend - see the test above, which drives
+    // priceMultiplier.)
     "errors.insufficient-funds",
     // PlayRoundRequest has no idempotency field at all, so SettleSimple's
     // idempotencyKey is dropped on the floor. A retried settle is NOT deduped
@@ -219,8 +95,6 @@ describe("conformance", () => {
 
   test("the suite runs, and only the checks this wire cannot express fail", async () => {
     const report = await runConformance(adapter, {
-      skipComplex: true,   // one-shot protocol, a real limitation not a gap
-      skipEvents: true,    // the fake server pushes none
       fixture: { sessionId: "conf-run" },
       perCheckTimeoutMs: 5_000,
     });
@@ -232,12 +106,24 @@ describe("conformance", () => {
     expect(unexpected).toEqual([]);
   }, 30_000);
 
+  test("the complex-round checks are among the ones that passed", async () => {
+    // The point of the change: these three used to be skips.
+    const report = await runConformance(adapter, {
+      fixture: { sessionId: "conf-complex" },
+      perCheckTimeoutMs: 5_000,
+    });
+    const byId = new Map(report.checks.map((c) => [c.id, c.status]));
+    expect(byId.get("complex.openComplex")).toBe("ok");
+    expect(byId.get("complex.updateComplex")).toBe("ok");
+    expect(byId.get("complex.closeComplex")).toBe("ok");
+    expect(byId.get("errors.bad-round-id")).toBe("ok");
+  }, 30_000);
+
   test("the known-unsupported checks really are still failing", async () => {
     // If the wire gains an idempotency field, or the test kit fix lands, this
     // goes red and the allowlist above must shrink. A stale allowlist is how a
     // suite quietly stops testing.
     const report = await runConformance(adapter, {
-      skipComplex: true, skipEvents: true,
       fixture: { sessionId: "conf-stale" }, perCheckTimeoutMs: 5_000,
     });
     const failing = new Set(report.checks.filter((c) => c.status === "fail").map((c) => c.id));

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -182,6 +182,16 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
 
         if (msg.type === "OpenRoundRequest") {
           if (!known.has(sid)) { err("SessionInvalid", "unknown session"); return; }
+          // The platform validates the chain: a previous_round_id that is not
+          // this session's actual previous round is "Invalid rounds sequence",
+          // and the open fails. The fake did not model this, so an adapter
+          // that chained every round looked fine here and failed on the
+          // sandbox after the first simple round.
+          const chain = p["previous_round_id"];
+          if (chain !== undefined && chain !== null && chain !== lastRounds.get(sid)?.["round_id"]) {
+            err("InvalidRoundOperation", "Invalid rounds sequence.");
+            return;
+          }
           const bet = betOf();
           const have = balances.get(sid) ?? START;
           if (bet > have) { err("InsufficientFunds", "not enough balance"); return; }

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -1,0 +1,293 @@
+// A fake Artube Games API, speaking the real wire protocol.
+//
+// Shared by the conformance run and the complex-round tests. It is
+// deliberately strict where the real platform is strict - an unknown
+// session, a stale round_version, a round that is already closed are all
+// refused with the documented error codes - because an adapter that only
+// ever meets a permissive fake passes here and fails on the sandbox.
+//
+// Money is kept in integer minor units internally and emitted in MAJOR
+// units, which is what the real wire carries ("balance": 150.75). That is
+// the whole point of the fixture: it is the half of the contract the
+// adapter has to convert, and a fake that emitted minor units would make
+// the conversion untestable.
+
+export interface FakeArtube {
+  url: string;
+  stop(): void;
+  /** Push an AutocloseRequestEvent for a round the fake has open. */
+  requestAutoclose(roundId: string): void;
+  /** Every frame the adapter sent, in order. */
+  readonly received: WireFrame[];
+  /** Frames of one type, oldest first. */
+  sent(type: string): WireFrame[];
+  balanceMinor(sessionId: string): number;
+  openRoundIds(): string[];
+  lastRoundState(sessionId: string): string | undefined;
+}
+
+export interface WireFrame {
+  type: string;
+  id: string;
+  schema: number;
+  payload: Record<string, unknown>;
+}
+
+interface FakeRound {
+  sessionId: string;
+  version: number;
+  betMinor: number;
+  state: string;
+  stateVersion: string;
+  features: string[];
+}
+
+export interface FakeArtubeOptions {
+  /** Bet ladder in MAJOR units. Index 2 is 1.00 so the conformance
+   *  fixture's betIndex 2 / bet 100 minor units lines up. */
+  ladder?: number[];
+  /** Starting balance in minor units. */
+  startMinor?: number;
+  /** Emit `game_settings.currency_minimal_unit`. Off exercises the
+   *  adapter's configured-decimals fallback. */
+  sendMinimalUnit?: boolean;
+  /** Suffix event type names with "Event" (both spellings are in the docs). */
+  eventSuffix?: boolean;
+  /** Answer Welcome with this schema. */
+  welcomeSchema?: number;
+}
+
+const MINOR = 100;
+
+export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
+  const ladderMajor = opts.ladder ?? [0.25, 0.5, 1, 2, 5, 10];
+  const ladderMinor = ladderMajor.map((b) => Math.round(b * MINOR));
+  const START = opts.startMinor ?? 1_000_000;
+  const sendMinimalUnit = opts.sendMinimalUnit ?? true;
+  const evt = (name: string) => (opts.eventSuffix === false ? name : `${name}Event`);
+
+  const balances = new Map<string, number>();      // minor units
+  const known = new Set<string>();
+  const lastRounds = new Map<string, Record<string, unknown>>();
+  const rounds = new Map<string, FakeRound>();
+  const received: WireFrame[] = [];
+  const sockets = new Set<{ send(s: string): void }>();
+  let roundSeq = 0;
+
+  const major = (minor: number) => Math.round(minor) / MINOR;
+
+  const server = Bun.serve({
+    port: 0,
+    fetch(req, srv) {
+      return srv.upgrade(req) ? undefined : new Response("expected websocket", { status: 426 });
+    },
+    websocket: {
+      open(ws) {
+        sockets.add(ws);
+        ws.send(JSON.stringify({
+          proto: 1, schema: opts.welcomeSchema ?? 1, chan: "control", type: "Welcome",
+          id: "w1", op_seq: 0, timestamp: new Date().toISOString(),
+          payload: { use: { max_schema: opts.welcomeSchema ?? 1 } },
+        }));
+      },
+      close(ws) { sockets.delete(ws); },
+      message(ws, raw): void {
+        const msg = JSON.parse(String(raw)) as WireFrame & { payload?: Record<string, unknown> };
+        received.push({ type: msg.type, id: msg.id, schema: msg.schema, payload: msg.payload ?? {} });
+        const p = msg.payload ?? {};
+
+        const reply = (type: string, payload: unknown) =>
+          ws.send(JSON.stringify({
+            proto: 1, schema: 1, chan: "rpc", type,
+            id: `r-${msg.id}`, corr_id: msg.id, op_seq: 0,
+            timestamp: new Date().toISOString(), payload,
+          }));
+        const err = (code: string, message: string) =>
+          ws.send(JSON.stringify({
+            proto: 1, schema: 1, chan: "rpc", type: "Error",
+            id: `e-${msg.id}`, corr_id: msg.id, op_seq: 0,
+            timestamp: new Date().toISOString(), payload: { code, message },
+          }));
+        const pushBalance = (sid: string, reason: string) =>
+          ws.send(JSON.stringify({
+            proto: 1, schema: 1, chan: "events", type: evt("BalanceChanged"),
+            id: crypto.randomUUID(), op_seq: 0, timestamp: new Date().toISOString(),
+            payload: { session_id: sid, balance: major(balances.get(sid) ?? 0), reason },
+          }));
+
+        if (msg.type === "Hello") return;
+
+        if (msg.type === "SessionInfoRequest") {
+          const sid = String(p["session_id"] ?? "s");
+          if (!balances.has(sid)) balances.set(sid, START);
+          known.add(sid);
+          const last = lastRounds.get(sid);
+          reply("SessionInfoResponse", {
+            security_hash: "hash",
+            currency: "USD",
+            balance: major(balances.get(sid)!),
+            ...(last ? { last_round: last } : {}),
+            game_settings: {
+              default_bet_index: 0,
+              allowed_bets: ladderMajor,
+              ...(sendMinimalUnit ? { currency_minimal_unit: 1 / MINOR } : {}),
+              available_auto_spin_counts: [10, 25, 50],
+              rtp_options: [{ rtp: 0.96, game_mode: "default" }],
+              locales: ["en"],
+            },
+          });
+          return;
+        }
+
+        const sid = String(p["session_id"] ?? "s");
+        const betOf = () => {
+          const i = Number(p["bet_index"] ?? 0);
+          const price = Number(p["price_multiplier"] ?? 1);
+          // An index off the end of the ladder is not a cheap bet: make it
+          // unaffordable so the overspend probe fails the way it would on a
+          // real wallet rather than settling at zero.
+          return ladderMinor[i] === undefined
+            ? Number.MAX_SAFE_INTEGER
+            : Math.round(ladderMinor[i]! * price);
+        };
+
+        if (msg.type === "PlayRoundRequest") {
+          if (!known.has(sid)) { err("SessionInvalid", "unknown session"); return; }
+          const bet = betOf();
+          const winMul = Number(p["win_multiplier"] ?? 0);
+          const have = balances.get(sid) ?? START;
+          if (bet > have) { err("InsufficientFunds", "not enough balance"); return; }
+          const win = Math.round(bet * winMul);
+          balances.set(sid, have - bet + win);
+          const roundId = `round-${++roundSeq}`;
+          lastRounds.set(sid, {
+            round_id: roundId,
+            price_multiplier: Number(p["price_multiplier"] ?? 1),
+            bet_index: Number(p["bet_index"] ?? 0),
+            win_multiplier: winMul,
+            win: major(win),
+            started_at: new Date().toISOString(),
+            finished_at: new Date().toISOString(),
+            round_version: 0,
+            round_state_version: String(p["round_state_version"] ?? "1"),
+            round_state: String(p["round_state"] ?? ""),
+            is_platform_max_win_reached: false,
+          });
+          reply("PlayRoundResponse", {
+            round_id: roundId, balance: major(balances.get(sid)!), win: major(win),
+          });
+          pushBalance(sid, "Win");
+          return;
+        }
+
+        if (msg.type === "OpenRoundRequest") {
+          if (!known.has(sid)) { err("SessionInvalid", "unknown session"); return; }
+          const bet = betOf();
+          const have = balances.get(sid) ?? START;
+          if (bet > have) { err("InsufficientFunds", "not enough balance"); return; }
+          balances.set(sid, have - bet);
+          const roundId = `round-${++roundSeq}`;
+          rounds.set(roundId, {
+            sessionId: sid,
+            version: 0,
+            betMinor: bet,
+            state: String(p["round_state"] ?? ""),
+            stateVersion: String(p["round_state_version"] ?? "1"),
+            features: featureTypes(p["features"]),
+          });
+          reply("OpenRoundResponse", {
+            round_version: 0, round_id: roundId, balance: major(balances.get(sid)!),
+          });
+          pushBalance(sid, "Bet");
+          return;
+        }
+
+        if (msg.type === "UpdateRoundStateRequest") {
+          const roundId = String(p["round_id"] ?? "");
+          const r = rounds.get(roundId);
+          if (!r) { err("InvalidRoundOperation", "Round is not open."); return; }
+          if (Number(p["round_version"]) !== r.version) {
+            { err("InvalidRoundOperation", `Stale round_version ${String(p["round_version"])}, expected ${r.version}.`); return; }
+          }
+          r.version += 1;
+          r.state = String(p["round_state"] ?? r.state);
+          r.stateVersion = String(p["round_state_version"] ?? r.stateVersion);
+          reply("UpdateRoundStateResponse", { round_version: r.version });
+          return;
+        }
+
+        if (msg.type === "CloseRoundRequest" || msg.type === "AutocloseRoundRequest") {
+          const roundId = String(p["round_id"] ?? "");
+          const r = rounds.get(roundId);
+          if (!r) { err("InvalidRoundOperation", "Round is not open."); return; }
+          if (Number(p["round_version"]) !== r.version) {
+            { err("InvalidRoundOperation", `Stale round_version ${String(p["round_version"])}, expected ${r.version}.`); return; }
+          }
+          const winMul = Number(p["win_multiplier"] ?? 0);
+          const win = Math.round(r.betMinor * winMul);
+          balances.set(r.sessionId, (balances.get(r.sessionId) ?? 0) + win);
+          // Features merge open-on-top-of-close, as documented.
+          const merged = [...new Set([...r.features, ...featureTypes(p["features"])])];
+          rounds.delete(roundId);
+          lastRounds.set(r.sessionId, {
+            round_id: roundId,
+            price_multiplier: 1,
+            bet_index: 0,
+            win_multiplier: winMul,
+            win: major(win),
+            started_at: new Date().toISOString(),
+            finished_at: new Date().toISOString(),
+            round_version: Number(p["round_version"] ?? 0),
+            round_state_version: String(p["round_state_version"] ?? "1"),
+            round_state: String(p["round_state"] ?? ""),
+            features: merged.map((t) => ({ type: t })),
+            is_platform_max_win_reached: false,
+          });
+          reply("CloseRoundResponse", {
+            balance: major(balances.get(r.sessionId)!),
+            win: major(win),
+            is_platform_max_win_reached: false,
+          });
+          pushBalance(r.sessionId, "Win");
+          return;
+        }
+
+        err("BadRequest", `unknown type ${msg.type}`);
+      },
+    },
+  });
+
+  return {
+    url: `ws://localhost:${server.port}`,
+    stop: () => server.stop(true),
+    received,
+    sent: (type: string) => received.filter((f) => f.type === type),
+    balanceMinor: (sessionId: string) => balances.get(sessionId) ?? 0,
+    openRoundIds: () => [...rounds.keys()],
+    lastRoundState: (sessionId: string) =>
+      lastRounds.get(sessionId)?.["round_state"] as string | undefined,
+    requestAutoclose(roundId: string) {
+      const r = rounds.get(roundId);
+      if (!r) throw new Error(`fake: no open round ${roundId}`);
+      const frame = JSON.stringify({
+        proto: 1, schema: 1, chan: "events", type: evt("AutocloseRequest"),
+        id: crypto.randomUUID(), op_seq: 0, timestamp: new Date().toISOString(),
+        payload: {
+          session_id: r.sessionId,
+          round_id: roundId,
+          round_version: r.version,
+          round_state_version: r.stateVersion,
+          round_state: r.state,
+        },
+      });
+      for (const ws of sockets) ws.send(frame);
+    },
+  };
+}
+
+function featureTypes(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((f) => (f && typeof f === "object" ? String((f as { type?: unknown }).type ?? "") : ""))
+    .filter((t) => t !== "");
+}

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -205,6 +205,21 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             stateVersion: String(p["round_state_version"] ?? "1"),
             features: featureTypes(p["features"]),
           });
+          // An open round IS the session's last round, and it has no
+          // finished_at. Modelling that is what makes the carry-from-an-open-
+          // round bug reproducible here rather than only on the sandbox.
+          lastRounds.set(sid, {
+            round_id: roundId,
+            price_multiplier: Number(p["price_multiplier"] ?? 1),
+            bet_index: Number(p["bet_index"] ?? 0),
+            win_multiplier: 0,
+            win: 0,
+            started_at: new Date().toISOString(),
+            round_version: 0,
+            round_state_version: String(p["round_state_version"] ?? "1"),
+            round_state: String(p["round_state"] ?? ""),
+            is_platform_max_win_reached: false,
+          });
           reply("OpenRoundResponse", {
             round_version: 0, round_id: roundId, balance: major(balances.get(sid)!),
           });

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -112,6 +112,26 @@ export interface CloseOutcome {
 export interface SpinContext {
   /** Mode id resolved by the wrapper (after promo override / nextMode override). */
   mode: string;
+  /** Index into the session's bet ladder for THIS round, as the orchestrator
+   *  resolved it: the client's choice, the session default, or the bet a promo
+   *  locked the round to. Server-authoritative - it is the same number the
+   *  wallet is charged against, so a client cannot desync it from the money.
+   *
+   *  It is an index, not an amount: math stays currency-blind. Use it for
+   *  mechanics whose shape legitimately depends on the stake tier (a meter
+   *  that fills proportionally to the bet, a ladder whose rungs differ per
+   *  tier), never to compute a win amount - that is `multiplier x bet`, and
+   *  bet belongs to the orchestrator.
+   *
+   *  Optional because a math that ignores it must keep compiling, and because
+   *  a host embedding this contract without an orchestrator (the simulator's
+   *  bare harness) has no ladder to index. */
+  betIndex?: number;
+  /** Price multiplier for THIS round (client price x mode stakeMultiplier),
+   *  as resolved by the orchestrator. 1 for an ordinary round, higher for a
+   *  feature buy, 0 for a promo-funded one. Same server-authoritative
+   *  guarantee as {@link betIndex}. */
+  priceMultiplier?: number;
   /** Dev-only forced-outcome hint. Populated by the orchestrator ONLY when
    *  cheats are explicitly enabled (createServer `enableCheats` /
    *  `OPEN_RGS_ENABLE_CHEATS=1`) AND not in production, it is always

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -1110,6 +1110,15 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         win,
         multiplier: cappedClose.multiplier,
         type: cappedClose.type,
+        // Same three fields a client close sends. They were missing here, so
+        // an autoclosed round updated the RGS's in-memory carry (below) and
+        // never the wallet's: the next openSession handed back the carry from
+        // before the round, and every meter the round had advanced silently
+        // reset. The wallet is the source of truth for carry, so the write
+        // that reaches it is the one that counts.
+        ...(cappedClose.carry !== undefined ? { carry: cappedClose.carry } : {}),
+        ...(cappedClose.nextMode !== undefined ? { nextMode: cappedClose.nextMode } : {}),
+        ...(mode.math.version ? { mathVersion: mode.math.version } : {}),
         // Same deterministic key as a client close of this round (above)  -
         // a close racing an autoclose collapses to one wallet credit.
         idempotencyKey: deriveIdempotencyKey(s.sessionId, open.roundId, "close"),

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -341,12 +341,20 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     return requested ?? manifest.defaultMode;
   }
 
-  function buildSpinContext(modeId: string, cheatRaw?: Record<string, unknown>, params?: Record<string, unknown>): SpinContext {
+  function buildSpinContext(
+    modeId: string,
+    bet: { betIndex: number; priceMultiplier: number },
+    cheatRaw?: Record<string, unknown>,
+    params?: Record<string, unknown>,
+  ): SpinContext {
     // Cheats are fully off unless explicitly enabled outside production
     // (see OrchestratorConfig.cheatsEnabled), a forced-outcome path can
     // never be reached in a production build.
     const cheat = cheatsEnabled ? parseCheat(cheatRaw) : undefined;
-    return { mode: modeId, cheat, params };
+    // betIndex/priceMultiplier come from computeBet, never straight off the
+    // wire: they are the same numbers the wallet is charged against, so a
+    // math reading them cannot be fed one stake and settled at another.
+    return { mode: modeId, betIndex: bet.betIndex, priceMultiplier: bet.priceMultiplier, cheat, params };
   }
 
   function computeBet(
@@ -634,7 +642,12 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
 
     // Dev cheats (when enabled) ride inside params.cheat, never a
     // first-class wire field. Ignored entirely when cheatsEnabled is false.
-    const ctx = buildSpinContext(requestedMode, req.params?.["cheat"] as Record<string, unknown> | undefined, req.params);
+    const ctx = buildSpinContext(
+      requestedMode,
+      { betIndex: betInfo.betIndex, priceMultiplier: betInfo.priceMultiplier * mode.stakeMultiplier },
+      req.params?.["cheat"] as Record<string, unknown> | undefined,
+      req.params,
+    );
     const math = mode.math as SimpleMath;
     const mathStart = performance.now();
     const outcome = await Promise.resolve(math.play(s.carry, ctx));
@@ -762,7 +775,12 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       throw new RGSError("INSUFFICIENT_BALANCE", `cost ${betInfo.effectiveCost} > balance ${s.balance}`);
     }
 
-    const ctx = buildSpinContext(requestedMode, undefined, req.params);
+    const ctx = buildSpinContext(
+      requestedMode,
+      { betIndex: betInfo.betIndex, priceMultiplier: betInfo.priceMultiplier * mode.stakeMultiplier },
+      undefined,
+      req.params,
+    );
     const math = mode.math as ComplexMath;
     const mathStart = performance.now();
     const open = await Promise.resolve(math.open(s.carry, ctx));
@@ -776,6 +794,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         betIndex: betInfo.betIndex,
         priceMultiplier: betInfo.priceMultiplier * mode.stakeMultiplier,
         initialState: open.state,
+        ...(mode.math.version ? { mathVersion: mode.math.version } : {}),
         idempotencyKey: initiatingIdemKey(s.sessionId, "open", req.idempotencyKey),
         ...(betInfo.promoId ? { promoId: betInfo.promoId } : {}),
       }));

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -775,10 +775,14 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       throw new RGSError("INSUFFICIENT_BALANCE", `cost ${betInfo.effectiveCost} > balance ${s.balance}`);
     }
 
+    // Same cheat plumbing as spin(). It was passing `undefined` here, so a
+    // forced outcome worked on a simple round and silently did nothing on a
+    // complex one - which is the mode where a deterministic opening draw is
+    // most needed, because everything after it is a branch.
     const ctx = buildSpinContext(
       requestedMode,
       { betIndex: betInfo.betIndex, priceMultiplier: betInfo.priceMultiplier * mode.stakeMultiplier },
-      undefined,
+      req.params?.["cheat"] as Record<string, unknown> | undefined,
       req.params,
     );
     const math = mode.math as ComplexMath;

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -495,8 +495,17 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       // Fresh INIT, go to platform, build a new LocalSession from
       // the SessionInfo it returns (per ADR-004, platform is the
       // source of truth for carry / nextMode / mathVersion).
-      info = await timedPlatformCall(metrics, "openSession",
-        () => platform.openSession(req.sid, conn.connectionId));
+      // translate(), the same as every other platform call. Without it an
+      // upstream refusal arrived as a bare Error, became INTERNAL_ERROR at
+      // the transport, and reached the client as "internal error (ref: ...)"
+      // - so the single most common integration failure, a session the
+      // wallet does not recognise, was also the least legible one.
+      try {
+        info = await timedPlatformCall(metrics, "openSession",
+          () => platform.openSession(req.sid, conn.connectionId));
+      } catch (e) {
+        throw translate(e, "INIT_FAILED");
+      }
       conn.sessionId = req.sid;
       conn.demo = !info.currency;
 

--- a/packages/core/src/transport-binary.ts
+++ b/packages/core/src/transport-binary.ts
@@ -224,9 +224,13 @@ export function binaryTransport(cfg: BinaryTransportConfig): BinaryClientTranspo
       log.info("Binary transport listening", {
         "event.category": "transport",
         "event.action": "listen",
-        "server.port": cfg.port,
+        "server.port": server.port ?? cfg.port,
       });
-      return { port: cfg.port };
+      // server.port, not cfg.port: port 0 means "bind anywhere", and the
+      // configured 0 is not a port anyone can connect to. Reporting it back
+      // made both this log line and createServer's caller wrong in the one
+      // case where the answer was not already known.
+      return { port: server.port ?? cfg.port };
     },
 
     async stop(opts: { drainMs?: number } = {}): Promise<void> {

--- a/packages/core/test/autoclose-policy.test.ts
+++ b/packages/core/test/autoclose-policy.test.ts
@@ -25,7 +25,9 @@ class SpyPlatform implements PlatformAdapter {
   async settleSimple(): Promise<RoundReceipt> { return { roundId: "s", balance: this.balance }; }
   async openComplex(req: OpenComplex): Promise<RoundReceipt> { this.balance -= req.bet; return { roundId: `r${++this.seq}`, balance: this.balance }; }
   closeReasons: (string | undefined)[] = [];
-  async closeComplex(req: CloseComplex): Promise<RoundReceipt> { this.closeWins.push(req.win); this.closeReasons.push(req.reason); this.balance += req.win; return { roundId: req.roundId, balance: this.balance }; }
+  closeCarries: (string | undefined)[] = [];
+  closeMathVersions: (string | undefined)[] = [];
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> { this.closeWins.push(req.win); this.closeReasons.push(req.reason); this.closeCarries.push(req.carry); this.closeMathVersions.push(req.mathVersion); this.balance += req.win; return { roundId: req.roundId, balance: this.balance }; }
   onEvent(_h: (e: PlatformEvent) => void) {}
 }
 
@@ -37,7 +39,7 @@ function complexMath(withAutoclose: boolean): ComplexMath {
     step: (state) => ({ state, ops: [] }),
     isTerminal: () => false,
     close: () => ({ multiplier: 0, ops: [], type: "close" }),
-    ...(withAutoclose ? { autoclose: () => ({ multiplier: 5, ops: [], type: "autoclose-banked" }) } : {}),
+    ...(withAutoclose ? { autoclose: () => ({ multiplier: 5, ops: [], type: "autoclose-banked", carry: "carry-from-autoclose" }) } : {}),
   };
 }
 
@@ -108,5 +110,20 @@ describe("autoclose policy (H5)", () => {
     const opened = await orch.openRound({ mode: "cx" }, conn);
     await orch.autocloseRound({ sessionId: "s6", roundId: opened.roundId, reason: "session-closed: kicked" });
     expect(platform.closeReasons).toEqual(["session-closed: kicked"]);
+  });
+
+  test("autoclose writes the math's carry to the WALLET, not just to memory", async () => {
+    // The wallet is the source of truth for carry: it is what the next
+    // openSession reads. An autoclose that updated only the in-memory session
+    // looked correct for as long as that process kept the session, and reset
+    // every meter the round had advanced the moment anyone reconnected.
+    const { orch, platform, conn } = setup("math-decides", true);
+    await orch.init({ sid: "s7" }, conn);
+    const opened = await orch.openRound({ mode: "cx" }, conn);
+    await orch.autocloseRound({ sessionId: "s7", roundId: opened.roundId, reason: "idle" });
+    expect(platform.closeCarries).toEqual(["carry-from-autoclose"]);
+    // Stamped with the math that produced it, the same as a client close, so
+    // the RGS can tell a carry written by older math from one it can use.
+    expect(platform.closeMathVersions).toEqual(["1"]);
   });
 });

--- a/packages/core/test/init-errors.test.ts
+++ b/packages/core/test/init-errors.test.ts
@@ -1,0 +1,69 @@
+// What a client is told when INIT fails.
+//
+// The wallet refusing a session is the single most common integration
+// failure, and it was also the least legible one: platform.openSession was
+// the one platform call init did not run through translate(), so an upstream
+// refusal arrived as a bare Error, became INTERNAL_ERROR at the transport,
+// and reached the client as "internal error (ref: ...)" with the actual
+// reason visible only in the pod's logs.
+
+import { describe, expect, test } from "bun:test";
+import { createOrchestrator } from "../src/index.js";
+import {
+  defineGame, RGSError,
+  type ConnectionMeta, type PlatformAdapter, type PlatformEvent,
+  type RoundReceipt, type SessionInfo, type SimpleMath,
+} from "@open-rgs/contract";
+
+function platformThatRefuses(message: string): PlatformAdapter {
+  return {
+    isHealthy: true,
+    diagnostics: {},
+    async connect() {},
+    disconnect() {},
+    async openSession(): Promise<SessionInfo> { throw new Error(message); },
+    async settleSimple(): Promise<RoundReceipt> { throw new Error("unused"); },
+    async openComplex(): Promise<RoundReceipt> { throw new Error("unused"); },
+    async closeComplex(): Promise<RoundReceipt> { throw new Error("unused"); },
+    onEvent(_h: (e: PlatformEvent) => void) {},
+  };
+}
+
+const math: SimpleMath = {
+  kind: "simple", name: "m", version: "1", rtp: 1,
+  play: () => ({ multiplier: 0, ops: [], type: "loss" }),
+};
+
+function orchestratorWith(platform: PlatformAdapter) {
+  return createOrchestrator({
+    manifest: defineGame({ id: "g", declaredRtp: 1, defaultMode: "base", modes: { base: { math, stakeMultiplier: 1 } } }),
+    platform,
+  });
+}
+
+const conn: ConnectionMeta = { connectionId: "c1", sessionId: null, demo: false };
+
+describe("init failures", () => {
+  test("a session the wallet does not recognise is SESSION_INVALID, not an opaque internal error", async () => {
+    const orch = orchestratorWith(platformThatRefuses("Artube SessionInvalid: The session is invalid or cannot be retrieved"));
+    try {
+      await orch.init({ sid: "gone" }, conn);
+      throw new Error("init should have failed");
+    } catch (e) {
+      expect(e).toBeInstanceOf(RGSError);
+      expect((e as RGSError).code).toBe("SESSION_INVALID");
+      // And the reason survives, because SESSION_INVALID is not an opaque code.
+      expect((e as RGSError).message).toMatch(/SessionInvalid/);
+    }
+  });
+
+  test("anything else still fails closed as INIT_FAILED", async () => {
+    const orch = orchestratorWith(platformThatRefuses("socket hung up"));
+    try {
+      await orch.init({ sid: "s" }, conn);
+      throw new Error("init should have failed");
+    } catch (e) {
+      expect((e as RGSError).code).toBe("INIT_FAILED");
+    }
+  });
+});


### PR DESCRIPTION
The Artube Games API has had `OpenRound` / `UpdateRoundState` / `CloseRound`
all along. `@open-rgs/adapter-artube` served only the one-shot `PlayRound` and
threw on the complex trio, so no open-rgs game could run an interactive round
on that platform. This implements them, and picks up four bugs found by
driving the complex path end to end for the first time.

## The adapter

- **Complex rounds.** `openComplex` / `updateComplex` / `closeComplex` map to
  the three messages. The platform's `round_version` is tracked per round -
  it is computed wallet-side and a stale one is refused with
  `InvalidRoundOperation`, so a close for a round this adapter never opened is
  refused locally rather than sent with a guessed number, and a failed close
  keeps its bookkeeping for the retry.
- **Autoclose.** `AutocloseRequestEvent` surfaces as
  `PlatformEvent{type:"autocloseRequested"}`, and the close it provokes goes
  back out as `AutocloseRoundRequest`.
- **Amounts.** Artube states money in major units (`150.75`); open-rgs counts
  integer minor units and refuses a fractional bet outright, so an
  unconverted `allowed_bets: [0.10, 0.25]` failed *every* round with
  `INVALID_BET`. Inbound amounts are scaled by
  `game_settings.currency_minimal_unit`, with `amountScaling: "verbatim"` to
  opt out.
- **Event names.** Only the unsuffixed spellings were matched, so
  `BalanceChangedEvent` and `SessionClosedEvent` were dropped as unknown
  types. Both spellings appear in Artube's docs.
- A complex close has two pieces of state (the round's final state and the
  next round's carry) and one wallet slot, so they travel in a marked
  envelope; an unmarked string still reads back verbatim. Features are read
  from a `$features` key in the math's own state, which keeps an Artube
  concept out of the neutral contract, and the close sends the open ∪ close
  union the platform's merge rule asks for.

## contract + core

- **`SpinContext.betIndex` / `priceMultiplier`** (additive, optional). Math was
  currency-blind and also stake-blind, which rules out a meter that fills in
  proportion to the stake or a ladder whose rungs differ per tier - unless the
  client sends its bet level in `params`, where a client that lies desyncs the
  mechanic from the money. Both come from `computeBet`, so they are the numbers
  the wallet is charged against.
- **An autoclose was dropping the math's carry.** It called `closeComplex`
  without `carry`, `nextMode` or `mathVersion`. The orchestrator updated its
  own in-memory session and the wallet never saw it, so an autoclosed round
  looked correct for as long as that process kept the session and reset every
  meter the moment anyone reconnected.
- **Forced outcomes never reached a complex round.** `openRound` passed
  `undefined` where `spin` passes `params.cheat`.
- **`binaryTransport` reported `cfg.port`.** `port: 0` means "bind anywhere",
  and the 0 went straight back to the caller and into the listen log.
- `openComplex` now stamps `mathVersion`, which `settleSimple` and
  `closeComplex` already did.

## Tests

`test/fake-artube.ts` is a fake Games API that refuses unknown sessions, stale
`round_version`s and closed rounds the way the platform does, and speaks major
units so the conversion is exercised rather than assumed. The conformance run
no longer skips the complex checks. `test/complex.test.ts` asserts the frames
themselves - which message type went out, which version rode on it, what
landed in the state slot, and that an autoclose comes back as
`AutocloseRoundRequest` rather than a plain close.

1012 tests pass; typecheck clean.