### PR TITLE
Resume a round the wallet has open

### DIFF
--- a/.changeset/resume-wallet-open-round.md
+++ b/.changeset/resume-wallet-open-round.md
@@ -1,0 +1,29 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+"@open-rgs/adapter-artube": minor
+---
+
+Resume a round the wallet has open and this process never opened.
+
+A round is opened and debited; the RGS restarts, or the player returns on
+another instance. The round exists, the wallet has its state, and the RGS
+remembers nothing — so every later round is refused and the player is stuck.
+Until now the only answers were to forfeit it or settle it behind their back.
+
+`SessionInfo.walletOpenRound` carries it, and at INIT the orchestrator rebuilds
+the round from it: the bet from the index and the ladder, the cost from the
+mode's stake, and — the part only the math can answer — what the player is
+being asked, via the new optional `ComplexMath.resume(state)`. The player lands
+back in the round and finishes it.
+
+`OpenComplex.modeId` lets an adapter record which mode a round belongs to, so
+the resolver does not have to guess whose state it is holding. Without one, it
+asks each complex math to resume the state and takes the first that accepts —
+`resume` is required to throw on a state that is not its own, which is what
+makes that a question rather than a guess.
+
+It refuses rather than guesses in three cases, each of which would mean
+settling a round under rules it was not played by: a mode that no longer
+exists, a math version that no longer matches, and a bet index off the
+session's ladder. The round stays open on the wallet and recoverable by hand.

--- a/packages/adapter-artube/src/index.ts
+++ b/packages/adapter-artube/src/index.ts
@@ -94,6 +94,8 @@ export const ARTUBE_ADAPTER_VERSION: string = pkg.version;
  *  value the state. */
 export interface ArtubeOpenRound {
   roundId: string;
+  /** Mode the round was opened in, if the state recorded one. */
+  modeId?: string;
   /** The round's state as the wallet last stored it. `ComplexMath.autoclose`
    *  takes exactly this. */
   state: string;
@@ -392,6 +394,8 @@ interface PendingRpc {
 /** What the adapter remembers about a round the wallet has open. */
 interface OpenRoundBook {
   sessionId: string;
+  /** Mode the round is being played in, when the RGS told us. */
+  modeId?: string;
   /** Latest round_version the wallet handed back. */
   version: number;
   /** round_state_version stamped at open; reused when a later request has
@@ -743,6 +747,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       state: unwrapState(last.round_state),
       betIndex: last.bet_index,
       priceMultiplier: last.price_multiplier,
+      ...(modeOf(last.round_state) !== undefined ? { modeId: modeOf(last.round_state)! } : {}),
       ...(last.round_state_version ? { mathVersion: last.round_state_version } : {}),
       ...(last.started_at ? { startedAt: last.started_at } : {}),
     };
@@ -750,6 +755,7 @@ export class ArtubeAdapter implements PlatformAdapter {
     if (!this.rounds.has(orphan.roundId)) {
       this.rounds.set(orphan.roundId, {
         sessionId,
+        ...(orphan.modeId !== undefined ? { modeId: orphan.modeId } : {}),
         version: last.round_version,
         stateVersion: last.round_state_version,
         features: new Set(),
@@ -886,7 +892,7 @@ export class ArtubeAdapter implements PlatformAdapter {
       ...(req.promoId  ? { free_round_campaign_id: req.promoId } : {}),
       ...(features.length > 0 ? { features: features.map((type) => ({ type })) } : {}),
       round_state_version: stateVersion,
-      round_state:         packOpenState(req.initialState),
+      round_state:         packOpenState(req.initialState, req.modeId),
     };
 
     const env = await this.rpc<OpenRoundRequestPayload, OpenRoundResponsePayload>(
@@ -896,6 +902,7 @@ export class ArtubeAdapter implements PlatformAdapter {
 
     this.rounds.set(env.payload.round_id, {
       sessionId:    req.sessionId,
+      ...(req.modeId !== undefined ? { modeId: req.modeId } : {}),
       version:      env.payload.round_version,
       stateVersion,
       features:     new Set(features),
@@ -933,7 +940,7 @@ export class ArtubeAdapter implements PlatformAdapter {
           round_id:            req.roundId,
           round_version:       book.version,
           round_state_version: book.stateVersion,
-          round_state:         packOpenState(req.state),
+          round_state:         packOpenState(req.state, book.modeId),
         },
       );
       for (const f of extractFeatures(req.state)) book.features.add(f);
@@ -1768,6 +1775,19 @@ function artubeSessionToContract(
   // No carry is the honest answer for an open round: unknown, not empty. The
   // orchestrator resumes from its own memory when it still has the session,
   // and this path is what runs when it does not.
+  if (p.last_round && isRoundOpen(p.last_round)) {
+    // The round the wallet still has and this process does not. Handed to the
+    // orchestrator so the player is put back INTO it, rather than losing a
+    // round they already paid for.
+    info.walletOpenRound = {
+      roundId: p.last_round.round_id,
+      state: unwrapState(p.last_round.round_state),
+      betIndex: p.last_round.bet_index,
+      priceMultiplier: p.last_round.price_multiplier,
+      ...(modeOf(p.last_round.round_state) !== undefined ? { modeId: modeOf(p.last_round.round_state)! } : {}),
+      ...(p.last_round.round_state_version ? { mathVersion: p.last_round.round_state_version } : {}),
+    };
+  }
   if (p.last_round && !isRoundOpen(p.last_round)) {
     const carry = unpackCarry(p.last_round.round_state);
     if (carry !== "") info.carry = carry;
@@ -1823,6 +1843,9 @@ interface RoundStateEnvelope {
    *  carry look absent - the player's meters reset - while a genuinely open
    *  round stays invisible. */
   open?: true;
+  /** Mode the round is being played in, stored so a process that did not open
+   *  it knows which math owns the state. */
+  mode?: string;
   /**
    * The RGS's idempotency key for the settle that wrote this state.
    *
@@ -1880,10 +1903,11 @@ function mayHaveLanded(e: unknown): boolean {
 }
 
 /** The state of a round that is still in flight, marked as such. */
-function packOpenState(state: string): string {
+function packOpenState(state: string, mode?: string): string {
   const env: RoundStateEnvelope = {
     [RGS_ENVELOPE_MARK]: 1,
     open: true,
+    ...(mode !== undefined ? { mode } : {}),
     state: asJsonOrString(state),
   };
   return JSON.stringify(env);
@@ -1902,6 +1926,11 @@ function parseEnvelope(roundState: string): RoundStateEnvelope | undefined {
  *  when it was written. */
 function isOpenState(roundState: string): boolean {
   return parseEnvelope(roundState)?.open === true;
+}
+
+/** The mode an in-flight round was opened in, if it was recorded. */
+function modeOf(roundState: string): string | undefined {
+  return parseEnvelope(roundState)?.mode;
 }
 
 /**

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -281,6 +281,24 @@ export interface ComplexMath {
 
   /** Optional autoclose resolver: produce a close outcome from current state. */
   autoclose?(state: RoundState): CloseOutcome | Promise<CloseOutcome>;
+
+  /**
+   * Describe a round that is already in flight, from its state alone.
+   *
+   * For the round nobody in this process opened: the wallet still has it, the
+   * RGS was restarted or the player moved to another instance, and the only
+   * thing left of the round is the state the wallet stored. Without this the
+   * choice is to forfeit it or to settle it behind the player's back; with
+   * it the player is put back where they were and finishes the round.
+   *
+   * MUST throw if `state` is not one of this math's own - the resolver uses
+   * that to tell whose round it is when the mode was not recorded.
+   *
+   * `ops` is what the client needs to redraw; a math that cannot reconstruct
+   * the visuals may return none, and the client shows the decision without
+   * the history that led to it.
+   */
+  resume?(state: RoundState): { awaiting?: AwaitingHint; ops?: Op[] };
 }
 
 export type MathModule = SimpleMath | ComplexMath;
@@ -388,6 +406,26 @@ export function defineGame(m: GameManifest): GameManifest {
 // is a single connected adapter with a healthy/unhealthy status, a fixed
 // RPC surface, and an event stream.
 
+/** A round the WALLET says is still open, with enough to resume it.
+ *
+ *  Distinct from {@link OpenRoundResume}, which is this RGS replaying a round
+ *  it still holds in memory. This one comes from the wallet, which knows the
+ *  round exists and stored its state but has no idea what any of it means. */
+export interface WalletOpenRound {
+  roundId: string;
+  /** The math's own state, as the wallet stored it. */
+  state: RoundState;
+  betIndex: number;
+  priceMultiplier: number;
+  /** Mode it was opened in, when the adapter recorded one. Without it the
+   *  orchestrator finds the owning math by asking each complex mode to
+   *  resume the state, and takes the first that accepts it. */
+  modeId?: string;
+  /** Math version that wrote the state. A round written by math that is no
+   *  longer loaded is not resumed: its rules are gone. */
+  mathVersion?: string;
+}
+
 export interface SessionInfo {
   sessionId: string;
   /** Empty string = demo session (no real wallet). */
@@ -414,6 +452,10 @@ export interface SessionInfo {
   promo?: PromoFreeRounds;
   /** Open round to resume on reconnect, if any. */
   openRound?: OpenRoundResume;
+  /** A round the wallet has open that this process did not open. Set by an
+   *  adapter whose wire can report one; the orchestrator resumes it at INIT
+   *  so the player finishes the round rather than losing it. */
+  walletOpenRound?: WalletOpenRound;
   /**
    * Platform data that belongs to the CLIENT, forwarded verbatim.
    *
@@ -549,6 +591,10 @@ export interface OpenComplex {
   betIndex: number;
   priceMultiplier: number;
   initialState: RoundState;
+  /** Mode this round is being played in. An adapter that can store it should:
+   *  it is what lets the round be resumed later by a process that did not
+   *  open it, without guessing which math owns the state. */
+  modeId?: string;
   mathVersion?: string;
   /** Promo pool id this round was consumed from, if any. */
   promoId?: string;

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -46,7 +46,7 @@ import { isAwaitingEndRound } from "./deferred-close.js";
  *  every transport and client says the same thing. */
 export const UNFINISHED_ROUND_MESSAGE = "Unfinished round \u2014 watching replay";
 import type { RgsMetrics } from "./metrics-rgs.js";
-import type { IdempotencyConfig, ConcurrencyPolicy } from "@open-rgs/contract";
+import type { IdempotencyConfig, ConcurrencyPolicy, AwaitingHint, Op, WalletOpenRound } from "@open-rgs/contract";
 
 export interface OrchestratorConfig {
   manifest: GameManifest;
@@ -341,6 +341,78 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     return requested ?? manifest.defaultMode;
   }
 
+  /**
+   * Rebuild an in-memory round from what the wallet stored.
+   *
+   * Everything except the state is arithmetic: the bet comes from the index
+   * and the ladder, the cost from the mode's stake. The state is the math's,
+   * and only the math that wrote it can say what the player is being asked -
+   * which is what `ComplexMath.resume` is for.
+   *
+   * Refuses, rather than guesses, in three cases, because each one would mean
+   * settling a round under rules it was not played by: a mode that is gone, a
+   * math version that no longer matches, and a math with no `resume`. The
+   * round stays open on the wallet and is still recoverable by hand.
+   */
+  function resumeWalletRound(open: WalletOpenRound | undefined, allowedBets: readonly number[]): sessions.OpenRound | undefined {
+    if (!open) return undefined;
+
+    const candidates: [string, GameMode][] = open.modeId
+      ? (manifest.modes[open.modeId] ? [[open.modeId, manifest.modes[open.modeId]!]] : [])
+      // The mode was not recorded (an older round, another implementation):
+      // ask each complex math whether the state is one of its own. `resume`
+      // is required to throw when it is not, which is what makes this a
+      // question rather than a guess.
+      : Object.entries(manifest.modes).filter(([, m]) => m.math.kind === "complex");
+
+    for (const [modeId, mode] of candidates) {
+      const math = mode.math;
+      if (math.kind !== "complex" || typeof math.resume !== "function") continue;
+      if (open.mathVersion !== undefined && math.version !== open.mathVersion) {
+        log.warn("Not resuming a round written by math that is no longer loaded", {
+          "event.category": "orchestrator",
+          "event.action":   "wallet_round_version_mismatch",
+          "round.id":       open.roundId,
+          "math.version.round":   open.mathVersion,
+          "math.version.current": math.version,
+        });
+        continue;
+      }
+      let described: { awaiting?: AwaitingHint; ops?: Op[] };
+      try {
+        described = math.resume(open.state);
+      } catch {
+        continue;   // not this math's round
+      }
+      const base = allowedBets[open.betIndex];
+      if (base === undefined) {
+        log.warn("Not resuming a round whose bet index is off this session's ladder", {
+          "event.category": "orchestrator",
+          "event.action":   "wallet_round_bet_unknown",
+          "round.id":       open.roundId,
+          "round.bet_index": open.betIndex,
+          "ladder.length":  allowedBets.length,
+        });
+        continue;
+      }
+      const bet = base * open.priceMultiplier;
+      return {
+        roundId: open.roundId,
+        modeId,
+        bet,
+        effectiveCost: bet * mode.stakeMultiplier,
+        state: open.state,
+        ...(described.awaiting ? { awaiting: described.awaiting } : {}),
+        actionLog: [],
+        // Whatever the math could reconstruct. The actions that led here are
+        // gone - they were only ever in the memory of a process that died.
+        opsLog: described.ops ? [...described.ops] : [],
+        openedAt: Date.now(),
+      };
+    }
+    return undefined;
+  }
+
   /** The wallet capped this round at its own maximum win. Log it where an
    *  operator reconciling a short payout will find it, and tell the client,
    *  which is the only party that can explain it to the player. */
@@ -471,6 +543,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     // connection exactly what happened and what's next.
     let s = sessions.get(req.sid);
     let info: import("@open-rgs/contract").SessionInfo;
+    let walletResume: sessions.OpenRound | undefined;
 
     if (s?.openRound) {
       // Don't re-call openSession on the platform, we still own this
@@ -524,6 +597,22 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       conn.sessionId = req.sid;
       conn.demo = !info.currency;
 
+      // A round the WALLET has open and this process never opened: the RGS
+      // was restarted, or the player came back on another instance. Put them
+      // back in it. The alternative is to forfeit a round they paid for or
+      // to settle it behind their back, and both are worse than finishing it.
+      const resumed = resumeWalletRound(info.walletOpenRound, info.allowedBets);
+      if (resumed) {
+        walletResume = resumed;
+        log.warn("Resuming a round the wallet had open", {
+          "event.category": "orchestrator",
+          "event.action":   "wallet_round_resumed",
+          "session.id":     req.sid,
+          "round.id":       resumed.roundId,
+          "mode.id":        resumed.modeId,
+        });
+      }
+
       // Math-version migration: if the platform returns a carry but
       // its mathVersion doesn't match what's currently loaded, we
       // discard the carry. Manifest.recovery policy could in future
@@ -551,6 +640,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       s = {
         sessionId: req.sid,
         connectionId: conn.connectionId,
+        ...(walletResume ? { openRound: walletResume } : {}),
         balance: info.balance,
         currency: info.currency,
         currencyDecimals: info.currencyDecimals,
@@ -825,6 +915,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         betIndex: betInfo.betIndex,
         priceMultiplier: betInfo.priceMultiplier * mode.stakeMultiplier,
         initialState: open.state,
+        modeId: requestedMode,
         ...(mode.math.version ? { mathVersion: mode.math.version } : {}),
         idempotencyKey: initiatingIdemKey(s.sessionId, "open", req.idempotencyKey),
         ...(betInfo.promoId ? { promoId: betInfo.promoId } : {}),

--- a/packages/core/test/wallet-round-resume.test.ts
+++ b/packages/core/test/wallet-round-resume.test.ts
@@ -1,0 +1,152 @@
+// A round the wallet has open and this process never opened.
+//
+// The RGS restarts, or the player comes back on another instance. The round
+// was paid for and its state is sitting in the wallet; the RGS remembers
+// nothing. Before this, the only options were to forfeit it or to settle it
+// behind the player's back. Now they are put back into it and finish it.
+
+import { describe, expect, test } from "bun:test";
+import { createOrchestrator } from "../src/index.js";
+import {
+  defineGame,
+  type ComplexMath, type ConnectionMeta, type PlatformAdapter, type PlatformEvent,
+  type RoundReceipt, type SessionInfo, type WalletOpenRound,
+} from "@open-rgs/contract";
+
+interface Table { pending: number; done?: boolean }
+
+/** A gamble round: the state says what is on the table. */
+function math(version = "1"): ComplexMath {
+  return {
+    kind: "complex", name: "gamble", version, rtp: 1,
+    open: () => ({ state: JSON.stringify({ pending: 1 }), ops: [], awaiting: { type: "decide" } }),
+    step: (state, action) => {
+      const t = JSON.parse(state) as Table;
+      if (action["choice"] === "collect") return { state: JSON.stringify({ ...t, done: true }), ops: [] };
+      return { state: JSON.stringify({ pending: t.pending * 2 }), ops: [], awaiting: { type: "decide" } };
+    },
+    isTerminal: (state) => (JSON.parse(state) as Table).done === true,
+    close: (state) => ({ multiplier: (JSON.parse(state) as Table).pending, ops: [], type: "win" }),
+    resume: (state) => {
+      const t = JSON.parse(state) as Table;
+      // Required to throw when the state is not this math's own: that is how
+      // the orchestrator identifies the owner when no mode was recorded.
+      if (typeof t.pending !== "number") throw new Error("not mine");
+      return t.done ? {} : { awaiting: { type: "decide" }, ops: [{ kind: "message", text: `${t.pending}x on the table` }] };
+    },
+  };
+}
+
+function platformWith(open: WalletOpenRound | undefined): PlatformAdapter & { closed: RoundReceipt[] } {
+  const closed: RoundReceipt[] = [];
+  return {
+    closed,
+    isHealthy: true,
+    diagnostics: {},
+    async connect() {}, disconnect() {},
+    async openSession(sessionId): Promise<SessionInfo> {
+      return {
+        sessionId, currency: "USD", currencyDecimals: 2,
+        balance: 10_000, allowedBets: [100, 200], defaultBetIndex: 0,
+        ...(open ? { walletOpenRound: open } : {}),
+      };
+    },
+    async settleSimple(): Promise<RoundReceipt> { throw new Error("unused"); },
+    async openComplex(): Promise<RoundReceipt> { throw new Error("should not open: a round is already open"); },
+    async closeComplex(req): Promise<RoundReceipt> {
+      const r = { roundId: req.roundId, balance: 10_000 + req.win };
+      closed.push(r);
+      return r;
+    },
+    onEvent(_h: (e: PlatformEvent) => void) {},
+  };
+}
+
+function orchestratorFor(platform: PlatformAdapter, mathVersion = "1") {
+  return createOrchestrator({
+    manifest: defineGame({
+      id: "g", declaredRtp: 1, defaultMode: "cx",
+      modes: { cx: { math: math(mathVersion), stakeMultiplier: 1 } },
+    }),
+    platform,
+  });
+}
+
+// The session store is a module-level singleton shared by every test file in
+// the process, so session ids have to be unique across the whole suite - not
+// just within this file. Generic ids passed here and failed in the full run.
+const conn = (): ConnectionMeta => ({ connectionId: `c-${Math.random()}`, sessionId: null, demo: false });
+
+const openRound: WalletOpenRound = {
+  roundId: "r-from-the-wallet",
+  state: JSON.stringify({ pending: 4 }),
+  betIndex: 1,
+  priceMultiplier: 1,
+  modeId: "cx",
+  mathVersion: "1",
+};
+
+describe("resuming a round the wallet has open", () => {
+  test("INIT puts the player back into it, with what they are being asked", async () => {
+    const platform = platformWith(openRound);
+    const orch = orchestratorFor(platform);
+    const init = await orch.init({ sid: "wallet-resume-1" }, conn());
+    expect(init.resume).toBeDefined();
+    expect(init.resume?.roundId).toBe("r-from-the-wallet");
+    expect(init.resume?.awaiting?.type).toBe("decide");
+    // The bet is arithmetic: index 1 of this session's ladder.
+    expect(init.resume?.bet).toBe(200);
+    // Whatever the math could reconstruct of the round so far.
+    expect(init.resume?.ops?.length).toBeGreaterThan(0);
+  });
+
+  test("and the player can finish it", async () => {
+    const platform = platformWith(openRound);
+    const orch = orchestratorFor(platform);
+    const c = conn();
+    await orch.init({ sid: "wallet-resume-2" }, c);
+    await orch.stepRound({ action: { type: "decide", choice: "collect" } }, c);
+    const close = await orch.closeRound({}, c);
+    // 4x was on the table when the process that opened it died.
+    expect(close.multiplier).toBe(4);
+    expect(close.win).toBe(4 * 200);
+    expect(platform.closed.map((r) => r.roundId)).toEqual(["r-from-the-wallet"]);
+  });
+
+  test("a round written by math that is gone is not resumed", async () => {
+    // Its rules no longer exist. Settling it under the replacement's rules
+    // would be inventing a result; it stays open and recoverable by hand.
+    const platform = platformWith({ ...openRound, mathVersion: "0" });
+    const orch = orchestratorFor(platform, "1");
+    const init = await orch.init({ sid: "wallet-resume-3" }, conn());
+    expect(init.resume).toBeUndefined();
+  });
+
+  test("without a recorded mode, the owning math is found by asking", async () => {
+    const platform = platformWith({ ...openRound, modeId: undefined });
+    const orch = orchestratorFor(platform);
+    const init = await orch.init({ sid: "wallet-resume-4" }, conn());
+    expect(init.resume?.roundId).toBe("r-from-the-wallet");
+  });
+
+  test("a state no math claims is left alone", async () => {
+    const platform = platformWith({ ...openRound, modeId: undefined, state: JSON.stringify({ something: "else" }) });
+    const orch = orchestratorFor(platform);
+    const init = await orch.init({ sid: "wallet-resume-5" }, conn());
+    expect(init.resume).toBeUndefined();
+  });
+
+  test("a bet index off this session's ladder is not resumed", async () => {
+    const platform = platformWith({ ...openRound, betIndex: 99 });
+    const orch = orchestratorFor(platform);
+    const init = await orch.init({ sid: "wallet-resume-6" }, conn());
+    expect(init.resume).toBeUndefined();
+  });
+
+  test("no open round, no resume", async () => {
+    const platform = platformWith(undefined);
+    const orch = orchestratorFor(platform);
+    const init = await orch.init({ sid: "wallet-resume-7" }, conn());
+    expect(init.resume).toBeUndefined();
+  });
+});

--- a/packages/platform-mock/src/index.ts
+++ b/packages/platform-mock/src/index.ts
@@ -63,7 +63,21 @@ interface MockState {
   allowedBets: number[];
   defaultBetIndex: number;
   promo?: PromoFreeRounds;
-  openRound?: { roundId: string; bet: number; finalState?: string; balanceBefore: number; carryBefore: CarryState | undefined };
+  openRound?: {
+    roundId: string;
+    bet: number;
+    finalState?: string;
+    balanceBefore: number;
+    carryBefore: CarryState | undefined;
+    /** Enough to hand the round back on the next openSession, the way a real
+     *  wallet does: it stored the state and the price, and knows nothing
+     *  about what any of it means. */
+    state?: string;
+    betIndex?: number;
+    priceMultiplier?: number;
+    modeId?: string;
+    mathVersion?: string;
+  };
   /** Math version that produced `carry`. Stored with it and handed back on the
    *  next openSession, so the RGS can tell a carry written by older math from
    *  one written by the math it is currently running - it discards the former
@@ -147,6 +161,19 @@ export class MockPlatform implements PlatformAdapter {
       allowedBets: s.allowedBets,
       defaultBetIndex: s.defaultBetIndex,
       promo: s.promo,
+      // A round left open is the wallet's to report: it is what lets an RGS
+      // that has forgotten the round (a restart, another instance) put the
+      // player back into it instead of stranding a round they paid for.
+      ...(s.openRound && s.openRound.state !== undefined ? {
+        walletOpenRound: {
+          roundId: s.openRound.roundId,
+          state: s.openRound.state,
+          betIndex: s.openRound.betIndex ?? 0,
+          priceMultiplier: s.openRound.priceMultiplier ?? 1,
+          ...(s.openRound.modeId !== undefined ? { modeId: s.openRound.modeId } : {}),
+          ...(s.openRound.mathVersion !== undefined ? { mathVersion: s.openRound.mathVersion } : {}),
+        },
+      } : {}),
       // The wallet is the source of truth for carry; hand back what we stored,
       // with the math version that wrote it.
       ...(s.carry !== undefined ? { carry: s.carry } : {}),
@@ -223,7 +250,14 @@ export class MockPlatform implements PlatformAdapter {
     const roundId = this.nextRoundId();
     // Capture pre-round state at OPEN: a complex round's money spans open->close,
     // so reversing it must restore the balance/carry from before the debit.
-    s.openRound = { roundId, bet: req.bet, balanceBefore, carryBefore };
+    s.openRound = {
+      roundId, bet: req.bet, balanceBefore, carryBefore,
+      state: req.initialState,
+      betIndex: req.betIndex,
+      priceMultiplier: req.priceMultiplier,
+      ...(req.modeId !== undefined ? { modeId: req.modeId } : {}),
+      ...(req.mathVersion !== undefined ? { mathVersion: req.mathVersion } : {}),
+    };
 
     const receipt: RoundReceipt = { roundId, balance: s.balance };
     if (isPromo) receipt.promo = this.consumePromo(s);
@@ -231,8 +265,15 @@ export class MockPlatform implements PlatformAdapter {
     return this.remember(req.idempotencyKey, receipt);
   }
 
-  async updateComplex(_req: UpdateComplex): Promise<void> {
-    /* audit-only no-op for the mock */
+  async updateComplex(req: UpdateComplex): Promise<void> {
+    // Audit-only for money, but the state itself is kept: it is what the
+    // wallet would be holding, and what a resume of this round reads. A mock
+    // that dropped it would report the round as it was at OPEN and quietly
+    // rewind the player's progress.
+    const s = this.state.get(req.sessionId);
+    if (s?.openRound && s.openRound.roundId === req.roundId) {
+      s.openRound.state = req.state;
+    }
   }
 
   async closeComplex(req: CloseComplex): Promise<RoundReceipt> {


### PR DESCRIPTION
A round belongs to the player, not to the session. It survives the session that opened it, and a fresh session inherits it — so a player whose pod rolled mid-round came back to a game that refused every new round with `Round is already opened` and gave them no way to finish the one they had paid for.

INIT now hands that round back.

- `ComplexMath.resume(state)` — only the math that wrote a state can say what the player is being asked. It must throw on a state that is not its own, which is what lets the resolver find a round's mode by asking each math in turn.
- `SessionInfo.walletOpenRound` — the adapter reports what the wallet is holding; the orchestrator rebuilds the round from it.
- `OpenComplex.modeId` — the adapter now stamps which mode owns a round, so later rounds need no search.

It **refuses** rather than guesses in three cases, each of which would mean settling a round under rules it was never played by: the mode is gone, the math version no longer matches, or the bet index is off the session's ladder. The round then stays open and recoverable by hand.

`@open-rgs/platform-mock` also reports its open round now and keeps in-flight state through `updateComplex`. It did neither, so this path could not be tested locally at all — and a mock that drops round state silently rewinds a player's progress.

Verified against a live Artube wallet: a stranded round was recovered, described correctly ("1x on the table — gamble to 2x or collect, 5 gambles left") and finished by the player.

🤖 Generated with [Claude Code](https://claude.com/claude-code)