### PR TITLE
Artube: the round the wallet has open and we do not

### DIFF
--- a/.changeset/artube-wallet-open-round.md
+++ b/.changeset/artube-wallet-open-round.md
@@ -11,8 +11,12 @@ refused with `InvalidRoundOperation: Round is already opened` — the player is
 stuck until someone closes it by hand.
 
 Artube's `SessionInfo` answers the question the contract cannot ask yet
-(ADR-007): `last_round` with no `finished_at` is the open round, with its
-state, its `round_version` and the price it was opened at.
+(ADR-007): `last_round` is the open round, with its state, its `round_version`
+and the price it was opened at. Which round that is comes from a marker the
+adapter writes into an in-flight round's state, not from `finished_at` — that
+field is documented optional and this wire omits it on finished rounds too, so
+requiring it drops every carry there is and treating its absence as "still
+open" makes every round look abandoned.
 `adapter.openRoundFor(sessionId)` returns it after every `openSession`, and the
 round is adopted so a `closeComplex` for it works — the version is the wallet's
 own rather than a guess.

--- a/.changeset/artube-wallet-open-round.md
+++ b/.changeset/artube-wallet-open-round.md
@@ -1,0 +1,22 @@
+---
+"@open-rgs/adapter-artube": minor
+---
+
+Surface the round the wallet has open and this process does not.
+
+A round is opened, and debited, by one process; that process dies, or the pod
+rolls, or the player returns on another instance. The RGS has no memory of the
+round, the wallet still does, and every subsequent round on that session is
+refused with `InvalidRoundOperation: Round is already opened` — the player is
+stuck until someone closes it by hand.
+
+Artube's `SessionInfo` answers the question the contract cannot ask yet
+(ADR-007): `last_round` with no `finished_at` is the open round, with its
+state, its `round_version` and the price it was opened at.
+`adapter.openRoundFor(sessionId)` returns it after every `openSession`, and the
+round is adopted so a `closeComplex` for it works — the version is the wallet's
+own rather than a guess.
+
+What to settle it at stays the game's decision: it owns the math that can value
+the state, and whether the policy is to pay what was on the table or forfeit
+it.

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -77,12 +77,22 @@ opaque string. The adapter packs both:
 { "$rgs": 1, "state": { "step": 9 }, "carry": { "meterPoints": 42 } }
 ```
 
-`openSession` unpacks `carry` out of it again - but only from a round that
-*finished*. `last_round` is whatever the session touched last, and while a
-round is open that is the open round, whose `round_state` is the math's
-in-flight state rather than anything to carry forward. Handing that back is
-how a pod restart mid-round silently resets a player's meters, so an
-unfinished round yields no carry at all: unknown, not empty. A string that was never packed
+An in-flight round is written the same way, marked `"open": true`:
+
+```json
+{ "$rgs": 1, "open": true, "state": { "phase": "decide", "pending": 2 } }
+```
+
+`openSession` reads the carry back out of a final envelope, and out of an
+unmarked string (anything written before this existed). A round marked open
+yields **no carry at all** — unknown, not empty: its state is the math's
+in-flight state, and handing that back is how a pod restart mid-round silently
+resets a player's meters.
+
+The marker is what says which, and it has to be, because the field that ought
+to answer does not: `last_round.finished_at` is documented optional and this
+wire omits it on finished rounds too. Requiring it drops every carry there is;
+treating its absence as "still open" makes every round look abandoned. A string that was never packed
 (a simple round's state, or anything written before this existed) is returned
 verbatim, so no meter resets on the first read after an upgrade. Because the
 wallet only persists the state of a round that moved money, this envelope is

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -102,6 +102,33 @@ sends the union on close - which is what the platform's merge rule asks for.
 `"$status": "cancelled"` in the final state closes the round as cancelled;
 anything else, a zero-win round included, is `completed`.
 
+## A round the wallet has open and you do not
+
+A round is opened - and debited - by one process. That process dies, or the
+pod rolls, or the player returns on another instance. The RGS has no memory of
+the round, the wallet still does, and every subsequent round on that session is
+refused with `InvalidRoundOperation: Round is already opened`. The player is
+stuck until someone closes it by hand.
+
+Artube's `SessionInfo` answers the question the open-rgs contract cannot ask
+yet (ADR-007): `last_round` with no `finished_at` IS the open round, carrying
+its state, its `round_version` and the price it was opened at. On every
+`openSession` the adapter surfaces it:
+
+```ts
+const orphan = adapter.openRoundFor(sessionId);
+// { roundId, state, betIndex, priceMultiplier, mathVersion?, startedAt? }
+```
+
+and adopts the round, so a `closeComplex` for it works - the version is the
+wallet's own, not a guess.
+
+What to settle it at is deliberately NOT the adapter's decision. The game owns
+the math that can value the state (`ComplexMath.autoclose` takes exactly this
+string), and only the game knows whether its policy is to pay what was on the
+table or to forfeit it. Close it with a `reason`, which makes it an
+`AutocloseRoundRequest` - it was not the player who asked.
+
 ## Amounts are converted, on purpose
 
 Artube states money in major units (`"balance": 150.75`). open-rgs counts

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -593,13 +593,19 @@ export class ArtubeAdapter implements PlatformAdapter {
    *  since it would otherwise be guessing a round_version - and the session
    *  stays wedged. Here the version is not a guess: the wallet just gave it. */
   private adoptOpenRound(sessionId: string, last: ArtubeLastRound | undefined): void {
-    if (!last || last.finished_at) {
+    // `finished_at` would be the obvious signal and it is not usable: it is
+    // documented optional and this wire omits it on finished rounds too, so
+    // treating its absence as "still open" makes every carry look absent -
+    // resetting the player's meters - while telling you nothing true. The
+    // marker this adapter writes into the state on open is the signal; a
+    // present `finished_at` is still believed when it says the round is done.
+    if (!last || last.finished_at || !isOpenState(last.round_state)) {
       this.orphans.delete(sessionId);
       return;
     }
     const orphan: ArtubeOpenRound = {
       roundId: last.round_id,
-      state: last.round_state,
+      state: unwrapState(last.round_state),
       betIndex: last.bet_index,
       priceMultiplier: last.price_multiplier,
       ...(last.round_state_version ? { mathVersion: last.round_state_version } : {}),
@@ -680,7 +686,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       ...(req.promoId  ? { free_round_campaign_id: req.promoId } : {}),
       ...(features.length > 0 ? { features: features.map((type) => ({ type })) } : {}),
       round_state_version: stateVersion,
-      round_state:         packRoundState(req.initialState),
+      round_state:         packOpenState(req.initialState),
     };
 
     const env = await this.rpc<OpenRoundRequestPayload, OpenRoundResponsePayload>(
@@ -727,7 +733,7 @@ export class ArtubeAdapter implements PlatformAdapter {
           round_id:            req.roundId,
           round_version:       book.version,
           round_state_version: book.stateVersion,
-          round_state:         packRoundState(req.state),
+          round_state:         packOpenState(req.state),
         },
       );
       for (const f of extractFeatures(req.state)) book.features.add(f);
@@ -1432,11 +1438,17 @@ function artubeSessionToContract(
   // it as a brand-new player - silently resetting the meters of anyone whose
   // pod restarted mid-round.
   //
-  // No carry is the honest answer here: it is unknown, not empty. The
+  // `unpackCarry` decides which it is, from the marker this adapter writes
+  // into an in-flight round's state. Not from `finished_at`: that field is
+  // documented optional and this wire omits it on finished rounds too, so
+  // requiring it drops every carry there is.
+  //
+  // No carry is the honest answer for an open round: unknown, not empty. The
   // orchestrator resumes from its own memory when it still has the session,
   // and this path is what runs when it does not.
-  if (p.last_round && p.last_round.finished_at) {
-    info.carry = unpackCarry(p.last_round.round_state);
+  if (p.last_round) {
+    const carry = unpackCarry(p.last_round.round_state);
+    if (carry !== "") info.carry = carry;
     // `round_state_version` is the field the settle WRITES mathVersion into
     // (see settleSimple), so it is the field to read it back from.
     // `round_version` is the wallet's own round counter, an unrelated number:
@@ -1479,6 +1491,16 @@ const RGS_ENVELOPE_MARK = "$rgs";
 
 interface RoundStateEnvelope {
   [RGS_ENVELOPE_MARK]: 1;
+  /** Present and true while the round is in flight. This is how a later
+   *  SessionInfo tells "the last round is still open" from "the last round
+   *  finished and left a carry".
+   *
+   *  It has to be a marker we write, because the field that ought to answer
+   *  does not: `last_round.finished_at` is documented optional and this wire
+   *  omits it on finished rounds too. Reading it as the signal makes every
+   *  carry look absent - the player's meters reset - while a genuinely open
+   *  round stays invisible. */
+  open?: true;
   state: unknown;
   carry?: unknown;
 }
@@ -1506,15 +1528,44 @@ function packRoundState(state: string, carry?: string): string {
   return JSON.stringify(env);
 }
 
+/** The state of a round that is still in flight, marked as such. */
+function packOpenState(state: string): string {
+  const env: RoundStateEnvelope = {
+    [RGS_ENVELOPE_MARK]: 1,
+    open: true,
+    state: asJsonOrString(state),
+  };
+  return JSON.stringify(env);
+}
+
+function parseEnvelope(roundState: string): RoundStateEnvelope | undefined {
+  const parsed = asJsonOrString(roundState);
+  if (parsed !== null && typeof parsed === "object"
+      && (parsed as Record<string, unknown>)[RGS_ENVELOPE_MARK] === 1) {
+    return parsed as unknown as RoundStateEnvelope;
+  }
+  return undefined;
+}
+
+/** True when this round_state belongs to a round that was still in flight
+ *  when it was written. */
+function isOpenState(roundState: string): boolean {
+  return parseEnvelope(roundState)?.open === true;
+}
+
+/** The math's own state, out of whichever envelope it arrived in. */
+function unwrapState(roundState: string): string {
+  const env = parseEnvelope(roundState);
+  return env === undefined ? roundState : fromJsonOrString(env.state);
+}
+
 /** What the next round should start from: the carry out of a packed
  *  envelope, or the whole string when it was never packed. */
 function unpackCarry(roundState: string): string {
-  const parsed = asJsonOrString(roundState);
-  if (parsed !== null && typeof parsed === "object" && (parsed as Record<string, unknown>)[RGS_ENVELOPE_MARK] === 1) {
-    const env = parsed as unknown as RoundStateEnvelope;
-    return env.carry === undefined ? "" : fromJsonOrString(env.carry);
-  }
-  return roundState;
+  const env = parseEnvelope(roundState);
+  if (env === undefined) return roundState;   // written before the envelope existed
+  if (env.open === true) return "";           // a round in flight carries nothing
+  return env.carry === undefined ? "" : fromJsonOrString(env.carry);
 }
 
 /** Features the math declared, read from a reserved key in its own state.
@@ -1522,7 +1573,7 @@ function unpackCarry(roundState: string): string {
  *  Artube concept in the neutral surface, so the math says it where it
  *  already says everything else. */
 function extractFeatures(state: string): string[] {
-  const parsed = asJsonOrString(state);
+  const parsed = asJsonOrString(unwrapState(state));
   if (parsed === null || typeof parsed !== "object") return [];
   const raw = (parsed as Record<string, unknown>)["$features"];
   if (!Array.isArray(raw)) return [];
@@ -1534,7 +1585,7 @@ function extractFeatures(state: string): string[] {
 /** "cancelled" only when the math asks for it by name. Everything else,
  *  a zero-win round included, is a round that completed. */
 function closeStatus(state: string): "completed" | "cancelled" {
-  const parsed = asJsonOrString(state);
+  const parsed = asJsonOrString(unwrapState(state));
   if (parsed !== null && typeof parsed === "object"
       && (parsed as Record<string, unknown>)["$status"] === "cancelled") {
     return "cancelled";

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -77,6 +77,37 @@ import pkg from "../package.json" with { type: "json" };
  *  see exactly which adapter is running in the pod. */
 export const ARTUBE_ADAPTER_VERSION: string = pkg.version;
 
+/** A round the WALLET says is still open on a session.
+ *
+ *  The recovery gap, in one shape. A round is opened - and debited - by one
+ *  process; that process dies, or the pod rolls, or the player comes back on
+ *  another instance. The RGS has no memory of the round, the wallet still
+ *  does, and every subsequent round on that session is refused with
+ *  `InvalidRoundOperation: Round is already opened`. The player is stuck
+ *  until someone closes it by hand.
+ *
+ *  Artube's SessionInfo answers the question the open-rgs contract cannot ask
+ *  yet (ADR-007): `last_round` with no `finished_at` IS the open round, with
+ *  the state, the version and the price it was opened at. The adapter surfaces
+ *  it here, and adopts the round so a close for it works. What to settle it
+ *  at is the game's decision, not the adapter's - it owns the math that can
+ *  value the state. */
+export interface ArtubeOpenRound {
+  roundId: string;
+  /** The round's state as the wallet last stored it. `ComplexMath.autoclose`
+   *  takes exactly this. */
+  state: string;
+  /** What the round was opened at, so a settle can be priced:
+   *  `allowedBets[betIndex] * priceMultiplier`. */
+  betIndex: number;
+  priceMultiplier: number;
+  /** Math version that wrote the state, when the wire carried one. A state
+   *  written by math that is no longer loaded must not be valued by the math
+   *  that replaced it. */
+  mathVersion?: string;
+  startedAt?: string;
+}
+
 // ── Wire types ────────────────────────────────────────────────────────
 
 type Channel = "rpc" | "events" | "control";
@@ -399,6 +430,10 @@ export class ArtubeAdapter implements PlatformAdapter {
   // round must echo; `features` accumulates so the close can send the
   // open-union-close set the docs ask for. The entry dies with the close.
   private readonly rounds = new Map<string, OpenRoundBook>();
+  // Rounds the wallet reported open on a session that this process did not
+  // open. Keyed by session, replaced on every openSession, cleared when the
+  // round is closed.
+  private readonly orphans = new Map<string, ArtubeOpenRound>();
   // Per-session minor-unit scale, learned from SessionInfo. Events carry a
   // balance but no currency metadata, so without this an out-of-band
   // BalanceChanged would arrive in different units than every other amount.
@@ -523,6 +558,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       heartbeat_timeout_ms:   this.heartbeatTimeoutMs,
       heartbeat_silent_ms:    this.lastPongAt ? Date.now() - this.lastPongAt : null,
       open_complex_rounds:    this.rounds.size,
+      wallet_reported_open_rounds: this.orphans.size,
       schema_version:         this.schemaVersion,
       amount_scaling:         this.scaleAmounts ? "minor-units" : "verbatim",
     };
@@ -542,7 +578,51 @@ export class ArtubeAdapter implements PlatformAdapter {
     );
     const scale = this.scaleFor(env.payload.game_settings);
     this.sessionScale.set(sessionId, scale);
+    this.adoptOpenRound(sessionId, env.payload.last_round);
     return artubeSessionToContract(sessionId, env.payload, scale, this.currencyDecimals);
+  }
+
+  /** The round the wallet says is open on this session and this process did
+   *  not open, if any. Populated by the most recent `openSession`. */
+  openRoundFor(sessionId: string): ArtubeOpenRound | undefined {
+    return this.orphans.get(sessionId);
+  }
+
+  /** Take ownership of a round the wallet reports open, so a close for it can
+   *  be sent. Without the book entry `closeComplex` refuses locally - rightly,
+   *  since it would otherwise be guessing a round_version - and the session
+   *  stays wedged. Here the version is not a guess: the wallet just gave it. */
+  private adoptOpenRound(sessionId: string, last: ArtubeLastRound | undefined): void {
+    if (!last || last.finished_at) {
+      this.orphans.delete(sessionId);
+      return;
+    }
+    const orphan: ArtubeOpenRound = {
+      roundId: last.round_id,
+      state: last.round_state,
+      betIndex: last.bet_index,
+      priceMultiplier: last.price_multiplier,
+      ...(last.round_state_version ? { mathVersion: last.round_state_version } : {}),
+      ...(last.started_at ? { startedAt: last.started_at } : {}),
+    };
+    this.orphans.set(sessionId, orphan);
+    if (!this.rounds.has(orphan.roundId)) {
+      this.rounds.set(orphan.roundId, {
+        sessionId,
+        version: last.round_version,
+        stateVersion: last.round_state_version,
+        features: new Set(),
+        chain: Promise.resolve(),
+      });
+    }
+    this.log.warn("Artube reports a round this process did not open", {
+      "event.category": "artube",
+      "event.action":   "orphan_round_adopted",
+      "artube.session_id":    sessionId,
+      "artube.round_id":      orphan.roundId,
+      "artube.round_version": last.round_version,
+      "artube.started_at":    orphan.startedAt,
+    });
   }
 
   async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
@@ -706,6 +786,9 @@ export class ArtubeAdapter implements PlatformAdapter {
     }
 
     this.rounds.delete(req.roundId);
+    if (this.orphans.get(req.sessionId)?.roundId === req.roundId) {
+      this.orphans.delete(req.sessionId);
+    }
 
     this.log.info("Artube complex round closed", {
       "event.category": "artube",

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -588,6 +588,87 @@ export class ArtubeAdapter implements PlatformAdapter {
     return this.orphans.get(sessionId);
   }
 
+  /**
+   * Claim one round by id, so a close for it can be sent.
+   *
+   * The last escape hatch, for the case `last_round` cannot reach: a complex
+   * round left open while simple rounds kept settling after it. Each of those
+   * is its own round, so the open one is not the session's last round and
+   * nothing in SessionInfo points at it - but the wallet still refuses every
+   * new round with `InvalidRoundOperation: Round is already opened`.
+   *
+   * The id comes from wherever the open was recorded: this adapter's own
+   * `round_open` log line, the operator's back office, a client's replay.
+   * `roundVersion` is the wallet's counter for it - 0 for a round that was
+   * opened and never updated, which is the usual shape of an abandoned one.
+   *
+   * Nothing here is inferred, which is the point: an adapter guessing at
+   * which round to close is how you settle the wrong one.
+   */
+  claimRound(sessionId: string, roundId: string, roundVersion = 0, stateVersion?: string): void {
+    this.rounds.set(roundId, {
+      sessionId,
+      version: roundVersion,
+      stateVersion: stateVersion ?? this.defaultRoundStateVersion,
+      features: new Set(),
+      chain: Promise.resolve(),
+    });
+    this.log.warn("Artube round claimed by id", {
+      "event.category": "artube",
+      "event.action":   "round_claimed_by_id",
+      "artube.session_id":    sessionId,
+      "artube.round_id":      roundId,
+      "artube.round_version": roundVersion,
+    });
+  }
+
+  /**
+   * Claim `last_round` as open whatever it looks like, and hand it back.
+   *
+   * The escape hatch for a round the marker cannot identify: written before
+   * the marker existed, or by another implementation of this wire. The
+   * symptom is unambiguous - every round on the session is refused with
+   * `InvalidRoundOperation: Round is already opened` - but the state alone
+   * does not say so, and there is no way to ask.
+   *
+   * Deliberately not automatic. It closes whatever the wallet last recorded,
+   * which is wrong if the session is not actually wedged, so it is something
+   * an operator invokes with the refusal in front of them.
+   */
+  async claimLastRound(sessionId: string, connectionId = "claim"): Promise<ArtubeOpenRound | undefined> {
+    const env = await this.rpc<SessionInfoRequestPayload, SessionInfoResponsePayload>(
+      "SessionInfoRequest",
+      { session_id: sessionId, player_connection_info: { player_connection_id: connectionId } },
+    );
+    const last = env.payload.last_round;
+    if (!last) return undefined;
+    this.sessionScale.set(sessionId, this.scaleFor(env.payload.game_settings));
+    const orphan: ArtubeOpenRound = {
+      roundId: last.round_id,
+      state: unwrapState(last.round_state),
+      betIndex: last.bet_index,
+      priceMultiplier: last.price_multiplier,
+      ...(last.round_state_version ? { mathVersion: last.round_state_version } : {}),
+      ...(last.started_at ? { startedAt: last.started_at } : {}),
+    };
+    this.orphans.set(sessionId, orphan);
+    this.rounds.set(orphan.roundId, {
+      sessionId,
+      version: last.round_version,
+      stateVersion: last.round_state_version,
+      features: new Set(),
+      chain: Promise.resolve(),
+    });
+    this.log.warn("Artube round claimed by hand", {
+      "event.category": "artube",
+      "event.action":   "orphan_round_claimed",
+      "artube.session_id":    sessionId,
+      "artube.round_id":      orphan.roundId,
+      "artube.round_version": last.round_version,
+    });
+    return orphan;
+  }
+
   /** Take ownership of a round the wallet reports open, so a close for it can
    *  be sent. Without the book entry `closeComplex` refuses locally - rightly,
    *  since it would otherwise be guessing a round_version - and the session

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -264,6 +264,9 @@ describe("complex rounds", () => {
     // Unknown, not empty, and above all not the open round's own state.
     const during = await adapter.openSession("open-carry", "c3");
     expect(during.carry).toBeUndefined();
+    // And it is the marker in the state that says so, not finished_at - this
+    // wire omits that on finished rounds too.
+    expect(adapter.openRoundFor("open-carry")).toBeDefined();
   });
 
   test("an open does not chain itself to whatever round came before", async () => {

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -183,6 +183,55 @@ describe("complex rounds", () => {
     expect((bal as { balance: number }).balance).toBe(fake.balanceMinor("s6"));
   });
 
+  test("a round the wallet has open but this process did not open is recoverable", async () => {
+    // The wedge: open a round, lose the process that opened it, come back.
+    // The wallet still has the round; without adopting it every later round
+    // on that session is refused with "Round is already opened" and the
+    // player is stuck until someone closes it by hand.
+    const { fake, adapter } = await connect();
+    await adapter.openSession("orphan", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "orphan", bet: 100, betIndex: 2, priceMultiplier: 1,
+      initialState: JSON.stringify({ phase: "decide", pending: 3 }),
+      mathVersion: "1.0.0",
+    });
+
+    // A new adapter: a different pod, or this one after a restart.
+    const fresh = new ArtubeAdapter({
+      wsUrl: fake.url, gameId: "complex-test", authToken: "test-key",
+      handshakeTimeoutMs: 5_000, rpcTimeoutMs: 5_000,
+    });
+    await fresh.connect();
+    try {
+      expect(fresh.openRoundFor("orphan")).toBeUndefined();
+      await fresh.openSession("orphan", "c2");
+
+      const orphan = fresh.openRoundFor("orphan");
+      expect(orphan).toBeDefined();
+      expect(orphan!.roundId).toBe(opened.roundId);
+      expect(orphan!.betIndex).toBe(2);
+      expect(orphan!.priceMultiplier).toBe(1);
+      expect(orphan!.mathVersion).toBe("1.0.0");
+      // The state is what a valuation is computed from, so it has to survive.
+      expect(JSON.parse(orphan!.state)).toMatchObject({ phase: "decide", pending: 3 });
+
+      // And it can actually be closed - the round_version came from the
+      // wallet, so this is not a guess.
+      const closed = await fresh.closeComplex({
+        sessionId: "orphan", roundId: orphan!.roundId,
+        finalState: orphan!.state, win: 300, multiplier: 3,
+        type: "recovered", reason: "orphaned-round",
+      });
+      expect(closed.balance).toBe(1_000_000 - 100 + 300);
+      expect(fresh.openRoundFor("orphan")).toBeUndefined();
+      // Settled by the platform's autoclose message, because it was not the
+      // player who asked for it.
+      expect(fake.sent("AutocloseRoundRequest").length).toBe(1);
+    } finally {
+      fresh.disconnect();
+    }
+  });
+
   test("disconnect() takes effect before the socket finishes closing", async () => {
     // Whoever asks isHealthy is deciding whether to route a round at this
     // adapter. "I told it to disconnect and it says it is fine" is wrong at

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -167,7 +167,6 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: winMul,
             win: major(win),
             started_at: new Date().toISOString(),
-            finished_at: new Date().toISOString(),
             round_version: 0,
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),
@@ -215,6 +214,9 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: 0,
             win: 0,
             started_at: new Date().toISOString(),
+            // No finished_at. The real wire omits it on FINISHED rounds too,
+            // which is exactly why the adapter cannot use it to tell an open
+            // round from a closed one - so the fake must not offer it either.
             round_version: 0,
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),
@@ -261,7 +263,6 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: winMul,
             win: major(win),
             started_at: new Date().toISOString(),
-            finished_at: new Date().toISOString(),
             round_version: Number(p["round_version"] ?? 0),
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),


### PR DESCRIPTION
Everything here came out of running the bench against the Artube sandbox.

## The wedge

A round is opened, and debited, by one process. That process dies, or the pod
rolls, or the player returns on another instance. The RGS has no memory of the
round, the wallet still does, and **every** subsequent round on that session is
refused with `InvalidRoundOperation: Round is already opened`. The player is
stuck until someone closes it by hand. This is the gap ADR-007 describes.

Artube's `SessionInfo` can answer it: `last_round` is the open round, with its
state, its `round_version` and the price it was opened at.
`adapter.openRoundFor(sessionId)` surfaces that after every `openSession`, and
the round is adopted so a `closeComplex` for it works — the version is the
wallet's own, not a guess. What to settle it at stays the game's decision: it
owns the math that can value the state.

Two escape hatches for what that cannot reach, both explicit because an adapter
guessing at which round to close is how you settle the wrong one:
`claimLastRound()` for a round written before the marker below existed, and
`claimRound(sessionId, roundId, roundVersion)` for the case `last_round` cannot
point at at all — a complex round left open while simple rounds kept settling
after it, each of those being its own round.

## `finished_at` is not usable, so mark the state instead

The obvious signal for "is this round still open" is
`last_round.finished_at`. It is documented optional, and **this wire omits it
on finished rounds too**. I shipped it as the signal first, and the effect on
the sandbox was immediate and total: every carry read as absent, so every
player's meters read as empty, while a genuinely open round stayed invisible.

So the adapter marks the state it writes on open and update:

```json
{ "$rgs": 1, "open": true, "state": { "phase": "decide", "pending": 2 } }
```

and reads that back. An unmarked string is still read as a carry, which keeps
rounds written before this readable.

## Also

`disconnect()` marks the adapter unhealthy synchronously. It was cleared in the
socket's close handler, so between the call and the event landing `isHealthy`
still read `true` — and whoever asks is deciding whether to route a round at
it. A machine fast enough to fire close in the same tick hides it, which is why
it passed locally and failed CI.

The fake server models an open round as `last_round` with no `finished_at`, so
all of this reproduces without a cluster.