### PR TITLE
Artube: recovery, demo sessions, and the gaps between working and shippable

### DIFF
--- a/.changeset/artube-demo-sessions.md
+++ b/.changeset/artube-demo-sessions.md
@@ -10,8 +10,12 @@ not persisted, and a session is a demo session when its **currency is null**.
 From there the backend is expected to track the virtual balance itself, for as
 long as the session lives.
 
-The decorator does that. A demo session is answered from memory and never
-reaches the wire; a real one passes straight through untouched. The bet ladder
+The decorator does that, for everything the Games API would be storing and not
+just the balance: the round state at open, each update, the final state at
+close, the carry, and the finished round the way `last_round` holds it. A demo
+session is answered from memory and never reaches the wire; a real one passes
+straight through untouched. `demoSessionFor(sessionId)` returns the store, since
+play money has no back office to inspect. The bet ladder
 still comes from the wallet — it is not money, and a demo player should be able
 to bet what a real one can.
 

--- a/.changeset/artube-demo-sessions.md
+++ b/.changeset/artube-demo-sessions.md
@@ -1,0 +1,21 @@
+---
+"@open-rgs/adapter-artube": minor
+---
+
+`withDemoSessions` — serve Artube demo sessions from memory.
+
+Artube's demo mode has no requests of its own: `PlayRound`, `OpenRound`,
+`UpdateRoundState` and `CloseRound` look identical either way, a demo round is
+not persisted, and a session is a demo session when its **currency is null**.
+From there the backend is expected to track the virtual balance itself, for as
+long as the session lives.
+
+The decorator does that. A demo session is answered from memory and never
+reaches the wire; a real one passes straight through untouched. The bet ladder
+still comes from the wallet — it is not money, and a demo player should be able
+to bet what a real one can.
+
+It persists nothing (matching the platform: a demo round is not stored, so a
+reconnect may not restore one) and it never infers demo-ness from anything but
+the wallet's own answer — a session-id prefix or a config flag getting that
+backwards is how play money reaches a real balance.

--- a/.changeset/artube-production-gaps.md
+++ b/.changeset/artube-production-gaps.md
@@ -1,0 +1,31 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+"@open-rgs/adapter-artube": minor
+---
+
+Close the gaps between "the rounds work" and "a real game could ship on this".
+
+**Idempotency, on a wire that has no idempotency field.** The same key now
+settles once per process — claimed before the request goes out, so concurrent
+duplicates collapse to one payment rather than racing, and scoped per session so
+one player's key cannot suppress another's. An unanswered settle is *checked*
+rather than retried blind: the key rides inside the round state, so the adapter
+reads the session's last round back and asks whether its own settle landed.
+Found it, returns the real receipt; did not, the failure stands. A retry that
+lands on another pod, or a wallet that is unreachable while the answer is lost,
+is still not covered and is logged for reconciliation.
+
+**Platform data reaches the client.** `SessionInfo.clientData` — an opaque,
+adapter-filled, RGS-unread bag, forwarded verbatim in the INIT response. The
+Artube adapter fills it with the `gamification_token` their docs say to forward
+unchanged, the platform max win, auto-spin counts, RTP display settings, win
+history and security hash. All of that was parsed off the wire and dropped,
+which meant a real game's UI could not be built on this adapter.
+
+**The platform's own max-win cap is visible.** `RoundReceipt.platformMaxWinReached`,
+surfaced to the client as `platformMaxWin` on spin and close. Distinct from the
+engine's own cap: this one is applied wallet-side and the RGS cannot infer it.
+
+**The concurrency certification is switched on**, which is how the dedupe's
+read-then-write race was found on its first run.

--- a/.changeset/artube-wallet-open-round.md
+++ b/.changeset/artube-wallet-open-round.md
@@ -12,11 +12,10 @@ stuck until someone closes it by hand.
 
 Artube's `SessionInfo` answers the question the contract cannot ask yet
 (ADR-007): `last_round` is the open round, with its state, its `round_version`
-and the price it was opened at. Which round that is comes from a marker the
-adapter writes into an in-flight round's state, not from `finished_at` — that
-field is documented optional and this wire omits it on finished rounds too, so
-requiring it drops every carry there is and treating its absence as "still
-open" makes every round look abandoned.
+and the price it was opened at. Which round that is comes from `finished_at` — null while
+open, set once closed — with a marker the adapter writes into an in-flight
+round's state as a second opinion, so the detection does not rest on an
+optional field staying present.
 `adapter.openRoundFor(sessionId)` returns it after every `openSession`, and the
 round is adopted so a `closeComplex` for it works — the version is the wallet's
 own rather than a guess.

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -212,15 +212,43 @@ The practical consequences:
   assuming a length or a set of values; it is whatever that wallet says it is
   on that session, and nothing here hardcodes it.
 
-## Known limitations
+## Idempotency, without an idempotency field
 
-**`idempotencyKey` is dropped.** `PlayRoundRequest` has no idempotency field,
-so the key open-rgs generates never reaches the wallet. A retried settle after
-a timeout or a reconnect is **not deduplicated wallet-side**. If the socket
-drops between send and reply, the RGS cannot tell a lost request from a lost
-response, and a retry can move money twice. Mitigate operationally -
-reconciliation against the wallet's own round records - until the protocol
-grows a field for it. This is the adapter's most significant gap.
+`PlayRoundRequest` and `CloseRoundRequest` have no idempotency field, so the
+key open-rgs generates cannot reach the wallet and the wallet cannot dedupe.
+Three things close most of that gap; read what each one does and does not
+cover before relying on it.
+
+**The same key is settled once per process.** The key is claimed *before* the
+request goes out and what is remembered is the in-flight promise, so two
+concurrent settles with one key produce one payment rather than a race. (The
+earlier version remembered the finished receipt, which was a read-then-write
+race — both missed, both paid. `@open-rgs/adapter-test-kit`'s concurrency
+certification found it the first time it was switched on.) Keys are scoped per
+session: a client-supplied key from one player can never suppress another's
+settle. A settle that *fails* releases its key, so a genuine retry is not
+refused by the memory of an attempt that moved no money.
+
+**An unanswered settle is checked, not retried blind.** The key rides inside
+the round state the adapter writes:
+
+```json
+{ "$rgs": 1, "key": "…", "state": { … }, "carry": { … } }
+```
+
+so when a settle times out or the socket drops, the adapter reads the session's
+last round back and looks for that key. Found: the settle landed, and its
+receipt is returned instead of a failure that would provoke a retry. Not found:
+the failure stands, which is the safe direction. This is what turns "lost
+request or lost response?" — the question that makes a blind retry dangerous —
+into one the adapter can answer.
+
+**What is still not covered.** A retry that lands on a *different pod* meets a
+cold dedupe cache; the reconciliation path is what catches it, and it needs the
+wallet reachable. If the wallet is unreachable *and* the answer was lost, the
+settle is genuinely unresolved and is logged as
+`event.action: settle_unreconciled` for reconciliation against the wallet's own
+records. A field on the wire would still be better than all of this.
 
 ## Conformance results
 
@@ -234,11 +262,32 @@ those are allowlisted with their reason rather than faked green:
 
 | Check | Why it cannot pass |
 |-------|--------------------|
-| `idempotency.duplicate-key` | No idempotency field on the wire (see above). |
 | `errors.insufficient-funds` | The probe drives `bet`, and this wire carries no amount by design. A test-kit fix that drives `priceMultiplier` instead is pending. |
+
+`idempotency.duplicate-key` used to be on that list and passes now — see above.
+The concurrency certification is switched on (it is opt-in, and was not), which
+is how the dedupe race was found. `concurrency.reverse-interleave` is skipped
+rather than failed: this wire has no game-initiated rollback message, so
+`reverseRound` has nothing to call.
 
 A second test asserts those two are *still* failing, so if the wire or the test
 kit changes, the allowlist goes red instead of quietly over-permitting.
+
+## What the wallet says for the client
+
+`SessionInfo.clientData` carries the per-session things a game's UI needs and
+the RGS has no business reading: the `gamification_token` their docs say to
+forward unchanged, the platform max win to print in the rules, the allowed
+auto-spin counts, the RTP to display, the win history, the security hash. They
+reach the client verbatim in the INIT response. Before this they were parsed
+off the wire and dropped, which meant a real game's UI could not be built on
+this adapter at all.
+
+`is_platform_max_win_reached` is the one that is *not* cosmetic: it is the
+wallet capping a round on its own side, which the RGS cannot infer — the
+balance is simply smaller than the multiplier implies. It comes back on the
+receipt as `platformMaxWinReached` and reaches the client as `platformMaxWin`
+on the spin and close responses.
 
 ## Configuration
 
@@ -248,6 +297,8 @@ kit changes, the allowlist goes red instead of quietly over-permitting.
 | `gameId` | Sent as the `X-Game-ID` header. |
 | `authToken` | Sent as the `X-Api-Key` header. Required in production. |
 | `rpcTimeoutMs` | Per-request deadline. Default 30000. |
+| `reconcileTimeoutMs` | How long to wait for the socket before asking whether an unanswered settle landed. Default 10000. |
+| `settleCacheSize` | Settled keys remembered per process. Default 10000. |
 | `currencyDecimals` | Fallback precision when the wallet sends no `currency_minimal_unit`. Default 2. |
 | `amountScaling` | `"minor-units"` (default) converts inbound amounts; `"verbatim"` passes them through. |
 | `defaultRoundStateVersion` | `round_state_version` when the RGS has no math version to stamp. Default `"1"`. |

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -89,10 +89,15 @@ yields **no carry at all** — unknown, not empty: its state is the math's
 in-flight state, and handing that back is how a pod restart mid-round silently
 resets a player's meters.
 
-The marker is what says which, and it has to be, because the field that ought
-to answer does not: `last_round.finished_at` is documented optional and this
-wire omits it on finished rounds too. Requiring it drops every carry there is;
-treating its absence as "still open" makes every round look abandoned. A string that was never packed
+Which round is which comes from `last_round.finished_at` - `null` while the
+round is open, set once it closes - with the marker as a second opinion. A
+round is treated as open if either says so.
+
+(An earlier build here refused to trust `finished_at`, on the strength of one
+session that was already wedged: its `last_round` WAS an open round, so the
+null was the field working correctly, read as evidence that it did not. The
+marker stays because it costs nothing and does not depend on an optional field
+staying present - not because the wire is untrustworthy.) A string that was never packed
 (a simple round's state, or anything written before this existed) is returned
 verbatim, so no meter resets on the first read after an upgrade. Because the
 wallet only persists the state of a round that moved money, this envelope is

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -144,6 +144,32 @@ string), and only the game knows whether its policy is to pay what was on the
 table or to forfeit it. Close it with a `reason`, which makes it an
 `AutocloseRoundRequest` - it was not the player who asked.
 
+## Demo sessions
+
+Artube's demo mode has no requests of its own — `PlayRound`, `OpenRound`,
+`UpdateRoundState` and `CloseRound` look identical either way. A session is a
+demo session when its **currency is null**; that is the whole marker, and from
+there the backend tracks the virtual balance itself.
+
+```ts
+const platform = withDemoSessions(new ArtubeAdapter({ ... }), {
+  startingBalance: 1_000_000,
+});
+```
+
+A demo session is then answered from memory and never reaches the wire; a real
+one passes straight through. The bet ladder still comes from the wallet — it is
+not money, and a demo player should be able to bet what a real one can — and so
+does the answer to "is this demo at all".
+
+Two things it does not do, both deliberate. It **persists nothing**: a demo
+balance and its carry live as long as the process, which is the platform's own
+behaviour (a demo round is not stored, so a reconnect may not restore one), and
+inventing durability for play money would be worse than not having it. And it
+**never guesses**: a session is demo because the wallet returned no currency
+for it, not because of a session-id prefix or a config flag. Getting that
+backwards is how play money reaches a real balance.
+
 ## Amounts are converted, on purpose
 
 Artube states money in major units (`"balance": 150.75`). open-rgs counts

--- a/packages/adapter-artube/README.md
+++ b/packages/adapter-artube/README.md
@@ -162,6 +162,14 @@ one passes straight through. The bet ladder still comes from the wallet — it i
 not money, and a demo player should be able to bet what a real one can — and so
 does the answer to "is this demo at all".
 
+**Everything the Games API would store is stored, not just the balance**: the
+round state at open, every update to it, the final state at close, the carry
+that threads to the next round, and the finished round the way `last_round`
+would hold it. A demo round that kept only the money would behave differently
+from a real one in the one place a game actually reads.
+`demoSessionFor(sessionId)` returns that store, because when a demo round
+behaves oddly there is no back office to go and look in.
+
 Two things it does not do, both deliberate. It **persists nothing**: a demo
 balance and its carry live as long as the process, which is the platform's own
 behaviour (a demo round is not stored, so a reconnect may not restore one), and

--- a/packages/adapter-artube/src/demo.ts
+++ b/packages/adapter-artube/src/demo.ts
@@ -1,0 +1,205 @@
+// Demo sessions, kept in this process.
+//
+// Artube's demo mode has no requests of its own: `PlayRound`, `OpenRound`,
+// `UpdateRoundState` and `CloseRound` look identical either way, and the
+// platform does not persist a demo round. A session is a demo session when
+// its **currency is null** - that is the whole marker - and from there the
+// backend is expected to track the virtual balance itself, for as long as the
+// session lives.
+//
+// So: wrap the wallet. A demo session is answered from memory and never
+// reaches the wire; a real one passes straight through, untouched. The
+// decision is per session and is made once, from what the wallet said when
+// the session opened.
+//
+// What this deliberately does NOT do:
+//
+//   Persist anything. A demo balance lives as long as the process, and a
+//   demo carry with it. That is the platform's own behaviour - "demo rounds
+//   are not persisted the way real-money rounds are, so a reconnect may not
+//   restore an in-progress demo round" - and pretending otherwise would mean
+//   inventing durability for play money while the real thing goes through a
+//   wallet.
+//
+//   Guess. A session is demo because the wallet returned no currency for it,
+//   never because of a session-id prefix or a config flag. Getting that
+//   backwards is how play money reaches a real balance.
+
+import type {
+  CarryState, CloseComplex, OpenComplex, PlatformAdapter, PlatformEvent,
+  RoundReceipt, SessionInfo, SettleSimple, UpdateComplex,
+} from "@open-rgs/contract";
+import { createLogger, type Logger } from "@open-rgs/log";
+import pkg from "../package.json" with { type: "json" };
+
+export interface DemoSessionsOptions {
+  /** Play-money balance a demo session starts with, in the currency's
+   *  minimal unit. Default 1_000_000 (10,000.00 at 2 decimals). */
+  startingBalance?: number;
+  logger?: Logger;
+}
+
+interface DemoSession {
+  balance: number;
+  carry?: CarryState;
+  nextMode?: string;
+  mathVersion?: string;
+  /** The open complex round, if any. Demo rounds are this process's own, so
+   *  the id is generated here. */
+  open?: { roundId: string; bet: number };
+  rounds: number;
+}
+
+/**
+ * Serve demo sessions from memory, pass everything else to `inner`.
+ *
+ * ```ts
+ * const platform = withDemoSessions(new ArtubeAdapter({ ... }), {
+ *   startingBalance: 1_000_000,
+ * });
+ * ```
+ *
+ * The returned adapter is a `PlatformAdapter` like any other; nothing above
+ * it needs to know which kind of session it is looking at.
+ */
+export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptions = {}): PlatformAdapter {
+  const startingBalance = opts.startingBalance ?? 1_000_000;
+  const log = opts.logger ?? createLogger({ service: "open-rgs-adapter-artube-demo", version: pkg.version });
+  const demo = new Map<string, DemoSession>();
+
+  const isDemo = (sessionId: string): boolean => demo.has(sessionId);
+
+  const receipt = (s: DemoSession, roundId: string): RoundReceipt => ({ roundId, balance: s.balance });
+
+  const wrapped: PlatformAdapter = {
+    connect: () => inner.connect(),
+    disconnect: () => inner.disconnect(),
+    get isHealthy() { return inner.isHealthy; },
+    get diagnostics() {
+      return { ...inner.diagnostics, demo_sessions: demo.size };
+    },
+
+    async openSession(sessionId: string, connectionId: string): Promise<SessionInfo> {
+      // Always ask the wallet: it owns the bet ladder, the promo pool and the
+      // answer to "is this a demo session at all".
+      const info = await inner.openSession(sessionId, connectionId);
+      if (info.currency !== "" && info.currency !== null && info.currency !== undefined) {
+        // A session that stops being demo cannot keep a demo balance.
+        if (demo.delete(sessionId)) {
+          log.warn("Demo session came back with a currency, dropping its play money", {
+            "event.category": "artube",
+            "event.action":   "demo_session_became_real",
+            "artube.session_id": sessionId,
+          });
+        }
+        return info;
+      }
+
+      let s = demo.get(sessionId);
+      if (!s) {
+        s = { balance: startingBalance, rounds: 0 };
+        demo.set(sessionId, s);
+        log.info("Demo session opened, balance served from memory", {
+          "event.category": "artube",
+          "event.action":   "demo_session_start",
+          "artube.session_id": sessionId,
+          "artube.demo_balance": s.balance,
+        });
+      }
+
+      // The wallet's own view of everything that is not money: the ladder, the
+      // default bet, the promo pool. Only the balance and the carry are ours.
+      const out: SessionInfo = {
+        ...info,
+        balance: s.balance,
+      };
+      if (s.carry !== undefined) out.carry = s.carry;
+      else delete out.carry;
+      if (s.mathVersion !== undefined) out.mathVersion = s.mathVersion;
+      else delete out.mathVersion;
+      if (s.nextMode !== undefined) out.nextMode = s.nextMode;
+      else delete out.nextMode;
+      return out;
+    },
+
+    async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+      const s = demo.get(req.sessionId);
+      if (!s) return inner.settleSimple(req);
+      s.balance = s.balance - req.bet + req.win;
+      s.carry = req.roundState;
+      s.mathVersion = req.mathVersion;
+      s.nextMode = req.nextMode;
+      s.rounds += 1;
+      return receipt(s, `demo-${crypto.randomUUID()}`);
+    },
+
+    async openComplex(req: OpenComplex): Promise<RoundReceipt> {
+      const s = demo.get(req.sessionId);
+      if (!s) return inner.openComplex(req);
+      if (s.open) {
+        // Same refusal the wallet gives, for the same reason: one open round
+        // per session, and a second open would strand the first one's stake.
+        throw new Error("demo: a round is already open on this session");
+      }
+      s.balance -= req.bet;
+      const roundId = `demo-${crypto.randomUUID()}`;
+      s.open = { roundId, bet: req.bet };
+      return receipt(s, roundId);
+    },
+
+    async updateComplex(req: UpdateComplex): Promise<void> {
+      if (!isDemo(req.sessionId)) {
+        if (typeof inner.updateComplex === "function") await inner.updateComplex(req);
+        return;
+      }
+      // The audit checkpoint exists so a regulator can reconstruct a
+      // real-money round. There is no money here and nothing to reconstruct.
+    },
+
+    async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+      const s = demo.get(req.sessionId);
+      if (!s) return inner.closeComplex(req);
+      if (!s.open || s.open.roundId !== req.roundId) {
+        throw new Error(`demo: no open round ${req.roundId} to close`);
+      }
+      s.balance += req.win;
+      s.carry = req.carry;
+      s.mathVersion = req.mathVersion;
+      s.nextMode = req.nextMode;
+      s.rounds += 1;
+      delete s.open;
+      return receipt(s, req.roundId);
+    },
+
+    onEvent(handler: (e: PlatformEvent) => void): void {
+      inner.onEvent((e) => {
+        // The session ending is the end of the play money with it. Artube
+        // does not persist a demo round, so there is nothing to come back to
+        // and keeping the balance would make the next session start rich.
+        if (e.type === "sessionClosed" && demo.delete(e.sessionId)) {
+          log.info("Demo session closed, play money discarded", {
+            "event.category": "artube",
+            "event.action":   "demo_session_end",
+            "artube.session_id": e.sessionId,
+          });
+        }
+        // A balance event is about a real wallet. Forwarding it for a demo
+        // session would overwrite the play balance with someone's real one.
+        if (e.type === "balanceChanged" && isDemo(e.sessionId)) return;
+        handler(e);
+      });
+    },
+  };
+
+  if (typeof inner.reverseRound === "function") {
+    wrapped.reverseRound = async (req) => {
+      if (isDemo(req.sessionId)) {
+        // Nothing to charge back: no money moved.
+        return { roundId: req.roundId, balance: demo.get(req.sessionId)!.balance, reversed: false, reason: "demo-session" };
+      }
+      return inner.reverseRound!(req);
+    };
+  }
+
+  return wrapped;
+}

--- a/packages/adapter-artube/src/demo.ts
+++ b/packages/adapter-artube/src/demo.ts
@@ -32,11 +32,46 @@ import type {
 import { createLogger, type Logger } from "@open-rgs/log";
 import pkg from "../package.json" with { type: "json" };
 
+/** A read-only look at what this process is storing for a demo session. */
+export interface DemoSessionView {
+  balance: number;
+  rounds: number;
+  carry?: CarryState;
+  mathVersion?: string;
+  nextMode?: string;
+  openRound?: DemoRound;
+  lastRound?: DemoRound;
+}
+
+/** The adapter returned by {@link withDemoSessions}, which can also report
+ *  what it is holding for a demo session. */
+export interface DemoCapableAdapter extends PlatformAdapter {
+  demoSessionFor(sessionId: string): DemoSessionView | undefined;
+}
+
 export interface DemoSessionsOptions {
   /** Play-money balance a demo session starts with, in the currency's
    *  minimal unit. Default 1_000_000 (10,000.00 at 2 decimals). */
   startingBalance?: number;
   logger?: Logger;
+}
+
+/** What the Games API would have stored about one round. Kept here instead. */
+export interface DemoRound {
+  roundId: string;
+  betIndex: number;
+  priceMultiplier: number;
+  bet: number;
+  /** The round's state, as the wallet's `round_state` would hold it: written
+   *  at open, replaced by every update, final at close. */
+  state: string;
+  stateVersion?: string;
+  /** Round-operation counter, the demo equivalent of `round_version`. */
+  version: number;
+  winMultiplier?: number;
+  win?: number;
+  startedAt: string;
+  finishedAt?: string;
 }
 
 interface DemoSession {
@@ -46,7 +81,9 @@ interface DemoSession {
   mathVersion?: string;
   /** The open complex round, if any. Demo rounds are this process's own, so
    *  the id is generated here. */
-  open?: { roundId: string; bet: number };
+  open?: DemoRound;
+  /** The last round to finish, the demo equivalent of `last_round`. */
+  lastRound?: DemoRound;
   rounds: number;
 }
 
@@ -62,7 +99,7 @@ interface DemoSession {
  * The returned adapter is a `PlatformAdapter` like any other; nothing above
  * it needs to know which kind of session it is looking at.
  */
-export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptions = {}): PlatformAdapter {
+export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptions = {}): DemoCapableAdapter {
   const startingBalance = opts.startingBalance ?? 1_000_000;
   const log = opts.logger ?? createLogger({ service: "open-rgs-adapter-artube-demo", version: pkg.version });
   const demo = new Map<string, DemoSession>();
@@ -130,7 +167,22 @@ export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptio
       s.mathVersion = req.mathVersion;
       s.nextMode = req.nextMode;
       s.rounds += 1;
-      return receipt(s, `demo-${crypto.randomUUID()}`);
+      const roundId = `demo-${crypto.randomUUID()}`;
+      const now = new Date().toISOString();
+      s.lastRound = {
+        roundId,
+        betIndex: req.betIndex,
+        priceMultiplier: req.priceMultiplier,
+        bet: req.bet,
+        state: req.roundState,
+        ...(req.mathVersion !== undefined ? { stateVersion: req.mathVersion } : {}),
+        version: 0,
+        winMultiplier: req.multiplier,
+        win: req.win,
+        startedAt: now,
+        finishedAt: now,
+      };
+      return receipt(s, roundId);
     },
 
     async openComplex(req: OpenComplex): Promise<RoundReceipt> {
@@ -143,17 +195,33 @@ export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptio
       }
       s.balance -= req.bet;
       const roundId = `demo-${crypto.randomUUID()}`;
-      s.open = { roundId, bet: req.bet };
+      s.open = {
+        roundId,
+        betIndex: req.betIndex,
+        priceMultiplier: req.priceMultiplier,
+        bet: req.bet,
+        state: req.initialState,
+        ...(req.mathVersion !== undefined ? { stateVersion: req.mathVersion } : {}),
+        version: 0,
+        startedAt: new Date().toISOString(),
+      };
       return receipt(s, roundId);
     },
 
     async updateComplex(req: UpdateComplex): Promise<void> {
-      if (!isDemo(req.sessionId)) {
+      const s = demo.get(req.sessionId);
+      if (!s) {
         if (typeof inner.updateComplex === "function") await inner.updateComplex(req);
         return;
       }
-      // The audit checkpoint exists so a regulator can reconstruct a
-      // real-money round. There is no money here and nothing to reconstruct.
+      // No audit trail to write - there is no money here - but the state
+      // itself is kept, because that is what the wallet would be holding and
+      // the point of this wrapper is that a demo round behaves like a real
+      // one everywhere except where the money is.
+      if (s.open && s.open.roundId === req.roundId) {
+        s.open.state = req.state;
+        s.open.version += 1;
+      }
     },
 
     async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
@@ -167,6 +235,14 @@ export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptio
       s.mathVersion = req.mathVersion;
       s.nextMode = req.nextMode;
       s.rounds += 1;
+      s.lastRound = {
+        ...s.open,
+        state: req.finalState,
+        ...(req.mathVersion !== undefined ? { stateVersion: req.mathVersion } : {}),
+        winMultiplier: req.multiplier,
+        win: req.win,
+        finishedAt: new Date().toISOString(),
+      };
       delete s.open;
       return receipt(s, req.roundId);
     },
@@ -191,6 +267,25 @@ export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptio
     },
   };
 
+  // Everything the Games API would be storing for this session, for the same
+  // reason the real one is worth looking at: when a demo round behaves oddly
+  // the question is what the store thinks, and there is no back office for
+  // play money.
+  (wrapped as PlatformAdapter & { demoSessionFor?: unknown }).demoSessionFor =
+    (sessionId: string): DemoSessionView | undefined => {
+      const s = demo.get(sessionId);
+      if (!s) return undefined;
+      return {
+        balance: s.balance,
+        rounds: s.rounds,
+        ...(s.carry !== undefined ? { carry: s.carry } : {}),
+        ...(s.mathVersion !== undefined ? { mathVersion: s.mathVersion } : {}),
+        ...(s.nextMode !== undefined ? { nextMode: s.nextMode } : {}),
+        ...(s.open ? { openRound: { ...s.open } } : {}),
+        ...(s.lastRound ? { lastRound: { ...s.lastRound } } : {}),
+      };
+    };
+
   if (typeof inner.reverseRound === "function") {
     wrapped.reverseRound = async (req) => {
       if (isDemo(req.sessionId)) {
@@ -201,5 +296,5 @@ export function withDemoSessions(inner: PlatformAdapter, opts: DemoSessionsOptio
     };
   }
 
-  return wrapped;
+  return wrapped as DemoCapableAdapter;
 }

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -1705,4 +1705,10 @@ function closeStatus(state: string): "completed" | "cancelled" {
 }
 
 // Demo sessions (currency: null) served from memory. See ./demo.ts.
-export { withDemoSessions, type DemoSessionsOptions } from "./demo.js";
+export {
+  withDemoSessions,
+  type DemoSessionsOptions,
+  type DemoCapableAdapter,
+  type DemoSessionView,
+  type DemoRound,
+} from "./demo.js";

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -1703,3 +1703,6 @@ function closeStatus(state: string): "completed" | "cancelled" {
   }
   return "completed";
 }
+
+// Demo sessions (currency: null) served from memory. See ./demo.ts.
+export { withDemoSessions, type DemoSessionsOptions } from "./demo.js";

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -168,9 +168,21 @@ interface ArtubeFreeRoundCampaign {
   total_win: number;
   is_complete: boolean;
 }
+interface ArtubePlatformMaxWin {
+  is_visible: boolean;
+  base_currency?: string;
+  base_currency_value: number;
+  player_currency_value: number;
+}
+interface ArtubeRtpSettings {
+  is_visible: boolean;
+  shown_rtp?: number;
+}
 interface ArtubeGameSettings {
   default_bet_index: number;
   allowed_bets: number[];
+  platform_max_win?: ArtubePlatformMaxWin;
+  rtp_settings?: ArtubeRtpSettings;
   /** Smallest representable amount in the session currency (0.01 for a
    *  2-decimal currency, 1 for a 0-decimal one). Optional on the wire;
    *  when absent we fall back to the adapter's `currencyDecimals`. */
@@ -198,6 +210,10 @@ interface SessionInfoResponsePayload {
   security_hash: string;
   currency: string;
   balance: number;
+  /** Token the game's own UI needs to start its tournament / promotion
+   *  widget. The docs are explicit that the backend forwards it unchanged. */
+  gamification_token?: string;
+  history?: Array<{ win: number; possible_win: number; is_own: boolean }>;
   last_round?: ArtubeLastRound;
   game_settings: ArtubeGameSettings;
   free_round_campaign?: ArtubeFreeRoundCampaign;
@@ -346,6 +362,12 @@ export interface ArtubeAdapterOptions {
    *  will make `bet` non-integer on a 2-decimal ladder, which the
    *  orchestrator refuses. Escape hatch, not a tuning knob. */
   amountScaling?: "minor-units" | "verbatim";
+  /** How many settled idempotency keys to remember, so a repeat of one
+   *  replays its receipt instead of paying twice. Default 10000. */
+  settleCacheSize?: number;
+  /** How long to wait for the socket to come back before giving up on asking
+   *  the wallet whether an unanswered settle landed. Default 10000. */
+  reconcileTimeoutMs?: number;
   /** `round_state_version` sent when the RGS has no math version to stamp
    *  (the orchestrator omits it on a complex open). Default "1". */
   defaultRoundStateVersion?: string;
@@ -444,6 +466,21 @@ export class ArtubeAdapter implements PlatformAdapter {
   private readonly currencyDecimals: number;
   private readonly scaleAmounts: boolean;
   private readonly defaultRoundStateVersion: string;
+  private readonly reconcileTimeoutMs: number;
+  /**
+   * Settles already sent, by idempotency key.
+   *
+   * The wallet cannot dedupe - no field for it - so the same key arriving
+   * twice would be two settles and two payments. The orchestrator derives one
+   * key per (session, round) for a close, which is exactly what a client
+   * close racing an autoclose produces, so "twice" is not hypothetical.
+   *
+   * In-process only, and honest about it: a retry that lands on another pod
+   * is not covered by this, which is what the reconciliation path is for.
+   * Bounded so a long-lived process cannot grow it without limit.
+   */
+  private readonly settled = new Map<string, Promise<RoundReceipt>>();
+  private readonly settledMax: number;
   private readonly schemaVersion: 1 | 2;
 
   private readonly gameId: string;
@@ -471,6 +508,8 @@ export class ArtubeAdapter implements PlatformAdapter {
     this.currencyDecimals     = opts.currencyDecimals     ?? 2;
     this.scaleAmounts         = (opts.amountScaling ?? "minor-units") === "minor-units";
     this.defaultRoundStateVersion = opts.defaultRoundStateVersion ?? "1";
+    this.reconcileTimeoutMs   = opts.reconcileTimeoutMs   ?? 10_000;
+    this.settledMax           = opts.settleCacheSize       ?? 10_000;
     this.schemaVersion        = opts.schemaVersion        ?? 1;
 
     // Caller can hand us a server-core logger so everything flows
@@ -560,6 +599,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       heartbeat_timeout_ms:   this.heartbeatTimeoutMs,
       heartbeat_silent_ms:    this.lastPongAt ? Date.now() - this.lastPongAt : null,
       open_complex_rounds:    this.rounds.size,
+      settle_keys_remembered: this.settled.size,
       wallet_reported_open_rounds: this.orphans.size,
       schema_version:         this.schemaVersion,
       amount_scaling:         this.scaleAmounts ? "minor-units" : "verbatim",
@@ -726,7 +766,58 @@ export class ArtubeAdapter implements PlatformAdapter {
     });
   }
 
-  async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+  /**
+   * One settle per idempotency key, even when the duplicates are concurrent.
+   *
+   * The key is claimed BEFORE the request goes out, and what is stored is the
+   * in-flight promise rather than the finished receipt. Storing the receipt
+   * meant a read-then-write race: two concurrent settles with the same key
+   * both missed the cache, both went to the wallet, and both were paid. (The
+   * adapter test kit's concurrency certification found that, on the first run
+   * where it was switched on.)
+   *
+   * A settle that FAILS releases its key, so a later genuine retry is not
+   * refused by the memory of an attempt that never moved money.
+   */
+  private dedupe(sessionId: string, rawKey: string | undefined, run: () => Promise<RoundReceipt>): Promise<RoundReceipt> {
+    if (rawKey === undefined) return run();
+    // Scoped to the session. An idempotency key means "this settle, on this
+    // session": the orchestrator's own keys are derived from the session and
+    // round, but a client-supplied one carries no such guarantee, and two
+    // players whose keys happened to collide would have one of them silently
+    // not paid.
+    const key = `${sessionId}\u0000${rawKey}`;
+
+    const existing = this.settled.get(key);
+    if (existing) {
+      this.log.warn("Duplicate settle key, replaying the first settle instead of paying again", {
+        "event.category": "artube",
+        "event.action":   "settle_deduped",
+        "artube.session_id": sessionId,
+        "artube.idempotency_key": rawKey,
+      });
+      return existing;
+    }
+
+    const attempt = run();
+    this.settled.set(key, attempt);
+    attempt.catch(() => {
+      if (this.settled.get(key) === attempt) this.settled.delete(key);
+    });
+    // Oldest out first; Map iterates in insertion order.
+    while (this.settled.size > this.settledMax) {
+      const oldest = this.settled.keys().next().value;
+      if (oldest === undefined) break;
+      this.settled.delete(oldest);
+    }
+    return attempt;
+  }
+
+  settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+    return this.dedupe(req.sessionId, req.idempotencyKey, () => this.settleSimpleOnce(req));
+  }
+
+  private async settleSimpleOnce(req: SettleSimple): Promise<RoundReceipt> {
     // Artube's PlayRoundRequest validator requires round_state to be a
     // non-empty string. core ≥0.3.0's orchestrator now always sends a
     // non-empty envelope (math carry, or a synthesised {type,multiplier,
@@ -739,12 +830,22 @@ export class ArtubeAdapter implements PlatformAdapter {
       win_multiplier:      req.multiplier,
       ...(req.promoId ? { free_round_campaign_id: req.promoId } : {}),
       round_state_version: req.mathVersion ?? "1",
-      round_state:         req.roundState,
+      round_state:         packRoundState(req.roundState, req.roundState, req.idempotencyKey),
     };
-    const env = await this.rpc<PlayRoundRequestPayload, PlayRoundResponsePayload>(
-      "PlayRoundRequest",
-      payload,
-    );
+    let env: Envelope<PlayRoundResponsePayload>;
+    try {
+      env = await this.rpc<PlayRoundRequestPayload, PlayRoundResponsePayload>(
+        "PlayRoundRequest",
+        payload,
+      );
+    } catch (e) {
+      // The request went out and nothing definitive came back, so the settle
+      // may or may not have landed. Retrying blind is how a player gets paid
+      // twice; failing blind is how they get paid never. Go and look.
+      const settled = await this.reconcileSettle(req.sessionId, req.idempotencyKey, e);
+      if (settled) return settled;
+      throw e;
+    }
     const receipt: RoundReceipt = {
       roundId: env.payload.round_id,
       balance: this.toMinor(env.payload.balance, req.sessionId),
@@ -752,6 +853,10 @@ export class ArtubeAdapter implements PlatformAdapter {
     if (env.payload.free_round_campaign) {
       receipt.promo = { remaining: env.payload.free_round_campaign.rounds_left };
     }
+    // The wallet's own cap, applied wallet-side. The RGS cannot infer it -
+    // the balance is simply smaller than the multiplier implies - so it is
+    // only knowable because the wallet says so here.
+    if (env.payload.is_platform_max_win_reached === true) receipt.platformMaxWinReached = true;
     return receipt;
   }
 
@@ -836,7 +941,11 @@ export class ArtubeAdapter implements PlatformAdapter {
     });
   }
 
-  async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+  closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+    return this.dedupe(req.sessionId, req.idempotencyKey, () => this.closeComplexOnce(req));
+  }
+
+  private async closeComplexOnce(req: CloseComplex): Promise<RoundReceipt> {
     const book = this.rounds.get(req.roundId);
     if (!book) {
       // An unknown round is not something to paper over: the money for it
@@ -864,7 +973,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       ...(features.length > 0 ? { features: features.map((t) => ({ type: t })) } : {}),
       round_version:       book.version,
       round_state_version: req.mathVersion ?? book.stateVersion,
-      round_state:         packRoundState(req.finalState, req.carry),
+      round_state:         packRoundState(req.finalState, req.carry, req.idempotencyKey),
     };
 
     let env: Envelope<CloseRoundResponsePayload>;
@@ -872,6 +981,14 @@ export class ArtubeAdapter implements PlatformAdapter {
       env = await this.onRound(book, () =>
         this.rpc<CloseRoundRequestPayload, CloseRoundResponsePayload>(type, payload));
     } catch (e) {
+      // Same question as a simple settle: did the credit land? A close is
+      // addressed to a known round id, so the answer is cheap to get and the
+      // cost of guessing is a double credit.
+      const settled = await this.reconcileSettle(req.sessionId, req.idempotencyKey, e, req.roundId);
+      if (settled) {
+        this.rounds.delete(req.roundId);
+        return settled;
+      }
       // Leave the book entry in place. The round is still open wallet-side,
       // and the orchestrator keeps its own open round for a retry or an
       // autoclose; dropping our version here would make that retry fail for
@@ -908,7 +1025,88 @@ export class ArtubeAdapter implements PlatformAdapter {
     if (env.payload.free_round_campaign) {
       receipt.promo = { remaining: env.payload.free_round_campaign.rounds_left };
     }
+    if (env.payload.is_platform_max_win_reached === true) receipt.platformMaxWinReached = true;
     return receipt;
+  }
+
+  /**
+   * Did a settle that gave no answer actually land?
+   *
+   * `PlayRoundRequest` and `CloseRoundRequest` carry no idempotency field, so
+   * the wallet cannot dedupe a retry and a lost response is indistinguishable
+   * from a lost request. The key the RGS generated rides inside the round
+   * state instead (see {@link RoundStateEnvelope.key}), which makes the
+   * question answerable: read the session's last round back, and if it
+   * carries this key, the settle landed and its receipt is right there.
+   *
+   * Returns the receipt when it landed, `undefined` when it provably did not
+   * or when the answer cannot be had - and `undefined` means the caller
+   * surfaces the original failure, which is the safe direction.
+   */
+  private async reconcileSettle(
+    sessionId: string,
+    key: string | undefined,
+    cause: unknown,
+    expectRoundId?: string,
+  ): Promise<RoundReceipt | undefined> {
+    if (key === undefined || !mayHaveLanded(cause)) return undefined;
+
+    // The socket may be mid-reconnect. Give it a bounded moment; without a
+    // connection there is no question to ask.
+    const deadline = Date.now() + this.reconcileTimeoutMs;
+    while (!this.ready && Date.now() < deadline) await new Promise((r) => setTimeout(r, 200));
+    if (!this.ready) {
+      this.log.error("Settle unresolved and the wallet is unreachable to ask", {
+        "event.category": "artube",
+        "event.action":   "settle_unreconciled",
+        "artube.session_id": sessionId,
+        "artube.idempotency_key": key,
+      });
+      return undefined;
+    }
+
+    try {
+      const env = await this.rpc<SessionInfoRequestPayload, SessionInfoResponsePayload>(
+        "SessionInfoRequest",
+        { session_id: sessionId, player_connection_info: { player_connection_id: "reconcile" } },
+      );
+      const last = env.payload.last_round;
+      const landed = last !== undefined
+        && settleKeyOf(last.round_state) === key
+        && (expectRoundId === undefined || last.round_id === expectRoundId);
+      if (!last || !landed) {
+        this.log.warn("Settle did not land; the failure stands", {
+          "event.category": "artube",
+          "event.action":   "settle_not_landed",
+          "artube.session_id": sessionId,
+          "artube.idempotency_key": key,
+        });
+        return undefined;
+      }
+      this.log.warn("Settle had landed after all; replaying its receipt instead of retrying", {
+        "event.category": "artube",
+        "event.action":   "settle_reconciled",
+        "artube.session_id": sessionId,
+        "artube.round_id":   last.round_id,
+        "artube.idempotency_key": key,
+      });
+      const scale = this.scaleFor(env.payload.game_settings);
+      this.sessionScale.set(sessionId, scale);
+      const receipt: RoundReceipt = {
+        roundId: last.round_id,
+        balance: scale === 1 ? env.payload.balance : Math.round(env.payload.balance * scale),
+      };
+      if (last.is_platform_max_win_reached === true) receipt.platformMaxWinReached = true;
+      return receipt;
+    } catch (e) {
+      this.log.error("Could not ask the wallet whether the settle landed", {
+        "event.category": "artube",
+        "event.action":   "settle_reconcile_failed",
+        "artube.session_id": sessionId,
+        "error.message":  e instanceof Error ? e.message : String(e),
+      });
+      return undefined;
+    }
   }
 
   /** Run `fn` after everything already queued on this round, and keep the
@@ -1522,6 +1720,36 @@ function artubeSessionToContract(
     allowedBets:     p.game_settings.allowed_bets.map(conv),
     defaultBetIndex: p.game_settings.default_bet_index,
   };
+  // Everything the wallet says that belongs to the CLIENT and not to the
+  // engine. The RGS reads none of it; without it a real game's UI cannot be
+  // built on this adapter at all, because the client talks to the RGS and
+  // never to the wallet.
+  const clientData: Record<string, unknown> = {};
+  if (p.gamification_token !== undefined) clientData["gamificationToken"] = p.gamification_token;
+  if (p.game_settings.platform_max_win) {
+    const mw = p.game_settings.platform_max_win;
+    clientData["platformMaxWin"] = {
+      isVisible: mw.is_visible,
+      // Amounts, so they cross the same way every other amount does.
+      playerCurrencyValue: scale === 1 ? mw.player_currency_value : Math.round(mw.player_currency_value * scale),
+      baseCurrencyValue: scale === 1 ? mw.base_currency_value : Math.round(mw.base_currency_value * scale),
+      ...(mw.base_currency !== undefined ? { baseCurrency: mw.base_currency } : {}),
+    };
+  }
+  if (p.game_settings.rtp_settings) {
+    clientData["rtp"] = {
+      isVisible: p.game_settings.rtp_settings.is_visible,
+      ...(p.game_settings.rtp_settings.shown_rtp !== undefined ? { shownRtp: p.game_settings.rtp_settings.shown_rtp } : {}),
+    };
+  }
+  if (p.game_settings.available_auto_spin_counts) {
+    clientData["autoSpinCounts"] = p.game_settings.available_auto_spin_counts;
+  }
+  if (p.game_settings.rtp_options) clientData["rtpOptions"] = p.game_settings.rtp_options;
+  if (p.history) clientData["history"] = p.history;
+  if (p.security_hash) clientData["securityHash"] = p.security_hash;
+  if (Object.keys(clientData).length > 0) info.clientData = clientData;
+
   if (p.free_round_campaign && !p.free_round_campaign.is_complete) {
     info.promo = artubeCampaignToPromo(p.free_round_campaign, scale);
   }
@@ -1595,6 +1823,21 @@ interface RoundStateEnvelope {
    *  carry look absent - the player's meters reset - while a genuinely open
    *  round stays invisible. */
   open?: true;
+  /**
+   * The RGS's idempotency key for the settle that wrote this state.
+   *
+   * `PlayRoundRequest` and `CloseRoundRequest` have no idempotency field, so
+   * the wallet cannot dedupe a retried settle - which makes a lost RESPONSE
+   * indistinguishable from a lost REQUEST, and a blind retry able to pay
+   * twice. The key cannot travel in a field that does not exist, but it can
+   * travel in the one field the game owns: after a settle that timed out,
+   * reading the session's last round back and finding this key is proof the
+   * settle landed.
+   *
+   * It does not make the wallet idempotent. It makes the ambiguity
+   * answerable, which is the part that was missing.
+   */
+  key?: string;
   state: unknown;
   carry?: unknown;
 }
@@ -1612,14 +1855,28 @@ function fromJsonOrString(v: unknown): string {
 
 /** `state` alone when there is no carry to keep; both under the marker
  *  when there is. */
-function packRoundState(state: string, carry?: string): string {
-  if (carry === undefined) return state;
+function packRoundState(state: string, carry?: string, key?: string): string {
+  if (carry === undefined && key === undefined) return state;
   const env: RoundStateEnvelope = {
     [RGS_ENVELOPE_MARK]: 1,
+    ...(key !== undefined ? { key } : {}),
     state: asJsonOrString(state),
-    carry: asJsonOrString(carry),
+    ...(carry !== undefined ? { carry: asJsonOrString(carry) } : {}),
   };
   return JSON.stringify(env);
+}
+
+/** The idempotency key stamped on a stored round state, if any. */
+function settleKeyOf(roundState: string): string | undefined {
+  return parseEnvelope(roundState)?.key;
+}
+
+/** Errors after which the settle MIGHT have landed: the request went out and
+ *  no definitive answer came back. An `Error` frame from the wallet is a
+ *  definitive answer and is not one of these. */
+function mayHaveLanded(e: unknown): boolean {
+  const msg = e instanceof Error ? e.message : String(e);
+  return /RPC timeout|WS closed|not connected|disconnected/i.test(msg);
 }
 
 /** The state of a round that is still in flight, marked as such. */

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -434,6 +434,8 @@ export class ArtubeAdapter implements PlatformAdapter {
   // open. Keyed by session, replaced on every openSession, cleared when the
   // round is closed.
   private readonly orphans = new Map<string, ArtubeOpenRound>();
+  // The wallet's own last_round, verbatim, per session. Diagnostics only.
+  private readonly lastRounds = new Map<string, ArtubeLastRound>();
   // Per-session minor-unit scale, learned from SessionInfo. Events carry a
   // balance but no currency metadata, so without this an out-of-band
   // BalanceChanged would arrive in different units than every other amount.
@@ -589,6 +591,22 @@ export class ArtubeAdapter implements PlatformAdapter {
   }
 
   /**
+   * Exactly what the wallet said its last round was, from the most recent
+   * `openSession`.
+   *
+   * For looking at, not for deciding with. When a session is refused with
+   * `Round is already opened` the only question that matters is which round
+   * the wallet means, and every field that might answer it - is
+   * `finished_at` there, does the state carry the open marker, what is the
+   * `round_version` - is otherwise visible only in a log line on a pod you
+   * may not be able to read. Contains no secret: it is this player's own
+   * round, already theirs to see in the client.
+   */
+  lastRoundFor(sessionId: string): Readonly<ArtubeLastRound> | undefined {
+    return this.lastRounds.get(sessionId);
+  }
+
+  /**
    * Claim one round by id, so a close for it can be sent.
    *
    * The last escape hatch, for the case `last_round` cannot reach: a complex
@@ -674,13 +692,9 @@ export class ArtubeAdapter implements PlatformAdapter {
    *  since it would otherwise be guessing a round_version - and the session
    *  stays wedged. Here the version is not a guess: the wallet just gave it. */
   private adoptOpenRound(sessionId: string, last: ArtubeLastRound | undefined): void {
-    // `finished_at` would be the obvious signal and it is not usable: it is
-    // documented optional and this wire omits it on finished rounds too, so
-    // treating its absence as "still open" makes every carry look absent -
-    // resetting the player's meters - while telling you nothing true. The
-    // marker this adapter writes into the state on open is the signal; a
-    // present `finished_at` is still believed when it says the round is done.
-    if (!last || last.finished_at || !isOpenState(last.round_state)) {
+    if (last) this.lastRounds.set(sessionId, last);
+    else this.lastRounds.delete(sessionId);
+    if (!last || !isRoundOpen(last)) {
       this.orphans.delete(sessionId);
       return;
     }
@@ -1519,15 +1533,14 @@ function artubeSessionToContract(
   // it as a brand-new player - silently resetting the meters of anyone whose
   // pod restarted mid-round.
   //
-  // `unpackCarry` decides which it is, from the marker this adapter writes
-  // into an in-flight round's state. Not from `finished_at`: that field is
-  // documented optional and this wire omits it on finished rounds too, so
-  // requiring it drops every carry there is.
+  // `isRoundOpen` decides which it is: the wire's own `finished_at`, plus the
+  // marker this adapter writes into an in-flight round's state as a second
+  // opinion that does not depend on an optional field staying present.
   //
   // No carry is the honest answer for an open round: unknown, not empty. The
   // orchestrator resumes from its own memory when it still has the session,
   // and this path is what runs when it does not.
-  if (p.last_round) {
+  if (p.last_round && !isRoundOpen(p.last_round)) {
     const carry = unpackCarry(p.last_round.round_state);
     if (carry !== "") info.carry = carry;
     // `round_state_version` is the field the settle WRITES mathVersion into
@@ -1632,6 +1645,23 @@ function parseEnvelope(roundState: string): RoundStateEnvelope | undefined {
  *  when it was written. */
 function isOpenState(roundState: string): boolean {
   return parseEnvelope(roundState)?.open === true;
+}
+
+/**
+ * Is the round the wallet just described still open?
+ *
+ * `finished_at` is the wire's own answer and it is the one to believe: it is
+ * `null` on an open round and set on a closed one. (An earlier build here
+ * refused to trust it, on the strength of one session that was ALREADY wedged
+ * - whose last_round was therefore an open round, with a null finished_at.
+ * That was the field working correctly, read as evidence that it did not.)
+ *
+ * The marker this adapter writes into an in-flight round's state is kept as a
+ * second opinion. It costs nothing, it does not depend on an optional field
+ * staying present, and a round is open if either says so.
+ */
+function isRoundOpen(last: ArtubeLastRound): boolean {
+  return !last.finished_at || isOpenState(last.round_state);
 }
 
 /** The math's own state, out of whichever envelope it arrived in. */

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -252,17 +252,24 @@ describe("complex rounds", () => {
   }, 15_000);
 
   test("a settle that never landed still fails", async () => {
-    // The safe direction. An unanswered settle that the wallet has no record
-    // of must surface as a failure, not be quietly treated as done.
-    const { adapter } = await connect({}, { rpcTimeoutMs: 500 });
+    // The safe direction: an unanswered settle the wallet has no record of
+    // must surface as a failure, not be quietly treated as done.
+    //
+    // reconcileTimeoutMs is short on purpose. The adapter waits that long for
+    // the socket to come back before giving up on asking, and a test that
+    // depends on the default is a test whose result depends on how busy the
+    // machine is.
+    const { adapter } = await connect({}, { rpcTimeoutMs: 500, reconcileTimeoutMs: 300 });
     await adapter.openSession("nothing", "c1");
-    // No key at all: nothing to reconcile against, so the failure stands.
     adapter.disconnect();
     await expect(adapter.settleSimple({
       sessionId: "nothing", bet: 100, betIndex: 2, priceMultiplier: 1,
       win: 0, multiplier: 0, type: "loss", roundState: "{}",
       idempotencyKey: "key-never",
-    })).rejects.toThrow();
+    })).rejects.toThrow(/not connected|disconnected|closed/i);
+    // ...and the key is released, so a real retry later is not refused by the
+    // memory of an attempt that moved no money.
+    expect((adapter as unknown as { settled: Map<string, unknown> }).settled.size).toBe(0);
   }, 15_000);
 
   test("a complex close whose reply is lost is checked the same way", async () => {

--- a/packages/adapter-artube/test/complex.test.ts
+++ b/packages/adapter-artube/test/complex.test.ts
@@ -232,6 +232,78 @@ describe("complex rounds", () => {
     }
   });
 
+  test("a settle whose reply is lost is checked, not retried blind", async () => {
+    // The wire has no idempotency field, so the wallet cannot dedupe a retry
+    // and a lost RESPONSE looks exactly like a lost REQUEST. Retrying blind
+    // pays twice; failing blind pays never. The key rides in the round state,
+    // so the adapter can go and look.
+    const { fake, adapter } = await connect({ swallowReplyFor: ["PlayRoundRequest"] }, { rpcTimeoutMs: 800 });
+    await adapter.openSession("lost", "c1");
+    const receipt = await adapter.settleSimple({
+      sessionId: "lost", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 250, multiplier: 2.5, type: "win", roundState: JSON.stringify({ meter: 1 }),
+      idempotencyKey: "key-abc",
+    });
+    // It landed - the wallet moved the money - so the receipt is the real one.
+    expect(receipt.balance).toBe(1_000_000 - 100 + 250);
+    expect(fake.balanceMinor("lost")).toBe(1_000_000 - 100 + 250);
+    // And exactly one settle was sent: no blind retry.
+    expect(fake.sent("PlayRoundRequest").length).toBe(1);
+  }, 15_000);
+
+  test("a settle that never landed still fails", async () => {
+    // The safe direction. An unanswered settle that the wallet has no record
+    // of must surface as a failure, not be quietly treated as done.
+    const { adapter } = await connect({}, { rpcTimeoutMs: 500 });
+    await adapter.openSession("nothing", "c1");
+    // No key at all: nothing to reconcile against, so the failure stands.
+    adapter.disconnect();
+    await expect(adapter.settleSimple({
+      sessionId: "nothing", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+      idempotencyKey: "key-never",
+    })).rejects.toThrow();
+  }, 15_000);
+
+  test("a complex close whose reply is lost is checked the same way", async () => {
+    const { fake, adapter } = await connect({ swallowReplyFor: ["CloseRoundRequest"] }, { rpcTimeoutMs: 800 });
+    await adapter.openSession("lost2", "c1");
+    const opened = await adapter.openComplex({
+      sessionId: "lost2", bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}",
+    });
+    const closed = await adapter.closeComplex({
+      sessionId: "lost2", roundId: opened.roundId,
+      finalState: JSON.stringify({ done: true }), carry: JSON.stringify({ m: 2 }),
+      win: 300, multiplier: 3, type: "win", idempotencyKey: "key-close",
+    });
+    expect(closed.roundId).toBe(opened.roundId);
+    expect(closed.balance).toBe(1_000_000 - 100 + 300);
+    expect(fake.sent("CloseRoundRequest").length).toBe(1);
+  }, 15_000);
+
+  test("the platform's own max-win cap reaches the receipt", async () => {
+    // The RGS cannot infer it: the balance is simply smaller than the
+    // multiplier implies. It is knowable only because the wallet says so.
+    const { adapter } = await connect({ maxWinReached: true });
+    await adapter.openSession("cap", "c1");
+    const r = await adapter.settleSimple({
+      sessionId: "cap", bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 900, multiplier: 9, type: "win", roundState: "{}",
+    });
+    expect(r.platformMaxWinReached).toBe(true);
+  });
+
+  test("what the wallet says for the client is forwarded, not dropped", async () => {
+    const { adapter } = await connect({ clientExtras: true });
+    const info = await adapter.openSession("extras", "c1");
+    const cd = info.clientData!;
+    // The one their docs are explicit about: forward it unchanged.
+    expect(cd["gamificationToken"]).toBe("tok-123");
+    expect(cd["autoSpinCounts"]).toEqual([10, 25, 50]);
+    // Amounts cross the same way every other amount does.
+    expect((cd["platformMaxWin"] as { playerCurrencyValue: number }).playerCurrencyValue).toBe(87_000);
+  });
+
   test("disconnect() takes effect before the socket finishes closing", async () => {
     // Whoever asks isHealthy is deciding whether to route a round at this
     // adapter. "I told it to disconnect and it says it is fine" is wrong at

--- a/packages/adapter-artube/test/conformance.test.ts
+++ b/packages/adapter-artube/test/conformance.test.ts
@@ -87,16 +87,16 @@ describe("conformance", () => {
     // on a real overspend - see the test above, which drives
     // priceMultiplier.)
     "errors.insufficient-funds",
-    // PlayRoundRequest has no idempotency field at all, so SettleSimple's
-    // idempotencyKey is dropped on the floor. A retried settle is NOT deduped
-    // by the wallet. See the README - this is the adapter's biggest known gap.
-    "idempotency.duplicate-key",
   ]);
 
   test("the suite runs, and only the checks this wire cannot express fail", async () => {
     const report = await runConformance(adapter, {
       fixture: { sessionId: "conf-run" },
       perCheckTimeoutMs: 5_000,
+      // Opt in. Parallel settles across sessions and a duplicate key fired
+      // twice at once are exactly the shapes a live pod meets and a
+      // single-threaded test never does.
+      concurrency: true,
     });
     expect(report.checks.length).toBeGreaterThan(0);
     const unexpected = report.checks
@@ -106,11 +106,32 @@ describe("conformance", () => {
     expect(unexpected).toEqual([]);
   }, 30_000);
 
+  test("the concurrency certification passes too", async () => {
+    // Opt-in, and never opted into before: parallel settles across sessions,
+    // and the same idempotency key fired twice at once - which the wallet
+    // cannot dedupe, so the adapter has to.
+    const report = await runConformance(adapter, {
+      fixture: { sessionId: "conf-conc" }, perCheckTimeoutMs: 5_000, concurrency: true,
+    });
+    const conc = report.checks.filter((c) => c.group === "concurrency");
+    const bad = conc.filter((c) => c.status === "fail").map((c) => `${c.id}: ${c.message ?? ""}`);
+    if (bad.length > 0) console.error("concurrency failures:", bad);
+    expect(bad).toEqual([]);
+    // The two that move money, by name, so a future skip cannot hide here.
+    const byId = new Map(conc.map((c) => [c.id, c.status]));
+    expect(byId.get("concurrency.parallel-distinct-settles")).toBe("ok");
+    expect(byId.get("concurrency.duplicate-key-parallel")).toBe("ok");
+    // Reversal is skipped, not failed: this wire has no game-initiated
+    // rollback message, so there is nothing for reverseRound to call.
+    expect(byId.get("concurrency.reverse-interleave")).toBe("skip");
+  }, 30_000);
+
   test("the complex-round checks are among the ones that passed", async () => {
     // The point of the change: these three used to be skips.
     const report = await runConformance(adapter, {
       fixture: { sessionId: "conf-complex" },
       perCheckTimeoutMs: 5_000,
+      concurrency: true,
     });
     const byId = new Map(report.checks.map((c) => [c.id, c.status]));
     expect(byId.get("complex.openComplex")).toBe("ok");
@@ -125,6 +146,7 @@ describe("conformance", () => {
     // suite quietly stops testing.
     const report = await runConformance(adapter, {
       fixture: { sessionId: "conf-stale" }, perCheckTimeoutMs: 5_000,
+      concurrency: true,
     });
     const failing = new Set(report.checks.filter((c) => c.status === "fail").map((c) => c.id));
     for (const id of WIRE_CANNOT) expect(failing.has(id)).toBe(true);

--- a/packages/adapter-artube/test/demo.test.ts
+++ b/packages/adapter-artube/test/demo.test.ts
@@ -106,6 +106,50 @@ describe("demo sessions", () => {
     expect(again.mathVersion).toBe("1.0.0");
   });
 
+  test("the round state is stored too, not just the balance", async () => {
+    // The wallet would be holding round_state through the whole round: the
+    // state at open, every update, the final one at close. A demo round that
+    // kept only the money would behave differently from a real one in the
+    // one place a game actually reads.
+    const { platform } = await connect();
+    await platform.openSession(DEMO, "c1");
+    const opened = await platform.openComplex({
+      sessionId: DEMO, bet: 100, betIndex: 3, priceMultiplier: 1,
+      initialState: JSON.stringify({ step: 1 }), mathVersion: "2.0.0",
+    });
+
+    let view = platform.demoSessionFor(DEMO)!;
+    expect(view.openRound?.roundId).toBe(opened.roundId);
+    expect(JSON.parse(view.openRound!.state)).toEqual({ step: 1 });
+    expect(view.openRound?.betIndex).toBe(3);
+    expect(view.openRound?.version).toBe(0);
+
+    await platform.updateComplex!({ sessionId: DEMO, roundId: opened.roundId, state: JSON.stringify({ step: 2 }) });
+    view = platform.demoSessionFor(DEMO)!;
+    expect(JSON.parse(view.openRound!.state)).toEqual({ step: 2 });
+    expect(view.openRound?.version).toBe(1);
+
+    await platform.closeComplex({
+      sessionId: DEMO, roundId: opened.roundId,
+      finalState: JSON.stringify({ step: 3 }),
+      carry: JSON.stringify({ meter: 9 }),
+      win: 200, multiplier: 2, type: "win", mathVersion: "2.0.0",
+    });
+    view = platform.demoSessionFor(DEMO)!;
+    expect(view.openRound).toBeUndefined();
+    // And the finished round is kept the way last_round would be.
+    expect(JSON.parse(view.lastRound!.state)).toEqual({ step: 3 });
+    expect(view.lastRound?.win).toBe(200);
+    expect(view.lastRound?.finishedAt).toBeDefined();
+    expect(JSON.parse(view.carry!)).toEqual({ meter: 9 });
+  });
+
+  test("a real session has no demo store at all", async () => {
+    const { platform } = await connect();
+    await platform.openSession(REAL, "c1");
+    expect(platform.demoSessionFor(REAL)).toBeUndefined();
+  });
+
   test("a real session is untouched by any of this", async () => {
     const { fake, platform } = await connect();
     const info = await platform.openSession(REAL, "c1");

--- a/packages/adapter-artube/test/demo.test.ts
+++ b/packages/adapter-artube/test/demo.test.ts
@@ -1,0 +1,154 @@
+// Demo sessions never reach the wire.
+//
+// Artube has no demo requests: the marker is a session whose currency is
+// null, and from there the backend keeps the play balance itself. The thing
+// worth testing is therefore negative - that nothing went to the wallet -
+// as much as it is that the arithmetic is right.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { PlatformEvent } from "@open-rgs/contract";
+import { ArtubeAdapter, withDemoSessions } from "../src/index.js";
+import { fakeArtube, type FakeArtube } from "./fake-artube.js";
+
+async function until(pred: () => boolean, what: string, ms = 2_000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred()) {
+    if (Date.now() > deadline) throw new Error(`timed out waiting for ${what}`);
+    await Bun.sleep(5);
+  }
+}
+
+const DEMO = "demo-session";
+const REAL = "real-session";
+
+let open: { fake: FakeArtube; adapter: ArtubeAdapter } | null = null;
+
+async function connect(startingBalance = 1_000_000) {
+  const fake = fakeArtube({ demoSessions: [DEMO] });
+  const events: PlatformEvent[] = [];
+  const adapter = new ArtubeAdapter({
+    wsUrl: fake.url, gameId: "demo-test", authToken: "k",
+    handshakeTimeoutMs: 5_000, rpcTimeoutMs: 5_000,
+  });
+  const platform = withDemoSessions(adapter, { startingBalance });
+  platform.onEvent((e) => events.push(e));
+  await platform.connect();
+  open = { fake, adapter };
+  return { fake, platform, events };
+}
+
+afterEach(() => {
+  open?.adapter.disconnect();
+  open?.fake.stop();
+  open = null;
+});
+
+describe("demo sessions", () => {
+  test("a session with no currency gets play money, and the wallet is not asked for it", async () => {
+    const { fake, platform } = await connect(500_000);
+    const info = await platform.openSession(DEMO, "c1");
+    expect(info.currency).toBeFalsy();       // what makes it demo
+    expect(info.balance).toBe(500_000);      // ours, not the wallet's 1,000,000
+    // The ladder still comes from the wallet: it is not money, and a demo
+    // player must be able to bet the same amounts as a real one.
+    expect(info.allowedBets).toEqual([25, 50, 100, 200, 500, 1000]);
+    expect(fake.sent("SessionInfoRequest").length).toBe(1);
+  });
+
+  test("a simple round moves the play balance and sends nothing", async () => {
+    const { fake, platform } = await connect();
+    await platform.openSession(DEMO, "c1");
+    const r = await platform.settleSimple({
+      sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 250, multiplier: 2.5, type: "win", roundState: JSON.stringify({ meter: 3 }),
+    });
+    expect(r.balance).toBe(1_000_000 - 100 + 250);
+    expect(fake.sent("PlayRoundRequest").length).toBe(0);
+  });
+
+  test("a complex round debits at open and credits at close, still off the wire", async () => {
+    const { fake, platform } = await connect();
+    await platform.openSession(DEMO, "c1");
+    const opened = await platform.openComplex({
+      sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}",
+    });
+    expect(opened.balance).toBe(1_000_000 - 100);
+    await platform.updateComplex!({ sessionId: DEMO, roundId: opened.roundId, state: "{}" });
+    const closed = await platform.closeComplex({
+      sessionId: DEMO, roundId: opened.roundId,
+      finalState: "{}", win: 400, multiplier: 4, type: "win",
+    });
+    expect(closed.balance).toBe(1_000_000 - 100 + 400);
+    expect(fake.sent("OpenRoundRequest").length).toBe(0);
+    expect(fake.sent("UpdateRoundStateRequest").length).toBe(0);
+    expect(fake.sent("CloseRoundRequest").length).toBe(0);
+  });
+
+  test("one open round at a time, the same as the wallet enforces", async () => {
+    const { platform } = await connect();
+    await platform.openSession(DEMO, "c1");
+    await platform.openComplex({ sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}" });
+    await expect(platform.openComplex({
+      sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1, initialState: "{}",
+    })).rejects.toThrow(/already open/);
+  });
+
+  test("the carry threads across demo rounds, in memory", async () => {
+    const { platform } = await connect();
+    await platform.openSession(DEMO, "c1");
+    await platform.settleSimple({
+      sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss",
+      roundState: JSON.stringify({ meter: 7 }), mathVersion: "1.0.0",
+    });
+    const again = await platform.openSession(DEMO, "c2");
+    expect(JSON.parse(again.carry!)).toEqual({ meter: 7 });
+    expect(again.mathVersion).toBe("1.0.0");
+  });
+
+  test("a real session is untouched by any of this", async () => {
+    const { fake, platform } = await connect();
+    const info = await platform.openSession(REAL, "c1");
+    expect(info.currency).toBe("USD");
+    expect(info.balance).toBe(1_000_000);    // the wallet's, not ours
+    const r = await platform.settleSimple({
+      sessionId: REAL, bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 250, multiplier: 2.5, type: "win", roundState: "{}",
+    });
+    expect(r.balance).toBe(1_000_000 - 100 + 250);
+    expect(fake.sent("PlayRoundRequest").length).toBe(1);
+  });
+
+  test("the session ending takes the play money with it", async () => {
+    // Artube does not persist a demo round, so there is nothing to come back
+    // to - and keeping the balance would make the next session start rich, or
+    // poor, depending on how the last one went.
+    const { fake, platform, events } = await connect();
+    await platform.openSession(DEMO, "c1");
+    await platform.settleSimple({
+      sessionId: DEMO, bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+    });
+    expect((await platform.openSession(DEMO, "c2")).balance).toBe(1_000_000 - 100);
+
+    fake.closeSession(DEMO);
+    await until(() => events.some((e) => e.type === "sessionClosed"), "sessionClosed");
+
+    // Fresh session, fresh play money.
+    expect((await platform.openSession(DEMO, "c3")).balance).toBe(1_000_000);
+  });
+
+  test("a real wallet's balance event never lands on a demo session", async () => {
+    // The event carries someone's real balance. Letting it through would
+    // overwrite the play balance with it.
+    const { fake, platform, events } = await connect();
+    await platform.openSession(DEMO, "c1");
+    await platform.openSession(REAL, "c2");
+    await platform.settleSimple({
+      sessionId: REAL, bet: 100, betIndex: 2, priceMultiplier: 1,
+      win: 0, multiplier: 0, type: "loss", roundState: "{}",
+    });
+    await until(() => events.some((e) => e.type === "balanceChanged"), "balanceChanged");
+    expect(events.filter((e) => e.type === "balanceChanged").every((e) => e.sessionId === REAL)).toBe(true);
+  });
+});

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -57,6 +57,14 @@ export interface FakeArtubeOptions {
   eventSuffix?: boolean;
   /** Answer Welcome with this schema. */
   welcomeSchema?: number;
+  /** Process these request types but send no response, as a wallet whose
+   *  reply is lost in the network does. The state change still happens. */
+  swallowReplyFor?: string[];
+  /** Report every settle as having hit the platform's own maximum win. */
+  maxWinReached?: boolean;
+  /** Send the session fields a client needs: gamification token, max win,
+   *  auto-spin counts, RTP display. */
+  clientExtras?: boolean;
   /** Session ids for which the wallet returns no currency - Artube's one and
    *  only marker for a demo session. */
   demoSessions?: string[];
@@ -71,6 +79,7 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
   const sendMinimalUnit = opts.sendMinimalUnit ?? true;
   const evt = (name: string) => (opts.eventSuffix === false ? name : `${name}Event`);
   const demoSessions = new Set(opts.demoSessions ?? []);
+  const swallow = new Set(opts.swallowReplyFor ?? []);
 
   const balances = new Map<string, number>();      // minor units
   const known = new Set<string>();
@@ -102,12 +111,16 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
         received.push({ type: msg.type, id: msg.id, schema: msg.schema, payload: msg.payload ?? {} });
         const p = msg.payload ?? {};
 
-        const reply = (type: string, payload: unknown) =>
+        const reply = (type: string, payload: unknown) => {
+          // The round happened; only the answer went missing. That is the
+          // case the RGS cannot tell from "the round never happened".
+          if (swallow.has(msg.type)) return;
           ws.send(JSON.stringify({
             proto: 1, schema: 1, chan: "rpc", type,
             id: `r-${msg.id}`, corr_id: msg.id, op_seq: 0,
             timestamp: new Date().toISOString(), payload,
           }));
+        };
         const err = (code: string, message: string) =>
           ws.send(JSON.stringify({
             proto: 1, schema: 1, chan: "rpc", type: "Error",
@@ -135,9 +148,19 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             currency: demoSessions.has(sid) ? null : "USD",
             balance: major(balances.get(sid)!),
             ...(last ? { last_round: last } : {}),
+            ...(opts.clientExtras ? { gamification_token: "tok-123" } : {}),
             game_settings: {
               default_bet_index: 0,
               allowed_bets: ladderMajor,
+              ...(opts.clientExtras ? {
+                platform_max_win: {
+                  is_visible: true,
+                  base_currency: "EUR",
+                  base_currency_value: 1000,
+                  player_currency_value: 870,
+                },
+                rtp_settings: { is_visible: true, shown_rtp: 96.5 },
+              } : {}),
               ...(sendMinimalUnit ? { currency_minimal_unit: 1 / MINOR } : {}),
               available_auto_spin_counts: [10, 25, 50],
               rtp_options: [{ rtp: 0.96, game_mode: "default" }],
@@ -179,10 +202,11 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             round_version: 0,
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),
-            is_platform_max_win_reached: false,
+            is_platform_max_win_reached: opts.maxWinReached === true,
           });
           reply("PlayRoundResponse", {
             round_id: roundId, balance: major(balances.get(sid)!), win: major(win),
+            is_platform_max_win_reached: opts.maxWinReached === true,
           });
           pushBalance(sid, "Win");
           return;

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -17,6 +17,8 @@ export interface FakeArtube {
   stop(): void;
   /** Push an AutocloseRequestEvent for a round the fake has open. */
   requestAutoclose(roundId: string): void;
+  /** Push a SessionClosedEvent for a session. */
+  closeSession(sessionId: string, reason?: string): void;
   /** Every frame the adapter sent, in order. */
   readonly received: WireFrame[];
   /** Frames of one type, oldest first. */
@@ -55,6 +57,9 @@ export interface FakeArtubeOptions {
   eventSuffix?: boolean;
   /** Answer Welcome with this schema. */
   welcomeSchema?: number;
+  /** Session ids for which the wallet returns no currency - Artube's one and
+   *  only marker for a demo session. */
+  demoSessions?: string[];
 }
 
 const MINOR = 100;
@@ -65,6 +70,7 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
   const START = opts.startMinor ?? 1_000_000;
   const sendMinimalUnit = opts.sendMinimalUnit ?? true;
   const evt = (name: string) => (opts.eventSuffix === false ? name : `${name}Event`);
+  const demoSessions = new Set(opts.demoSessions ?? []);
 
   const balances = new Map<string, number>();      // minor units
   const known = new Set<string>();
@@ -124,7 +130,9 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
           const last = lastRounds.get(sid);
           reply("SessionInfoResponse", {
             security_hash: "hash",
-            currency: "USD",
+            // A demo session is one with no currency. That is the whole
+            // marker: same requests, same everything else.
+            currency: demoSessions.has(sid) ? null : "USD",
             balance: major(balances.get(sid)!),
             ...(last ? { last_round: last } : {}),
             game_settings: {
@@ -294,6 +302,14 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
     openRoundIds: () => [...rounds.keys()],
     lastRoundState: (sessionId: string) =>
       lastRounds.get(sessionId)?.["round_state"] as string | undefined,
+    closeSession(sessionId: string, reason = "player left") {
+      const frame = JSON.stringify({
+        proto: 1, schema: 1, chan: "events", type: evt("SessionClosed"),
+        id: crypto.randomUUID(), op_seq: 0, timestamp: new Date().toISOString(),
+        payload: { session_id: sessionId, reason },
+      });
+      for (const ws of sockets) ws.send(frame);
+    },
     requestAutoclose(roundId: string) {
       const r = rounds.get(roundId);
       if (!r) throw new Error(`fake: no open round ${roundId}`);

--- a/packages/adapter-artube/test/fake-artube.ts
+++ b/packages/adapter-artube/test/fake-artube.ts
@@ -167,6 +167,7 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: winMul,
             win: major(win),
             started_at: new Date().toISOString(),
+            finished_at: new Date().toISOString(),
             round_version: 0,
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),
@@ -214,9 +215,9 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: 0,
             win: 0,
             started_at: new Date().toISOString(),
-            // No finished_at. The real wire omits it on FINISHED rounds too,
-            // which is exactly why the adapter cannot use it to tell an open
-            // round from a closed one - so the fake must not offer it either.
+            // No finished_at: that is what an open round looks like, and it
+            // is the wire's own answer to "is this round still open". The
+            // sandbox returns exactly this shape.
             round_version: 0,
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),
@@ -263,6 +264,7 @@ export function fakeArtube(opts: FakeArtubeOptions = {}): FakeArtube {
             win_multiplier: winMul,
             win: major(win),
             started_at: new Date().toISOString(),
+            finished_at: new Date().toISOString(),
             round_version: Number(p["round_version"] ?? 0),
             round_state_version: String(p["round_state_version"] ?? "1"),
             round_state: String(p["round_state"] ?? ""),

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -414,6 +414,26 @@ export interface SessionInfo {
   promo?: PromoFreeRounds;
   /** Open round to resume on reconnect, if any. */
   openRound?: OpenRoundResume;
+  /**
+   * Platform data that belongs to the CLIENT, forwarded verbatim.
+   *
+   * Every wallet has some of this: a token the game's UI needs to initialise
+   * a tournament widget, the max win to print in the rules, the auto-spin
+   * counts an operator allows, the RTP to display. None of it is the RGS's
+   * business - it never reads it, never validates it, never acts on it - but
+   * the client cannot get it any other way, because the client talks to the
+   * RGS and not to the wallet.
+   *
+   * Typing each field would mean putting one platform's vocabulary in a
+   * neutral contract, and dropping them (which is what happened before this
+   * existed) means a real game's UI cannot be built on this RGS at all. So:
+   * an opaque bag, adapter-filled, handed to the client untouched.
+   *
+   * NOT for anything the RGS must act on. A number the engine has to respect
+   * - a cap it must enforce, a balance it must trust - belongs in a real
+   * field with real semantics, not in here.
+   */
+  clientData?: Record<string, unknown>;
   /** Last math carry from this player's most recent COMPLETED round.
    *  Adapter is the source of truth for cross-round state, it stores the
    *  carry alongside its own round-settle records and returns it here on
@@ -575,6 +595,16 @@ export interface RoundReceipt {
    *  about the bonus (cumulative win, completion flags, leaderboard
    *  contribution, ...) is platform-side and never crosses this surface. */
   promo?: { remaining: number };
+  /**
+   * The PLATFORM says this round hit its own maximum-win limit.
+   *
+   * Distinct from the engine's `maxWinMultiplier`, which the RGS enforces
+   * itself and reports as outcome type `max_win_reached`. This one is the
+   * wallet's cap, applied wallet-side, and the RGS finds out only because the
+   * wallet says so on the receipt. A game that shows "MAX WIN" needs to know,
+   * and an operator reconciling a capped round needs it in the log.
+   */
+  platformMaxWinReached?: boolean;
 }
 
 /** Reverse (roll back) an already-settled round, a chargeback, a
@@ -765,6 +795,9 @@ export interface ClientResponseInit {
   /** Active promo free-rounds pool surfaced to the client for the
    *  opt-in offer. Mirrors `SessionInfo.promo`. Absent when none. */
   promo?: { id: string; bet: number; remaining: number; total?: number; label?: string; validTo?: string };
+  /** Platform data forwarded verbatim from {@link SessionInfo.clientData}.
+   *  The RGS neither reads nor validates it; see that field. */
+  clientData?: Record<string, unknown>;
   /** A round was in flight when the player disconnected, replay it.
    *  ops:        full cumulative ops sequence (open + every step) so the
    *              client can rebuild the visual state.
@@ -788,6 +821,9 @@ export interface ClientResponseSpin {
   /** Updated promo pool view after this round, if a promo was consumed.
    *  `done: true` when the pool has been drained (remaining === 0). */
   promo?: { remaining: number; done: boolean };
+  /** The platform capped this round at its own maximum win. See
+   *  {@link RoundReceipt.platformMaxWinReached}. */
+  platformMaxWin?: true;
 }
 
 export interface ClientResponseOpenRound {
@@ -810,6 +846,9 @@ export interface ClientResponseCloseRound {
   win: number;
   multiplier: number;
   type: string;
+  /** The platform capped this round at its own maximum win. See
+   *  {@link RoundReceipt.platformMaxWinReached}. */
+  platformMaxWin?: true;
 }
 
 export interface ClientResponsePromoAccept {

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -341,6 +341,20 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     return requested ?? manifest.defaultMode;
   }
 
+  /** The wallet capped this round at its own maximum win. Log it where an
+   *  operator reconciling a short payout will find it, and tell the client,
+   *  which is the only party that can explain it to the player. */
+  function notePlatformMaxWin(sessionId: string, roundId: string, receipt: { platformMaxWinReached?: boolean }): boolean {
+    if (receipt.platformMaxWinReached !== true) return false;
+    log.warn("Platform capped this round at its own maximum win", {
+      "event.category": "orchestrator",
+      "event.action":   "platform_max_win",
+      "session.id":     sessionId,
+      "round.id":       roundId,
+    });
+    return true;
+  }
+
   function buildSpinContext(
     modeId: string,
     bet: { betIndex: number; priceMultiplier: number },
@@ -473,6 +487,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         balance: s.balance,
         allowedBets: s.allowedBets,
         defaultBetIndex: s.defaultBetIndex,
+        ...(s.clientData !== undefined ? { clientData: s.clientData } : {}),
         ...(s.promo ? { promo: {
           id: s.promo.id,
           bet: s.promo.bet,
@@ -544,6 +559,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         ...(restoredCarry !== undefined ? { carry: restoredCarry } : {}),
         ...(restoredNextMode !== undefined ? { nextMode: restoredNextMode } : {}),
         ...(info.promo && info.promo.remaining > 0 ? { promo: sessions.promoFromApi(info.promo) } : {}),
+        ...(info.clientData !== undefined ? { clientData: info.clientData } : {}),
         createdAt: Date.now(),
       };
       // put() can evict idle overflow. Those sessions are gone from the cache,
@@ -571,6 +587,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       allowedBets: info.allowedBets,
       defaultBetIndex: info.defaultBetIndex,
       modes: modeCatalogForClient(),
+      ...(info.clientData !== undefined ? { clientData: info.clientData } : {}),
       ...(conn.demo ? { demo: true as const } : {}),
     };
 
@@ -750,6 +767,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       win,
       multiplier: cappedOutcome.multiplier,
       type: cappedOutcome.type,
+      ...(notePlatformMaxWin(s.sessionId, receipt.roundId, receipt) ? { platformMaxWin: true as const } : {}),
     };
 
     if (wasPromo) {
@@ -999,6 +1017,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       win,
       multiplier: cappedClose.multiplier,
       type: cappedClose.type,
+      ...(notePlatformMaxWin(s.sessionId, receipt.roundId, receipt) ? { platformMaxWin: true as const } : {}),
     };
   }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -53,6 +53,10 @@ export interface OpenRound {
 
 export interface LocalSession {
   readonly sessionId: string;
+  /** Platform data for the client, verbatim from SessionInfo. Kept so a
+   *  resume answers with the same thing a fresh INIT did - a client that
+   *  reconnected has not stopped needing its tournament token. */
+  clientData?: Record<string, unknown>;
   /** Connection currently attached to this session; null once that
    *  connection dropped (detached). The concurrency policy arbitrates on
    *  this: a second INIT while non-null hits kick-old / reject-new; a


### PR DESCRIPTION
Follow-up to #68 and #69, all of it found by running the bench against the
Artube sandbox and then auditing what a real game would still be missing.

## Recovery: the round the wallet has and you do not

A round is opened and debited; the process that opened it dies, or the pod
rolls. The RGS forgets, the wallet does not, and every later round on that
session is refused with `Round is already opened` until someone closes it by
hand. `openRoundFor(sessionId)` surfaces it from `SessionInfo` after every
`openSession` and adopts the round so a close works — the `round_version` is
the wallet's own, not a guess. `claimLastRound()` and
`claimRound(sessionId, roundId, roundVersion)` are explicit hatches for the
cases detection cannot reach, because an adapter guessing at which round to
close is how you settle the wrong one.

Detection believes `finished_at` (null while open) with the in-flight marker
the adapter writes as a second opinion. An earlier build in this branch
refused to trust `finished_at` on the strength of one session that was already
wedged — whose `last_round` was therefore an open round, so the field working
correctly was read as evidence that it did not. That reasoning is corrected
here and in the README.

## Demo sessions

Artube has no demo requests: a session whose **currency is null** is the demo
session, and the backend keeps its state itself. `withDemoSessions` serves them
entirely from memory — balance, the round state at open, each update, the final
state at close, the carry, and the finished round the way `last_round` holds it.
The bet ladder still comes from the wallet. It persists nothing, matching the
platform, and it never infers demo-ness from anything but the wallet's answer.

## Idempotency, on a wire that has no idempotency field

The same key settles once per process, claimed *before* the request goes out so
concurrent duplicates collapse instead of racing, scoped per session so one
player's key cannot suppress another's. An unanswered settle is checked rather
than retried blind: the key rides inside the round state, so the adapter reads
the session's last round back and asks whether its own settle landed.

The first version of that cache stored finished receipts and had a
read-then-write race — both duplicates missed, both were paid. The test kit's
concurrency certification caught it on the first run where it was enabled, which
is also the argument for enabling it.

## Platform data reaches the client

`SessionInfo.clientData`: an opaque, adapter-filled, RGS-unread bag forwarded
verbatim on INIT. The Artube adapter fills it with the `gamification_token`
their docs are explicit about forwarding unchanged, the platform max win, the
auto-spin counts, the RTP display settings, the win history, the security hash.
All of it was parsed off the wire and dropped, which meant a real game's UI
could not be built on this adapter at all.

`RoundReceipt.platformMaxWinReached` is the one that is not cosmetic: a cap
applied wallet-side that the RGS cannot infer, since the balance is simply
smaller than the multiplier implies. It reaches the client as `platformMaxWin`.

---

1035 tests, typecheck clean. `idempotency.duplicate-key` is off the conformance
allowlist; `errors.insufficient-funds` remains (the probe drives `bet`, and this
wire is amount-blind by design).