### PR TITLE
multiplierBasis: what a win multiplier is a multiple of

### DIFF
--- a/.changeset/multiplier-basis.md
+++ b/.changeset/multiplier-basis.md
@@ -1,0 +1,34 @@
+---
+"@open-rgs/contract": minor
+"@open-rgs/core": minor
+---
+
+`GameMode.multiplierBasis` — what a win multiplier is a multiple of
+
+open-rgs has always settled `win = multiplier × effectiveCost`: a multiple of
+what the round cost. That is one of the two conventions in use. The other —
+the one most published paytables are written in — is that the multiplier is a
+multiple of the **bet**, and the price of a feature buy has nothing to do with
+what a win pays. "Max win 10000x" means 10000 times the bet whether the
+feature was entered for 1x or for 2100x.
+
+A game on the second convention running under the first overpays by the buy's
+price multiplier, which at 2100x is not a rounding error. It also records a
+multiplier the game's own paytable screen contradicts: a max win stored as
+4.76x.
+
+```ts
+modes: {
+  "super-core": {
+    math,
+    stakeMultiplier: 2100,     // what the round costs
+    multiplierBasis: "bet",    // what a multiplier is OF
+    maxWinMultiplier: 10_000,  // read in the same basis
+  },
+}
+```
+
+Defaults to `"cost"`, so no existing game changes. The basis is resolved when
+a round opens and stored with it, so a config change cannot re-price a round
+already in flight. The mode catalog now reports `multiplierBasis`, because a
+client rendering `x{multiplier}` cannot otherwise know what the x is of.

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -318,6 +318,27 @@ export interface GameMode {
   internal?: boolean;
   /** Per-mode RTP for the mode catalog and certification. Defaults to math.rtp. */
   declaredRtp?: number;
+  /**
+   * What the math's multiplier is a multiple OF.
+   *
+   * `"cost"` (default) - a multiple of what the round cost, i.e.
+   * `bet x stakeMultiplier`. A 10x win on a 100x buy pays 1000 bets. This is
+   * the convention where a buy's price scales its wins with it.
+   *
+   * `"bet"` - a multiple of the BET the ladder names at `bet_index`, with the
+   * price of the round playing no part. A 10x win on a 100x buy pays 10 bets.
+   * This is the convention most published paytables are written in: "max win
+   * 10000x" means 10000 times the bet, whatever the feature cost to enter,
+   * and the price is a separate number the wallet is told about.
+   *
+   * The choice is not cosmetic and it is not recoverable after the fact: the
+   * multiplier the platform records is the math's own, so a game that means
+   * "10000x the bet" and declares `"cost"` both overpays AND writes a
+   * multiplier into round history that the paytable screen contradicts.
+   *
+   * Defaults to `"cost"` so existing games are untouched.
+   */
+  multiplierBasis?: "cost" | "bet";
   /** Per-mode max-win cap as a multiple of `bet` (post-stakeMultiplier).
    *  e.g. maxWinMultiplier=10000 means the orchestrator will cap any
    *  single round's win at 10,000 x bet. Most jurisdictions require this.

--- a/packages/core/src/orchestrator.ts
+++ b/packages/core/src/orchestrator.ts
@@ -401,6 +401,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
         modeId,
         bet,
         effectiveCost: bet * mode.stakeMultiplier,
+        winBasis: mode.multiplierBasis === "bet" ? base : bet * mode.stakeMultiplier,
         state: open.state,
         ...(described.awaiting ? { awaiting: described.awaiting } : {}),
         actionLog: [],
@@ -449,13 +450,15 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     modeId: string,
     requestedBetIndex: number | undefined,
     requestedPriceMultiplier: number | undefined,
-  ): { bet: number; betIndex: number; priceMultiplier: number; effectiveCost: number; promoId?: string } {
+  ): { bet: number; baseBet: number; betIndex: number; priceMultiplier: number; effectiveCost: number; winBasis: number; promoId?: string } {
     const promoOv = promo.activeOverride(s, modeId);
     if (promoOv) {
       const idx = s.allowedBets.indexOf(promoOv.bet);
       if (idx < 0) throw new RGSError("INVALID_BET", "Promo-locked bet not in allowedBets");
       // Promo-overridden free rounds skip stake fold by definition.
-      return { bet: promoOv.bet, betIndex: idx, priceMultiplier: 1, effectiveCost: promoOv.bet, promoId: promoOv.promoId };
+      // A promo-funded round costs the player nothing, so "cost" and "bet"
+      // are the same number here and the basis cannot change what it pays.
+      return { bet: promoOv.bet, baseBet: promoOv.bet, betIndex: idx, priceMultiplier: 1, effectiveCost: promoOv.bet, winBasis: promoOv.bet, promoId: promoOv.promoId };
     }
     const betIndex = requestedBetIndex ?? s.defaultBetIndex;
     if (!Number.isInteger(betIndex) || betIndex < 0 || betIndex >= s.allowedBets.length) {
@@ -489,14 +492,22 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     // win calc, and the audit log's "amount paid" field, never sent
     // on the wire as `bet`.
     const effectiveCost = bet * mode.stakeMultiplier;
-    return { bet, betIndex, priceMultiplier, effectiveCost };
+    // What a multiplier from THIS mode's math is a multiple of. Under the
+    // default it is what the round cost; under "bet" it is the rung of the
+    // ladder, and the price of the round - a feature buy's whole point - has
+    // nothing to do with what a win pays.
+    const winBasis = mode.multiplierBasis === "bet" ? baseBet : effectiveCost;
+    return { bet, baseBet, betIndex, priceMultiplier, effectiveCost, winBasis };
   }
 
   function modeCatalogForClient() {
-    const out: { id: string; label?: string; stakeMultiplier: number; declaredRtp?: number }[] = [];
+    const out: { id: string; label?: string; stakeMultiplier: number; declaredRtp?: number; multiplierBasis: "cost" | "bet" }[] = [];
     for (const [id, m] of Object.entries(manifest.modes)) {
       if (m.internal) continue;
-      out.push({ id, label: m.label, stakeMultiplier: m.stakeMultiplier, declaredRtp: m.declaredRtp ?? m.math.rtp });
+      // A client that renders "x{multiplier}" has to know what the x is of.
+      // Showing a cost-basis multiplier next to a paytable written against
+      // the bet is how a player is told they won 4.76x on a max win.
+      out.push({ id, label: m.label, stakeMultiplier: m.stakeMultiplier, declaredRtp: m.declaredRtp ?? m.math.rtp, multiplierBasis: m.multiplierBasis ?? "cost" });
     }
     return out;
   }
@@ -775,15 +786,17 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     // client can render a CONGRATULATIONS-YOU-MAXED-OUT screen.
     const cappedOutcome = applyMaxWinCap(
       outcome,
-      betInfo.effectiveCost,
+      betInfo.winBasis,
       mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
     );
-    // Win = multiplier x what was actually paid. For ante/buy modes
-    // that's the fractional effectiveCost; settleAmount rounds the
-    // product half-to-even at this one boundary (ADR-002) so the win
-    // crossing the wallet is integer minor units.
-    const win = settleAmount(cappedOutcome.multiplier, betInfo.effectiveCost);
-    assertFundedWin(betInfo.effectiveCost, cappedOutcome.multiplier);
+    // Win = multiplier x whatever this mode's multiplier is a multiple OF.
+    // Under the default that is what was actually paid - for ante/buy modes
+    // the fractional effectiveCost. Under multiplierBasis "bet" it is the
+    // ladder's rung, and a feature buy's price does not scale its wins.
+    // settleAmount rounds the product half-to-even at this one boundary
+    // (ADR-002) so the win crossing the wallet is integer minor units.
+    const win = settleAmount(cappedOutcome.multiplier, betInfo.winBasis);
+    assertFundedWin(betInfo.winBasis, cappedOutcome.multiplier);
 
     let receipt;
     try {
@@ -942,6 +955,7 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
       modeId: requestedMode,
       bet: betInfo.bet,
       effectiveCost: betInfo.effectiveCost,
+      winBasis: betInfo.winBasis,
       state: open.state,
       ...(open.awaiting ? { awaiting: open.awaiting } : {}),
       actionLog: [],
@@ -1050,11 +1064,14 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
 
     const cappedClose = applyMaxWinCapClose(
       closeResult,
-      open.effectiveCost,
+      open.winBasis,
       mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
     );
-    const win = settleAmount(cappedClose.multiplier, open.effectiveCost);
-    assertFundedWin(open.effectiveCost, cappedClose.multiplier);
+    // The basis was resolved when the round OPENED and stored with it. Re-reading
+    // the mode here would settle a round under a basis it was not opened under,
+    // which is the one way a config change could repay a round already in flight.
+    const win = settleAmount(cappedClose.multiplier, open.winBasis);
+    assertFundedWin(open.winBasis, cappedClose.multiplier);
     let receipt;
     try {
       receipt = await timedPlatformCall(metrics, "closeComplex", () => platform.closeComplex({
@@ -1215,11 +1232,14 @@ export function createOrchestrator(cfg: OrchestratorConfig): OrchestratorAPI {
     // from math.autoclose() (or a cap-exceeding one) would settle unguarded.
     const cappedClose = applyMaxWinCapClose(
       closeResult,
-      open.effectiveCost,
+      open.winBasis,
       mode.maxWinMultiplier ?? manifest.maxWinMultiplier,
     );
-    const win = settleAmount(cappedClose.multiplier, open.effectiveCost);
-    assertFundedWin(open.effectiveCost, cappedClose.multiplier);
+    // The basis was resolved when the round OPENED and stored with it. Re-reading
+    // the mode here would settle a round under a basis it was not opened under,
+    // which is the one way a config change could repay a round already in flight.
+    const win = settleAmount(cappedClose.multiplier, open.winBasis);
+    assertFundedWin(open.winBasis, cappedClose.multiplier);
     let receipt;
     try {
       receipt = await timedPlatformCall(metrics, "closeComplex", () => platform.closeComplex({
@@ -1360,8 +1380,9 @@ function sessionOrThrow(id: string | null | undefined): sessions.LocalSession {
   return s;
 }
 
-/** A 0 effective bet (e.g. a `stakeMultiplier: 0` free-round mode) with a
- *  winning multiplier would settle `win = multiplier x 0 = 0`, silently
+/** A 0 basis (e.g. a `stakeMultiplier: 0` free-round mode, or a 0 rung under
+ *  multiplierBasis "bet") with a winning multiplier would settle
+ *  `win = multiplier x 0 = 0`, silently
  *  losing the player's payout. Forbid it: free rounds must be funded so the
  *  win is non-zero: either by a promo pool (which locks a non-zero bet) or by
  *  accumulating the feature's winnings into the parent round's carry and

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -37,6 +37,10 @@ export interface OpenRound {
    *  1-unit base = 1.25). Used for balance check, max-win cap, win
    *  calculation, and the audit log's "amount paid" field. */
   effectiveCost: number;
+  /** What this round's closing multiplier is a multiple of - the mode's
+   *  `multiplierBasis` resolved to a number at OPEN time. Stored rather than
+   *  recomputed because a round outlives the config read that opened it. */
+  winBasis: number;
   state: RoundState;
   awaiting?: AwaitingHint;
   /** Action log for replay-on-reconnect. */

--- a/packages/core/test/multiplier-basis.test.ts
+++ b/packages/core/test/multiplier-basis.test.ts
@@ -1,0 +1,177 @@
+// What a win multiplier is a multiple OF.
+//
+// open-rgs has always settled `win = multiplier x effectiveCost`, i.e. a
+// multiple of what the round COST. That is one of the two conventions in use.
+// The other - the one most published paytables are written in - is that the
+// multiplier is a multiple of the BET, and the price of a feature buy has
+// nothing to do with what a win pays: "max win 10000x" means 10000 times the
+// bet whether you entered the feature for 1x or for 2100x.
+//
+// A game on the second convention that settles under the first overpays by
+// the buy's price multiplier, which at 2100x is not a rounding error. It also
+// writes a multiplier into round history that the game's own paytable screen
+// contradicts - a max win recorded as 4.76x.
+//
+// `multiplierBasis` picks. Default "cost", so nothing that exists changes.
+
+import { describe, expect, test } from "bun:test";
+import { createOrchestrator } from "../src/index.js";
+import {
+  defineGame,
+  type PlatformAdapter, type SessionInfo, type SettleSimple, type RoundReceipt,
+  type SimpleMath, type ComplexMath, type ConnectionMeta, type PlatformEvent,
+  type CloseComplex, type OpenComplex,
+} from "@open-rgs/contract";
+
+const BET = 100;
+const BUY_COST = 50;        // a 50x feature buy
+const WIN_MULTIPLIER = 10;  // the paytable's number
+
+/** Records what the wallet was actually told, which is half the point: the
+ *  multiplier the platform stores is the one a player sees in their history. */
+class MiniPlatform implements PlatformAdapter {
+  isHealthy = true;
+  diagnostics = {};
+  balance = 10_000_000;
+  settles: SettleSimple[] = [];
+  closes: CloseComplex[] = [];
+  private seq = 0;
+  private openBet = 0;
+  private openPrice = 1;
+  async connect() {}
+  disconnect() {}
+  async openSession(sessionId: string): Promise<SessionInfo> {
+    return { sessionId, currency: "USD", currencyDecimals: 2, balance: this.balance, allowedBets: [BET], defaultBetIndex: 0 };
+  }
+  async settleSimple(req: SettleSimple): Promise<RoundReceipt> {
+    this.settles.push(req);
+    this.balance = this.balance - req.bet * (req.priceMultiplier ?? 1) + req.win;
+    return { roundId: `s${++this.seq}`, balance: this.balance };
+  }
+  async openComplex(req: OpenComplex): Promise<RoundReceipt> {
+    this.openBet = req.bet;
+    this.openPrice = req.priceMultiplier ?? 1;
+    this.balance -= this.openBet * this.openPrice;
+    return { roundId: "r1", balance: this.balance };
+  }
+  async closeComplex(req: CloseComplex): Promise<RoundReceipt> {
+    this.closes.push(req);
+    this.balance += req.win;
+    return { roundId: req.roundId, balance: this.balance };
+  }
+  onEvent(_h: (e: PlatformEvent) => void) {}
+}
+
+const payer: SimpleMath = {
+  kind: "simple", name: "payer", version: "1", rtp: 1,
+  play: () => ({ multiplier: WIN_MULTIPLIER, ops: [], type: "win" }),
+};
+
+const hugePayer: SimpleMath = {
+  kind: "simple", name: "huge", version: "1", rtp: 1,
+  play: () => ({ multiplier: 10_000, ops: [], type: "win" }),
+};
+
+const complexPayer: ComplexMath = {
+  kind: "complex", name: "cpayer", version: "1", rtp: 1,
+  open: () => ({ state: "{}", ops: [] }),
+  step: () => ({ state: "{}", ops: [] }),
+  isTerminal: () => true,
+  close: () => ({ multiplier: WIN_MULTIPLIER, ops: [], type: "win" }),
+};
+
+function setup() {
+  const platform = new MiniPlatform();
+  const manifest = defineGame({
+    id: "g", declaredRtp: 1, defaultMode: "base", maxWinMultiplier: 100_000,
+    modes: {
+      base:       { math: payer, stakeMultiplier: 1 },
+      // The same buy, settled under each convention.
+      "buy-cost": { math: payer, stakeMultiplier: BUY_COST },
+      "buy-bet":  { math: payer, stakeMultiplier: BUY_COST, multiplierBasis: "bet" },
+      // A cap that means "10000x the bet" rather than "10000x the stake".
+      "buy-capped": { math: hugePayer, stakeMultiplier: BUY_COST, multiplierBasis: "bet", maxWinMultiplier: 5_000 },
+      "complex-bet": { math: complexPayer, stakeMultiplier: BUY_COST, multiplierBasis: "bet" },
+    },
+  });
+  const orch = createOrchestrator({ manifest, platform });
+  const conn: ConnectionMeta = { connectionId: "c1", sessionId: null, demo: false };
+  return { orch, conn, platform };
+}
+
+describe("multiplierBasis", () => {
+  test("the default is unchanged: a win is a multiple of what the round cost", async () => {
+    const { orch, conn, platform } = setup();
+    await orch.init({ sid: "mb-default" }, conn);
+    const r = await orch.spin({ mode: "buy-cost" }, conn);
+    // 10x on a 50x buy of a 100 bet = 10 x 5000
+    expect(r.win).toBe(WIN_MULTIPLIER * BET * BUY_COST);
+    expect(platform.settles[0]!.multiplier).toBe(WIN_MULTIPLIER);
+  });
+
+  test('"bet" pays a multiple of the bet, and the buy price plays no part', async () => {
+    const { orch, conn, platform } = setup();
+    const init = await orch.init({ sid: "mb-bet" }, conn);
+    const before = init.balance;
+    const r = await orch.spin({ mode: "buy-bet" }, conn);
+    expect(r.win).toBe(WIN_MULTIPLIER * BET);
+    // Charged the buy, paid the paytable.
+    expect(r.balance).toBe(before - BET * BUY_COST + WIN_MULTIPLIER * BET);
+    expect(platform.settles[0]!.multiplier).toBe(WIN_MULTIPLIER);
+  });
+
+  test("the two bases differ by exactly the buy's price", async () => {
+    const { orch, conn } = setup();
+    await orch.init({ sid: "mb-ratio" }, conn);
+    const cost = await orch.spin({ mode: "buy-cost" }, conn);
+    const bet = await orch.spin({ mode: "buy-bet" }, conn);
+    expect(cost.win / bet.win).toBe(BUY_COST);
+  });
+
+  test("the platform is told the paytable's multiplier, not a rescaled one", async () => {
+    // The reason this is not merely cosmetic: the multiplier the wallet
+    // stores is what a player sees in their round history, and a game whose
+    // screen says 10000x must not record 200x.
+    const { orch, conn, platform } = setup();
+    await orch.init({ sid: "mb-wire" }, conn);
+    await orch.spin({ mode: "buy-bet" }, conn);
+    const settle = platform.settles[0]!;
+    expect(settle.multiplier).toBe(WIN_MULTIPLIER);
+    // The price still reaches the wallet - as the price, on its own field.
+    expect(settle.priceMultiplier).toBe(BUY_COST);
+    expect(settle.bet).toBe(BET);
+    expect(settle.betIndex).toBe(0);
+  });
+
+  test("the max-win cap is read in the same basis", async () => {
+    const { orch, conn, platform } = setup();
+    await orch.init({ sid: "mb-cap" }, conn);
+    const r = await orch.spin({ mode: "buy-capped" }, conn);
+    // Capped at 5000x the BET, not 5000x the stake.
+    expect(r.win).toBe(5_000 * BET);
+    expect(platform.settles[0]!.multiplier).toBe(5_000);
+    expect(platform.settles[0]!.type).toBe("max_win_reached");
+  });
+
+  test("a complex round closes under the basis it was opened with", async () => {
+    const { orch, conn, platform } = setup();
+    const init = await orch.init({ sid: "mb-complex" }, conn);
+    const before = init.balance;
+    await orch.openRound({ mode: "complex-bet" }, conn);
+    const closed = await orch.closeRound({}, conn);
+    expect(closed.win).toBe(WIN_MULTIPLIER * BET);
+    expect(closed.balance).toBe(before - BET * BUY_COST + WIN_MULTIPLIER * BET);
+    expect(platform.closes[0]!.multiplier).toBe(WIN_MULTIPLIER);
+  });
+
+  test("the mode catalog says which basis each mode uses", async () => {
+    const { orch, conn } = setup();
+    const init = await orch.init({ sid: "mb-catalog" }, conn);
+    const modes = init.modes as { id: string; multiplierBasis: string }[];
+    // A client rendering "x{multiplier}" cannot know what the x is of
+    // otherwise, and getting it wrong is how a player is told a max win
+    // paid 4.76x.
+    expect(modes.find((m) => m.id === "base")!.multiplierBasis).toBe("cost");
+    expect(modes.find((m) => m.id === "buy-bet")!.multiplierBasis).toBe("bet");
+  });
+});


### PR DESCRIPTION
Stacked on #71.

The engine settles `win = multiplier × effectiveCost` — a multiple of what the round **cost**. That is one of the two conventions games are written in. The other is that the multiplier is a multiple of the **bet**, and the price of a feature buy has nothing to do with what a win pays. That is how most published paytables read: *max win 10000x* means 10000 times the bet, whether the feature was entered for 1x or for 2100x.

A game on the second convention running under the first overpays by the buy's price multiplier. At 2100x that is not a rounding error. It also writes a multiplier into round history that the game's own paytable screen contradicts — a max win recorded as 4.76x.

```ts
"super-core": {
  math,
  stakeMultiplier: 2100,     // what the round costs
  multiplierBasis: "bet",    // what a multiplier is OF
  maxWinMultiplier: 10_000,  // read in the same basis
}
```

Defaults to `"cost"`, so nothing existing moves. Three things follow from the choice rather than being separate knobs:

- the max-win cap is read in the same basis, so `maxWinMultiplier` means what a regulator means when it caps a win at N times the bet;
- the basis is resolved at **open** and stored on the round, so a config change cannot settle a round in flight under a basis it was not opened under;
- the mode catalog reports it — a client rendering `x{multiplier}` cannot know what the x is of otherwise.

Found while porting a real game: a 2100x feature buy whose paytable tops out at 10000x the bet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)